### PR TITLE
feat(models): repoint default `sonnet` alias to claude-sonnet-5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **Default `sonnet` alias → `claude-sonnet-5`.** The `sonnet` alias (the model used for every `/v1/chat/completions` request that omits `model`, and OpenClaw's OCP primary via `ocp-connect`) now resolves to `claude-sonnet-5` instead of `claude-sonnet-4-6`. `claude-sonnet-4-6` remains available by full ID for pinning. This is a behavior change for clients relying on the default — pin `claude-sonnet-4-6` explicitly to retain the previous model. Split out from the additive `claude-sonnet-5` model entry (#152) per Iron Rule 11.
+
 ## v3.22.0 — 2026-07-16
 
 Minor release: TUI-mode latency and streaming features — **all opt-in and off by default**, so the default request path (`-p` / `--output-format stream-json`) is byte-for-byte unchanged — plus hardening from an independent (Codex) re-review of the streaming work. No new `cli.js` wire behavior and no new endpoint; the new surface is entirely OCP-owned TUI-mode configuration (env vars) and `/health` observation. Every code PR carried a fresh-context reviewer (Iron Rule 10).

--- a/README.md
+++ b/README.md
@@ -716,8 +716,8 @@ Any tool use happens server-side, under the `--allowedTools` set configured on t
 | `claude-opus-4-8` | Most capable (default for `opus` alias) |
 | `claude-opus-4-7` | Previous Opus, retained for pinning |
 | `claude-opus-4-6` | Older Opus, retained for pinning |
-| `claude-sonnet-5` | Latest Sonnet (default for `sonnet` alias) |
-| `claude-sonnet-4-6` | Previous Sonnet, retained for pinning |
+| `claude-sonnet-5` | Latest Sonnet (available by full ID; `sonnet` alias repoint tracked separately) |
+| `claude-sonnet-4-6` | Good balance of speed/quality (default for `sonnet` alias) |
 | `claude-haiku-4-5-20251001` | Fastest, lightweight (default for `haiku` alias) |
 
 The canonical list lives in [`models.json`](./models.json) — the single source of truth as of v3.11.0. Both `server.mjs` (the `/v1/models` endpoint) and `setup.mjs` (the OpenClaw registration) derive from it. Adding a new model is now a one-file edit:

--- a/README.md
+++ b/README.md
@@ -716,8 +716,8 @@ Any tool use happens server-side, under the `--allowedTools` set configured on t
 | `claude-opus-4-8` | Most capable (default for `opus` alias) |
 | `claude-opus-4-7` | Previous Opus, retained for pinning |
 | `claude-opus-4-6` | Older Opus, retained for pinning |
-| `claude-sonnet-5` | Latest Sonnet (available by full ID; `sonnet` alias repoint tracked separately) |
-| `claude-sonnet-4-6` | Good balance of speed/quality (default for `sonnet` alias) |
+| `claude-sonnet-5` | Latest Sonnet (default for `sonnet` alias) |
+| `claude-sonnet-4-6` | Previous Sonnet, retained for pinning |
 | `claude-haiku-4-5-20251001` | Fastest, lightweight (default for `haiku` alias) |
 
 The canonical list lives in [`models.json`](./models.json) — the single source of truth as of v3.11.0. Both `server.mjs` (the `/v1/models` endpoint) and `setup.mjs` (the OpenClaw registration) derive from it. Adding a new model is now a one-file edit:

--- a/README.md
+++ b/README.md
@@ -716,7 +716,8 @@ Any tool use happens server-side, under the `--allowedTools` set configured on t
 | `claude-opus-4-8` | Most capable (default for `opus` alias) |
 | `claude-opus-4-7` | Previous Opus, retained for pinning |
 | `claude-opus-4-6` | Older Opus, retained for pinning |
-| `claude-sonnet-4-6` | Good balance of speed/quality (default for `sonnet` alias) |
+| `claude-sonnet-5` | Latest Sonnet (default for `sonnet` alias) |
+| `claude-sonnet-4-6` | Previous Sonnet, retained for pinning |
 | `claude-haiku-4-5-20251001` | Fastest, lightweight (default for `haiku` alias) |
 
 The canonical list lives in [`models.json`](./models.json) — the single source of truth as of v3.11.0. Both `server.mjs` (the `/v1/models` endpoint) and `setup.mjs` (the OpenClaw registration) derive from it. Adding a new model is now a one-file edit:

--- a/models.json
+++ b/models.json
@@ -53,7 +53,7 @@
   ],
   "aliases": {
     "opus": "claude-opus-4-8",
-    "sonnet": "claude-sonnet-4-6",
+    "sonnet": "claude-sonnet-5",
     "haiku": "claude-haiku-4-5-20251001"
   },
   "legacyAliases": {

--- a/models.json
+++ b/models.json
@@ -27,6 +27,14 @@
       "maxTokens": 16384
     },
     {
+      "id": "claude-sonnet-5",
+      "displayName": "Claude Sonnet 5",
+      "openclawName": "Claude Sonnet 5 (via CLI)",
+      "reasoning": true,
+      "contextWindow": 200000,
+      "maxTokens": 16384
+    },
+    {
       "id": "claude-sonnet-4-6",
       "displayName": "Claude Sonnet 4.6",
       "openclawName": "Claude Sonnet 4.6 (via CLI)",
@@ -45,7 +53,7 @@
   ],
   "aliases": {
     "opus": "claude-opus-4-8",
-    "sonnet": "claude-sonnet-4-6",
+    "sonnet": "claude-sonnet-5",
     "haiku": "claude-haiku-4-5-20251001"
   },
   "legacyAliases": {

--- a/models.json
+++ b/models.json
@@ -53,7 +53,7 @@
   ],
   "aliases": {
     "opus": "claude-opus-4-8",
-    "sonnet": "claude-sonnet-5",
+    "sonnet": "claude-sonnet-4-6",
     "haiku": "claude-haiku-4-5-20251001"
   },
   "legacyAliases": {

--- a/ocp-connect
+++ b/ocp-connect
@@ -122,11 +122,17 @@ provider = {
     "models": []
 }
 
-# Model metadata mapping (prefix match for versioned IDs like claude-haiku-4-5-20251001)
+# Model metadata mapping. Prefix match on the model FAMILY (claude-opus / -sonnet /
+# -haiku), not a pinned version. A version-pinned prefix like "claude-sonnet-4"
+# silently misses "claude-sonnet-5" and falls through to the non-reasoning /
+# 8k-output default (PR #152 review) — every future Sonnet/Opus/Haiku bump would
+# re-trip it. Family prefixes classify any versioned ID correctly with no per-model
+# edit. (ADR 0003: models.json is the SPOT for model existence; /v1/models does not
+# expose reasoning/maxTokens, so family classification stays here.)
 model_meta = {
-    "claude-opus-4": {"name": "Claude Opus (OCP)", "reasoning": True, "maxTokens": 16384},
-    "claude-sonnet-4": {"name": "Claude Sonnet (OCP)", "reasoning": True, "maxTokens": 16384},
-    "claude-haiku-4": {"name": "Claude Haiku (OCP)", "reasoning": False, "maxTokens": 8192},
+    "claude-opus": {"name": "Claude Opus (OCP)", "reasoning": True, "maxTokens": 16384},
+    "claude-sonnet": {"name": "Claude Sonnet (OCP)", "reasoning": True, "maxTokens": 16384},
+    "claude-haiku": {"name": "Claude Haiku (OCP)", "reasoning": False, "maxTokens": 8192},
 }
 
 def get_model_meta(mid):
@@ -178,11 +184,11 @@ config.setdefault("agents", {})
 config["agents"].setdefault("defaults", {})
 config["agents"]["defaults"].setdefault("models", {})
 
-# Build alias map (prefix match)
+# Build alias map (family prefix match — version-agnostic, see model_meta note)
 alias_prefixes = {
-    "claude-opus-4": "Claude Opus",
-    "claude-sonnet-4": "Claude Sonnet",
-    "claude-haiku-4": "Claude Haiku",
+    "claude-opus": "Claude Opus",
+    "claude-sonnet": "Claude Sonnet",
+    "claude-haiku": "Claude Haiku",
 }
 
 for mid in model_ids:

--- a/ocp-connect
+++ b/ocp-connect
@@ -202,8 +202,13 @@ for mid in model_ids:
 
 # Handle primary/backup
 if priority == "1":
-    # OCP as primary — pick the best model (prefer sonnet for daily use)
-    primary_model = provider_name + "/claude-sonnet-4-6" if "claude-sonnet-4-6" in model_ids else provider_name + "/" + model_ids[0]
+    # OCP as primary — pick the best model (prefer the latest Sonnet for daily use,
+    # tracking the `sonnet` alias default in models.json; fall back across versions).
+    _sonnet_pref = ["claude-sonnet-5", "claude-sonnet-4-6"]
+    primary_model = next(
+        (provider_name + "/" + m for m in _sonnet_pref if m in model_ids),
+        provider_name + "/" + model_ids[0],
+    )
     config["agents"]["defaults"].setdefault("model", {})
     config["agents"]["defaults"]["model"]["primary"] = primary_model
     # Keep existing fallbacks

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -3322,8 +3322,8 @@ test("models.json aliases.haiku === 'claude-haiku-4-5-20251001' (usage-probe SPO
   assert.equal(_spotModels.aliases.haiku, "claude-haiku-4-5-20251001");
 });
 
