### PR TITLE
fix(tui): a null message_id must not disarm the streaming auth-banner guard (re-land lost from #159 squash)

### DIFF
--- a/lib/tui/stream.mjs
+++ b/lib/tui/stream.mjs
@@ -173,6 +173,9 @@ export function parseDeltaChunk(text, consumed = 0) {
 //    fails the turn loudly (SSE error frame, no cache, counted on /health). Fail-loud is
 //    the correct posture — a proxy that silently serves text the transcript disagrees with
 //    is the exact class of bug ALIGNMENT.md exists to prevent.
+// Sentinel for "no message seen yet". Deliberately not null/undefined — see the constructor.
+const NO_MESSAGE_YET = Symbol("no-message-yet");
+
 export class TuiDeltaAssembler {
   constructor({ holdbackChars = DEFAULT_HOLDBACK_CHARS, detectError = detectTuiUpstreamError } = {}) {
     this.holdbackChars = holdbackChars;
@@ -180,7 +183,12 @@ export class TuiDeltaAssembler {
     this.emitted = "";   // bytes ALREADY written to the client — unretractable
     this.pending = "";   // held back, not yet written
     this.released = false;
-    this.messageId = null;
+    // NOT null: a payload may legitimately carry message_id === null, and if the sentinel were
+    // also null the FIRST such payload would compare equal to it, register no boundary, and
+    // leave `messages` at 0 — which used to disarm the restartedAfterEmit guard below entirely.
+    // A unique object is === to nothing a JSON payload can produce, so the first fire ALWAYS
+    // registers as message 1, whatever its message_id is (or isn't).
+    this.messageId = NO_MESSAGE_YET;
     this.deltas = 0;     // hook fires seen
     this.messages = 0;   // distinct message_ids seen
     this.restartedAfterEmit = false;
@@ -198,7 +206,12 @@ export class TuiDeltaAssembler {
       this.messages++;
       if (this.emitted === "") {
         this.pending = "";        // safe: the transcript will drop this message too
-      } else if (this.messages > 1) {
+      } else {
+        // A boundary while bytes are ALREADY out is unrecoverable, full stop — the count of
+        // messages seen so far is irrelevant. The old `else if (this.messages > 1)` guard was
+        // the sole reason a null-message_id first payload could disarm F1: it left `messages`
+        // at 0, so the real boundary evaluated 1 > 1 === false and never armed. The invariant
+        // is "a boundary occurred while emitted !== ''", and that is exactly what this says.
         this.restartedAfterEmit = true; // unrecoverable — finalize() will refuse the turn
       }
     }

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -3598,6 +3598,26 @@ test("F1: an auth banner rendered as a LATER message is never forwarded to the c
   assert.equal(a.finalize(BANNER).ok, false, "and the turn is refused, not served");
 });
 
+test("F1: a first payload with message_id:null cannot disarm the guard", () => {
+  // The residual bypass the reviewer found by probing. `this.messageId` used to be initialized
+  // to null, so a first payload carrying message_id:null compared EQUAL to it → no boundary
+  // registered → `messages` stayed 0 → when the REAL boundary arrived, `messages > 1` evaluated
+  // 1 > 1 === false → restartedAfterEmit never armed → the released branch forwarded the banner.
+  // The whole F1 guard was disarmed by a single null field. parseDeltaChunk does not validate
+  // message_id, so such a payload does reach push().
+  const a = new TuiDeltaAssembler({ holdbackChars: 100 });
+  const narration = "I'll check that file for you and then report back with what I find inside it.";
+  a.push({ hook_event_name: "MessageDisplay", message_id: null, delta: narration + narration });
+  assert.notEqual(a.emitted, "", "precondition: the narration released to the client");
+  assert.equal(a.messages, 1, "a null message_id is still a MESSAGE — it must register as one");
+
+  const BANNER = "Please run /login · API Error: 401 Invalid authentication credentials";
+  const out = a.push({ hook_event_name: "MessageDisplay", message_id: "m2", delta: BANNER });
+  assert.equal(out, null, "the banner must not be forwarded — the guard must arm regardless");
+  assert.equal(a.restartedAfterEmit, true);
+  assert.ok(!a.emitted.includes("401"));
+});
+
 test("F1: whitespace cannot buy a release — the holdback screens TRIMMED length", () => {
   // detectTuiUpstreamError() TRIMS before applying its <=100-char rule, so gating release on
   // the UNTRIMMED pending.length let 101 spaces trim to "" → the detector has nothing to


### PR DESCRIPTION
# Pull Request

Follow-up to #159. **This fix was reviewed and approved as part of #159 but was lost in the squash merge** — the PR head GitHub captured was one commit behind my final push, so the merged code on `main` still carries the hole. Verified after the fact: `main` is missing `NO_MESSAGE_YET` in `lib/tui/stream.mjs` and the regression test in `test-features.mjs`. This re-lands commit `0ae4eab` verbatim.

## The bug

`TuiDeltaAssembler` is the mechanism #159 nominates as its **primary safety property**: it holds back the first N characters of a streamed turn so an auth-failure banner — which the interactive CLI renders as ordinary assistant *text* — can never reach a client as a normal answer (the C-1 gate, #133).

`this.messageId` was initialized to `null`. So a first `MessageDisplay` payload carrying `message_id: null` compared **equal** to the sentinel → no boundary registered → `this.messages` stayed **0**. When the *real* message boundary then arrived, `else if (this.messages > 1)` evaluated `1 > 1` → false → `restartedAfterEmit` never armed → the `released` branch forwarded the banner to the client.

**The entire F1 defense was disarmable by a single absent field.** `parseDeltaChunk` does not validate `message_id`, so such a payload does reach `push()`.

Found by the independent reviewer on its *second* pass, by **probing the fixed code rather than reading it** — the F1 fix itself was correct; its *arming* could be skipped.

## The fix (both changes narrow behavior; neither can regress)

- `messageId` initializes to a `Symbol` sentinel, which is `===` to nothing a JSON payload can produce. The first fire therefore **always** registers as message 1, whatever its `message_id` is — or isn't.
- The boundary branch drops the `this.messages > 1` sub-condition. It bought nothing and was the sole cause. The real invariant is *"a boundary occurred while `emitted !== ''`"* — unrecoverable regardless of how many messages have been seen — and that is now what the code says.

Whether `claude` ever emits `message_id: null` is unverified (the observed contract has it present), so this is **defense-in-depth, not a live bug**. But a guard that a feature nominates as its primary safety property should not be disarmable by a field's absence.

## Evidence

**Mutation-tested on this branch**: restore the `null` sentinel + the `messages > 1` condition → `316 passed, 1 failed` (`"a null message_id is still a MESSAGE — it must register as one"`). With the fix → **317 passed, 0 failed**.

## Endpoint Class (REQUIRED)

- [x] **Class B** — ADR 0007 (OCP-owned TUI spawn). **`cli.js` does NOT perform this operation**: `TuiDeltaAssembler` is OCP's own delta→SSE reconciler, not a mirror of any CLI behavior. No `cli.js` citation applies.
- No endpoint, header, or SSE field added or changed. Behavior change is strictly *less* emission on a turn that was already being refused.

## Type of change
- [x] Bug fix (hardening; streaming remains opt-in and default-off)

### User-visible change self-check (铁律第五律 5.3)
- [x] Not user-visible — no env var, endpoint, CLI subcommand, or output shape changes. No README update needed. No version bump (separate `chore(release)`, per #143).

### Privacy self-check
- [x] Role-based terms only; no personal paths, hostnames, emails, or IPs.

## Related
#159 (streaming; this fix was approved there and lost in the squash) · #133 (the C-1 auth-banner gate this protects) · ADR 0007

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqgWJcjxrjjL9L9SkpZyXR
