### PR TITLE
fix(init): resolve claude.exe on Windows instead of unspawnable MSYS path

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -100,6 +100,37 @@ function resolveClaude() {
     }
   }
 
+  // Windows: the POSIX well-known paths below never match, so resolution would
+  // fall through to `which`. Under Git Bash that returns an MSYS-style path
+  // (`/c/Users/.../claude`, often extension-less) that Node's spawn cannot
+  // execute (ENOENT on both the auth check and every completion). Resolve a real
+  // `claude.exe` via Windows-native lookups instead. A real claude.exe (incl. the
+  // WinGet App Execution Alias) is directly spawnable by Node — no shell needed.
+  if (process.platform === "win32") {
+    const winCandidates = [];
+    const { LOCALAPPDATA, ProgramFiles } = process.env;
+    if (LOCALAPPDATA) winCandidates.push(join(LOCALAPPDATA, "Microsoft", "WinGet", "Links", "claude.exe"));
+    if (ProgramFiles) winCandidates.push(join(ProgramFiles, "Claude", "claude.exe"));
+    for (const p of winCandidates) {
+      if (existsSync(p)) { console.warn(`[init] CLAUDE_BIN not set, resolved to ${p}`); return p; }
+    }
+    // PATH lookup via Windows-native `where` (returns proper C:\... paths, one per
+    // line). Prefer an .exe: .cmd/.bat cannot be spawned without a shell.
+    try {
+      const lines = execFileSync("where", ["claude"], { encoding: "utf8", timeout: 5000 })
+        .split(/\r?\n/).map(s => s.trim()).filter(Boolean);
+      const exe = lines.find(p => /\.exe$/i.test(p)) || lines.find(p => /\.(cmd|bat)$/i.test(p));
+      if (exe) { console.warn(`[init] CLAUDE_BIN not set, resolved via where: ${exe}`); return exe; }
+    } catch { /* fall through to FATAL */ }
+    console.error(
+      "FATAL: claude.exe not found.\n" +
+      "  Set CLAUDE_BIN to the full path of claude.exe, e.g.\n" +
+      "  set CLAUDE_BIN=%LOCALAPPDATA%\\Microsoft\\WinGet\\Links\\claude.exe\n" +
+      "  (a claude.cmd/.bat shim will not work — OCP spawns the binary without a shell.)"
+    );
+    process.exit(1);
+  }
+
   const home = process.env.HOME || "";
   const candidates = [
     "/opt/homebrew/bin/claude",


### PR DESCRIPTION
## Summary

On Windows, `resolveClaude()`'s well-known paths are all POSIX, so resolution fell through to `execFileSync("which","claude")`. Under Git Bash that returns an MSYS-style path (`/c/Users/.../claude`, often extension-less) that Node's shell-less spawn cannot execute — producing `spawnSync ... claude ENOENT` on both the auth check (`server.mjs` ~611 `execFileSync`) and every completion (`server.mjs` ~809 `spawn`). Net effect on Windows: the auth check reports "check failed" and every request fails with an auth/subscription-looking error, **despite a valid token**. This adds a `process.platform === "win32"` branch that resolves a real, directly-spawnable `claude.exe`.

## Endpoint Class (REQUIRED)

- [x] **Not endpoint-touching** — refactor / tooling that does not modify any request handler. The change is confined to `resolveClaude()` (local binary resolution). It adds/changes no endpoint, header, request field, or response field, and neither spawn site uses a shell, so the wire path is untouched.

## Claude Code Alignment Evidence (REQUIRED)

This change is local **process-launch / binary-resolution infrastructure**. It has no `cli.js` wire analogue and is **not** a Class A operation (per `ALIGNMENT.md`, the `cli.js`-mirror surface is the `/v1/messages` routes + the OAuth bearer machinery), nor is it a Class B endpoint. A `cli.js:NNNN` citation is therefore genuinely unavailable and is **declared absent rather than fabricated**, per `CLAUDE.md` server.mjs hard-requirement #1 ("If `cli.js` does not perform the operation, the PR must state this explicitly and justify scope under `ALIGNMENT.md` Rule 2").

Scope justification under Rule 2: this is not an invented wire operation. It fixes a Windows-only crash in how OCP launches the CLI it already legitimately spawns. It changes no observable Anthropic-facing behavior. No `alignment.yml` blacklist tokens are introduced.

## Type of change

- [x] Bug fix

## Verification

Verified end-to-end on Windows (Claude Code CLI installed via WinGet), with `CLAUDE_BIN` **unset** so the new branch does the resolving:

- `[init] CLAUDE_BIN not set, resolved to %LOCALAPPDATA%\Microsoft\WinGet\Links\claude.exe`
- `GET /status` → `"auth":"ok"` with live plan/usage data
- `POST /v1/chat/completions` → real completion returned (`WINFIX_OK`)

Guard: the branch is entered only on `win32` and only when `CLAUDE_BIN` is unset; macOS/Linux resolution is byte-for-byte unchanged. `node --check server.mjs` passes.

## Reviewer note

An independent fresh-context reviewer (Iron Rule 10 — not the commit author) reviewed the diff against `ALIGNMENT.md` and `.github/workflows/alignment.yml` and returned **APPROVE**: change confined to `resolveClaude()`, no wire surface, non-Windows path byte-for-byte unchanged, both spawn sites confirmed shell-less, imports present, `node --check` clean, no blacklisted tokens, and the "no `cli.js` wire analogue" declaration judged honest and rule-compliant.