-test("models.json aliases.sonnet === 'claude-sonnet-4-6' (default-request-model SPOT)", () => {
-  assert.equal(_spotModels.aliases.sonnet, "claude-sonnet-4-6");
+test("models.json aliases.sonnet === 'claude-sonnet-5' (default-request-model SPOT)", () => {
+  assert.equal(_spotModels.aliases.sonnet, "claude-sonnet-5");
 });
 
 // ── escapeHtml + key-name validator (issue #114) ────────────────────────────

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -3322,8 +3322,33 @@ test("models.json aliases.haiku === 'claude-haiku-4-5-20251001' (usage-probe SPO
   assert.equal(_spotModels.aliases.haiku, "claude-haiku-4-5-20251001");
 });
 
-test("models.json aliases.sonnet === 'claude-sonnet-5' (default-request-model SPOT)", () => {
-  assert.equal(_spotModels.aliases.sonnet, "claude-sonnet-5");
+test("models.json aliases.sonnet === 'claude-sonnet-4-6' (default-request-model SPOT)", () => {
+  assert.equal(_spotModels.aliases.sonnet, "claude-sonnet-4-6");
+});
+
+// ── Referential integrity (PR #152 review) ──────────────────────────────────
+// The value-mirror assertions above only prove the alias equals a string literal —
+// they pass even if that literal points at a model that does not exist in
+// models[]. A one-line slip (edit an alias, forget the models[] entry) would leave
+// /v1/models missing the model while every `model: "<alias>"` request passes
+// validation and then fails at CLI spawn. VALID_MODELS keys on alias *names*, so
+// nothing else checks alias *targets*. This is the guard with teeth.
+const _spotModelIds = new Set(_spotModels.models.map(m => m.id));
+
+test("models.json: claude-sonnet-5 is present in models[] (the entry this PR adds)", () => {
+  assert.ok(_spotModelIds.has("claude-sonnet-5"), "claude-sonnet-5 must exist as a models[].id");
+});
+
+test("models.json: every aliases value resolves to a real models[].id (referential integrity)", () => {
+  for (const [name, target] of Object.entries(_spotModels.aliases)) {
+    assert.ok(_spotModelIds.has(target), `aliases.${name} -> '${target}' is a dangling alias (no matching models[].id)`);
+  }
+});
+
+test("models.json: every legacyAliases value resolves to a real models[].id (referential integrity)", () => {
+  for (const [name, target] of Object.entries(_spotModels.legacyAliases || {})) {
+    assert.ok(_spotModelIds.has(target), `legacyAliases.${name} -> '${target}' is a dangling alias (no matching models[].id)`);
+  }
 });
 
 // ── escapeHtml + key-name validator (issue #114) ────────────────────────────

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -3322,8 +3322,8 @@ test("models.json aliases.haiku === 'claude-haiku-4-5-20251001' (usage-probe SPO
   assert.equal(_spotModels.aliases.haiku, "claude-haiku-4-5-20251001");
 });
 
-test("models.json aliases.sonnet === 'claude-sonnet-4-6' (default-request-model SPOT)", () => {
-  assert.equal(_spotModels.aliases.sonnet, "claude-sonnet-4-6");
+test("models.json aliases.sonnet === 'claude-sonnet-5' (default-request-model SPOT)", () => {
+  assert.equal(_spotModels.aliases.sonnet, "claude-sonnet-5");
 });
 
 // ── Referential integrity (PR #152 review) ──────────────────────────────────


### PR DESCRIPTION
Split out from #152 per Iron Rule 11 (one PR per layer per severity). #152 adds the `claude-sonnet-5` entry to `models.json` (purely additive); **this PR makes the behavior change** — moving the default `sonnet` alias from `claude-sonnet-4-6` → `claude-sonnet-5`.

### Why separate
`aliases.sonnet` is the default model for every `/v1/chat/completions` request that omits `model` (`server.mjs`), and — via `ocp-connect` — OpenClaw's OCP primary. Repointing it silently changes behavior for every such client, so per your review it deserves its own PR + CHANGELOG line, distinct from the additive model entry.

### Changes
- **models.json:** `aliases.sonnet` → `claude-sonnet-5`. `claude-sonnet-4-6` stays available by full ID for pinning. Both are `pricing: tier_3_15` — no cost regression.
- **ocp-connect:** `primary_model` now prefers `claude-sonnet-5` (fallback → `claude-sonnet-4-6` → first model), so OpenClaw's primary tracks the alias default instead of staying pinned to 4-6.
- **README:** "default for `sonnet` alias" annotation moved onto `claude-sonnet-5`.
- **CHANGELOG:** Unreleased § Changed entry documenting the default change + how to pin the old model.
- **test:** SPOT assertion updated to `claude-sonnet-5`; the referential-integrity tests added in #152 continue to guard that the alias target exists in `models[]`.

### Scope / alignment
No `server.mjs` change, so no `cli.js` citation required. models.json is the SPOT (ADR 0003).

### Dependency
**Depends on #152** — needs the `claude-sonnet-5` `models[]` entry to exist, otherwise the referential-integrity test fails. Please land #152 first, then this. (Branch is stacked on #152's head.)

Tests: `266 passed, 0 failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)