### PR TITLE
fix(init): resolve Windows claude.exe only

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -97,8 +97,40 @@ function _collectNodeManagerCandidates(home) {
 
   return out;
 }
+function _joinIfBase(base, ...parts) {
+  return base ? join(base, ...parts) : null;
+}
+function _collectWindowsClaudeCandidates() {
+  const userProfile = process.env.USERPROFILE || process.env.HOME || "";
+  const localAppData = process.env.LOCALAPPDATA || "";
+  return [
+    _joinIfBase(userProfile, ".local", "bin", "claude.exe"),
+    _joinIfBase(localAppData, "Microsoft", "WinGet", "Links", "claude.exe"),
+    _joinIfBase(localAppData, "Microsoft", "WindowsApps", "claude.exe"),
+  ].filter(Boolean);
+}
+function _isWindowsSpawnableBinary(path) {
+  return /\.exe$/i.test(path);
+}
+function _lookupLines(out) {
+  return out.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+}
+function _warnUnspawnableWindowsMatches(lines) {
+  const unspawnable = lines.filter(p => !/\.exe$/i.test(p));
+  if (unspawnable.length > 0) {
+    console.warn(`[init] Ignoring non-exe Windows claude command(s): ${unspawnable.join(", ")}`);
+  }
+}
 function resolveClaude() {
+  const isWin = process.platform === "win32";
   if (process.env.CLAUDE_BIN) {
+    if (isWin && !_isWindowsSpawnableBinary(process.env.CLAUDE_BIN)) {
+      console.error(
+        `FATAL: CLAUDE_BIN="${process.env.CLAUDE_BIN}" is not a native Windows executable.\n` +
+        "  Set CLAUDE_BIN to claude.exe; shell shims cannot be spawned without a shell."
+      );
+      process.exit(1);
+    }
     try {
       accessSync(process.env.CLAUDE_BIN, constants.X_OK);
       return process.env.CLAUDE_BIN;
@@ -108,28 +140,48 @@ function resolveClaude() {
     }
   }
 
-  const home = process.env.HOME || "";
-  const candidates = [
-    "/opt/homebrew/bin/claude",
-    "/usr/local/bin/claude",
-    "/usr/bin/claude",
-    join(home, ".local/bin/claude"),
-    ..._collectNodeManagerCandidates(home),
-  ];
+  const home = process.env.HOME || process.env.USERPROFILE || "";
+  const candidates = isWin
+    ? _collectWindowsClaudeCandidates()
+    : [
+        "/opt/homebrew/bin/claude",
+        "/usr/local/bin/claude",
+        "/usr/bin/claude",
+        join(home, ".local/bin/claude"),
+        ..._collectNodeManagerCandidates(home),
+      ];
   for (const p of candidates) {
     try { accessSync(p, constants.X_OK); console.warn(`[init] CLAUDE_BIN not set, resolved to ${p}`); return p; } catch {}
   }
 
-  try {
-    const resolved = execFileSync("which", ["claude"], { encoding: "utf8", timeout: 5000 }).trim();
-    if (resolved) { console.warn(`[init] CLAUDE_BIN not set, resolved via which: ${resolved}`); return resolved; }
-  } catch {}
+  if (isWin) {
+    try {
+      const lines = _lookupLines(execFileSync("where.exe", ["claude.exe"], { encoding: "utf8", timeout: 5000 }));
+      const resolved = lines.find(_isWindowsSpawnableBinary);
+      if (resolved) { console.warn(`[init] CLAUDE_BIN not set, resolved via where.exe: ${resolved}`); return resolved; }
+    } catch {}
+
+    try {
+      const lines = _lookupLines(execFileSync("where.exe", ["claude"], { encoding: "utf8", timeout: 5000 }));
+      const resolved = lines.find(_isWindowsSpawnableBinary);
+      if (resolved) { console.warn(`[init] CLAUDE_BIN not set, resolved via where.exe: ${resolved}`); return resolved; }
+      _warnUnspawnableWindowsMatches(lines);
+    } catch {}
+  } else {
+    try {
+      const resolved = execFileSync("which", ["claude"], { encoding: "utf8", timeout: 5000 }).trim();
+      if (resolved) { console.warn(`[init] CLAUDE_BIN not set, resolved via which: ${resolved}`); return resolved; }
+    } catch {}
+  }
 
   console.error(
     "FATAL: claude binary not found.\n" +
-    "  Set CLAUDE_BIN=/path/to/claude or ensure claude is in PATH.\n" +
-    "  Hint: if you use nvm/fnm/asdf, set CLAUDE_BIN to the absolute path\n" +
-    "  shown by `which claude` in your interactive shell.\n" +
+    (isWin
+      ? "  Set CLAUDE_BIN to the absolute path of claude.exe or ensure claude.exe is in PATH.\n" +
+        "  Hint: npm .cmd/.bat/.ps1 shims cannot be spawned without a shell.\n"
+      : "  Set CLAUDE_BIN=/path/to/claude or ensure claude is in PATH.\n" +
+        "  Hint: if you use nvm/fnm/asdf, set CLAUDE_BIN to the absolute path\n" +
+        "  shown by `which claude` in your interactive shell.\n") +
     "  Checked: " + candidates.join(", ")
   );
   process.exit(1);

--- a/server.mjs
+++ b/server.mjs
@@ -156,12 +156,6 @@ function resolveClaude() {
 
   if (isWin) {
     try {
-      const lines = _lookupLines(execFileSync("where.exe", ["claude.exe"], { encoding: "utf8", timeout: 5000 }));
-      const resolved = lines.find(_isWindowsSpawnableBinary);
-      if (resolved) { console.warn(`[init] CLAUDE_BIN not set, resolved via where.exe: ${resolved}`); return resolved; }
-    } catch {}
-
-    try {
       const lines = _lookupLines(execFileSync("where.exe", ["claude"], { encoding: "utf8", timeout: 5000 }));
       const resolved = lines.find(_isWindowsSpawnableBinary);
       if (resolved) { console.warn(`[init] CLAUDE_BIN not set, resolved via where.exe: ${resolved}`); return resolved; }
@@ -178,7 +172,8 @@ function resolveClaude() {
     "FATAL: claude binary not found.\n" +
     (isWin
       ? "  Set CLAUDE_BIN to the absolute path of claude.exe or ensure claude.exe is in PATH.\n" +
-        "  Hint: npm .cmd/.bat/.ps1 shims cannot be spawned without a shell.\n"
+        "  Hint: npm .cmd/.bat/.ps1 shims cannot be spawned without a shell.\n" +
+        "  The .exe requirement is an intentional allow-list for shell-less spawning.\n"
       : "  Set CLAUDE_BIN=/path/to/claude or ensure claude is in PATH.\n" +
         "  Hint: if you use nvm/fnm/asdf, set CLAUDE_BIN to the absolute path\n" +
         "  shown by `which claude` in your interactive shell.\n") +


### PR DESCRIPTION
## Summary
- Resolve native Windows `claude.exe` locations before falling back to PATH lookup.
- On `win32`, use `where.exe` but only accept `.exe` matches as the server's shell-less child process target.
- Reject explicit `CLAUDE_BIN` values that are not native `.exe` binaries, including npm/Git Bash shell shims.
- Warn when PATH only finds non-`.exe` commands.

## Alignment
- **ALIGNMENT.md Rule 2 - No Invention:** this PR changes only local executable discovery and fatal diagnostics. It does not add or modify any endpoint, header, request field, response field, authentication behavior, or outbound wire call.
- **CLAUDE.md `server.mjs` hard requirement #1:** no `cli.js` citation applies because this change does not touch a Class A operation or assert that Claude Code performs a wire operation. The complete diff is limited to `server.mjs` startup resolution.
- The local Alignment Guardrail blacklist and port-SPOT scans pass.

## Prior art and attribution
- This builds on the public analysis in #147 by @Justinsato. In particular, it preserves the diagnosis that npm/Git Bash shell shims are invalid shell-less spawn targets, while adding native-installer discovery at `%USERPROFILE%\\.local\\bin\\claude.exe` and avoiding speculative Program Files paths.

## Test plan
- PASS: `node --check server.mjs`
- PASS: `git diff --check`
- PASS: `gitleaks detect --source . --config .gitleaks.toml --redact`
- PASS: local Alignment Guardrail blacklist scan
- PASS: local Alignment Guardrail port SPOT scan
- PASS: local commit-citation soft check
- PASS: WSL/Linux `npm test` on Node v24.15.0 (`317 passed, 0 failed`)
- PASS: native Windows npm-global cohort: the only PATH matches were `claude` and `claude.cmd`; with `CLAUDE_BIN` unset, startup logs the ignored non-`.exe` matches and exits with the intended actionable fatal diagnostic.
- NOTE: this Windows host has no native `claude.exe`, so it cannot yet supply the requested WinGet/native-installer or authenticated completion evidence.
- NOTE: native Windows `npm test` on this checkout still fails with `310 passed, 7 failed`; the PR changes only `server.mjs`, while the failures are in pre-existing snapshot/TUI Windows portability tests.