### PR TITLE
docs(readme): stop the feature bullet promising what § honest limits forbids (#136)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ One proxy. Multiple IDEs. All models. **$0 API cost.**
 
 There are several Claude proxy projects. OCP picks a specific lane: **align tightly with what `cli.js` actually does, observe + multiplex what's already there, don't extend the protocol.** What you get:
 
-- **LAN multi-user keys** (v3.7.0) — reach one Claude Pro/Max subscription from your own devices across the LAN. Each device gets a per-key API token (no OAuth session leak), with independent usage tracking and one-line revocation. Pro/Max are **per-user** accounts — see [Sharing with family / a team — honest limits](#auth-modes) before extending access to other **people**.
+- **LAN multi-user keys** (v3.7.0) — reach one Claude Pro/Max subscription from your own devices across the LAN. Each device gets a per-key API token (no OAuth session leak), with independent usage tracking and one-line revocation. Pro/Max are **per-user** accounts — see [Sharing with family / a team — honest limits](#deployment-model--security-read-this) before extending access to other **people**.
 - **`ocp-connect` one-shot IDE setup** — one command on the client machine detects and configures Claude Code, Cursor, Cline, Continue.dev, OpenCode, and OpenClaw. No pasting `OPENAI_BASE_URL` six times.
 - **Response cache with per-key isolation + singleflight** (v3.13.0). Optional SHA-256 prompt cache, isolated per API key (cross-user pollution is impossible by hash construction, not by application logic), with stampede protection on concurrent identical prompts. Off by default. ([PR #65](https://github.com/dtzp555-max/ocp/pull/65), [PR #66](https://github.com/dtzp555-max/ocp/pull/66))
 - **Per-key request quotas** (v3.8.0). Daily / weekly / monthly limits per key — set a kid's iPad to 20/day, a partner's laptop to 100/week. ([PR #18](https://github.com/dtzp555-max/ocp/pull/18))
@@ -49,7 +49,7 @@ OCP and the alternatives serve adjacent but distinct needs. Pick the one that fi
 | GitHub stars / ecosystem size | small | large | mid |
 | Governance discipline (CI-enforced alignment with cli.js) | yes | n/a | n/a |
 
-**Plain English**: `claude-code-router` is the routing-and-switching power tool — pick it if you want to mix Anthropic, OpenAI, Gemini, and local models behind one endpoint. `anthropic-proxy` is the minimal forwarder. **OCP focuses on disciplined `cli.js`-aligned forwarding plus subscription multiplexing** — pick it if you want to share one Claude Pro/Max subscription across IDEs, devices, and people, with LAN auth, quotas, and a governance contract that prevents endpoint drift.
+**Plain English**: `claude-code-router` is the routing-and-switching power tool — pick it if you want to mix Anthropic, OpenAI, Gemini, and local models behind one endpoint. `anthropic-proxy` is the minimal forwarder. **OCP focuses on disciplined `cli.js`-aligned forwarding plus subscription multiplexing** — pick it if you want to reach one Claude Pro/Max subscription from your own IDEs and devices, with LAN auth, quotas, and a governance contract that prevents endpoint drift.
 
 ### Related: OLP — Open LLM Proxy
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ After install the `ocp` CLI lives at `~/ocp/ocp`. To put it on your PATH, either
 export OPENAI_BASE_URL=http://127.0.0.1:3456/v1
 ```
 
-**LAN mode** — share with other devices on your network:
+**LAN mode** — reach OCP from your own devices on the network (Claude Pro/Max are per-user accounts — see [Sharing with family / a team — honest limits](#deployment-model--security-read-this) before extending access to other people):
 ```bash
 # Enable LAN access with per-user auth (recommended)
 node setup.mjs --bind 0.0.0.0 --auth-mode multi

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ One proxy. Multiple IDEs. All models. **$0 API cost.**
 
 There are several Claude proxy projects. OCP picks a specific lane: **align tightly with what `cli.js` actually does, observe + multiplex what's already there, don't extend the protocol.** What you get:
 
-- **LAN multi-user keys** (v3.7.0) — share one Claude Pro/Max subscription with family, friends, or your own devices. Each user gets a per-key API token (no OAuth session leak), with independent usage tracking and one-line revocation.
+- **LAN multi-user keys** (v3.7.0) — reach one Claude Pro/Max subscription from your own devices across the LAN. Each device gets a per-key API token (no OAuth session leak), with independent usage tracking and one-line revocation. Pro/Max are **per-user** accounts — see [Sharing with family / a team — honest limits](#auth-modes) before extending access to other **people**.
 - **`ocp-connect` one-shot IDE setup** — one command on the client machine detects and configures Claude Code, Cursor, Cline, Continue.dev, OpenCode, and OpenClaw. No pasting `OPENAI_BASE_URL` six times.
 - **Response cache with per-key isolation + singleflight** (v3.13.0). Optional SHA-256 prompt cache, isolated per API key (cross-user pollution is impossible by hash construction, not by application logic), with stampede protection on concurrent identical prompts. Off by default. ([PR #65](https://github.com/dtzp555-max/ocp/pull/65), [PR #66](https://github.com/dtzp555-max/ocp/pull/66))
 - **Per-key request quotas** (v3.8.0). Daily / weekly / monthly limits per key — set a kid's iPad to 20/day, a partner's laptop to 100/week. ([PR #18](https://github.com/dtzp555-max/ocp/pull/18))


### PR DESCRIPTION
# Pull Request

Closes #136 (documentation half — see the issue thread for what I am explicitly *not* deciding).

## Summary

An external user reported that Claude Code **refuses to run OCP's own copy-paste install prompt**, because the premise as written — pooling one Pro/Max subscription across a family — violates Anthropic's Usage Policy.

The install prompts themselves were already fixed since that report (they now say *"my own devices on the network"*, and the LAN section carries a ToS warning). What remained is a **self-contradiction inside the README**:

| | |
|---|---|
| **line 27**, feature bullet | *"share one Claude Pro/Max subscription with **family, friends**, or your own devices"* |
| **line 427**, § honest limits | *"The defensible framing is **'one person, your own devices'** — sharing with friends or a team is **not**."* |

The top-of-funnel bullet promotes exactly what the project's own ToS section calls indefensible. **That is a defect on its own terms**, independent of anyone's view on the underlying policy: a reader who trusts the bullet is walked straight into the thing the same document later tells them not to do — and it is the first thing an install-time reviewer (human or AI) sees.

## What this changes

One bullet, aligned to the position the project **already took**, with a link to the honest-limits section.

## What this deliberately does NOT change

- The auth modes, the LAN feature, per-key quotas — no code, no behavior.
- The maintainer's own account of how they use OCP. **Whether the maintainer's household shares their subscription is the account holder's call and their risk, not something a docs PR should quietly rewrite.** This PR only stops the document arguing with itself.

## Type of change
- [x] Documentation

### Endpoint Class
- [x] **Not endpoint-touching** — README only. No `server.mjs` change, so no `cli.js` citation applies.

### User-visible change self-check (铁律第五律 5.3)
- [x] User-visible (README), documented by construction. No version bump (docs-only, per the #143 precedent).

### Privacy self-check
- [x] Role-based terms only; no personal paths, hostnames, emails, or IPs.

## Related
#136

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqgWJcjxrjjL9L9SkpZyXR
