### PR TITLE
chore(release): v3.22.1 — renumber unpublished v3.22.0 + fold in #161/#152

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
-## v3.22.0 — 2026-07-16
+## v3.22.1 — 2026-07-17
 
-Minor release: TUI-mode latency and streaming features — **all opt-in and off by default**, so the default request path (`-p` / `--output-format stream-json`) is byte-for-byte unchanged — plus hardening from an independent (Codex) re-review of the streaming work. No new `cli.js` wire behavior and no new endpoint; the new surface is entirely OCP-owned TUI-mode configuration (env vars) and `/health` observation. Every code PR carried a fresh-context reviewer (Iron Rule 10).
+Minor release: TUI-mode latency and streaming features — **all opt-in and off by default**, so the default request path (`-p` / `--output-format stream-json`) is byte-for-byte unchanged — plus hardening from an independent (Codex) re-review of the streaming work, Windows `claude.exe` startup resolution, and the Claude Sonnet 5 model entry. No new `cli.js` wire behavior and no new endpoint; the new surface is entirely OCP-owned TUI-mode configuration (env vars), startup binary discovery, model metadata, and `/health` observation. Every code PR carried a fresh-context reviewer (Iron Rule 10). (Version note: v3.22.0 was prepared but never tagged; its contents ship here as v3.22.1 together with the additions below.)
+
+### Added
+
+- **Claude Sonnet 5 in the model SPOT (#152, contributed by @vvlasy-openclaw)** — `claude-sonnet-5` added to `models.json` (`contextWindow` 200000 / `maxTokens` 16384 / `reasoning` true, consistent with existing entries), exposed via `/v1/models` and the OpenClaw sync. Purely additive: the `sonnet` alias still resolves to `claude-sonnet-4-6` (the repoint is tracked separately in #168). `ocp-connect`'s model classifier now matches on the model *family* prefix (`claude-sonnet`/`claude-opus`/`claude-haiku`) instead of version-pinned prefixes, so current and future versioned IDs register with correct `reasoning`/`maxTokens` metadata. New referential-integrity tests guard that every alias target exists in `models[]`.
+- **Windows `claude.exe` startup resolution (#161, contributed by @nyxst4ck, diagnosis credit #147 @Justinsato)** — on Windows, `resolveClaude()` now discovers a native `claude.exe` (`%USERPROFILE%\.local\bin`, WinGet Links, WindowsApps, then `where.exe`) and rejects npm `.cmd`/`.bat`/`.ps1` shims, which cannot be spawned without a shell — previously startup resolved a shim and failed. A non-`.exe` `CLAUDE_BIN` on Windows is a fatal error with an actionable hint. The macOS/Linux path is byte-for-byte unchanged. Note: this is startup binary resolution only — full Windows support is not yet claimed (snapshot-path portability is tracked in #167).
 
 ### Added — TUI mode (all opt-in, default off)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-claude-proxy",
-  "version": "3.22.0",
+  "version": "3.22.1",
   "description": "OCP (Open Claude Proxy) — use your Claude Pro/Max subscription as an OpenAI-compatible API for any IDE. Works with Cline, OpenCode, Aider, Continue.dev, OpenClaw, and more.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v3.22.1

**Why renumbered:** v3.22.0 (#166) was merged but never tagged; #161 (Windows `claude.exe` resolution) and #152 (Sonnet 5 model entry) then landed on `main`. Rather than tagging the historical `b7463a6`, the maintainer opted to ship one release at HEAD as **v3.22.1**. The v3.22.0 CHANGELOG section is retitled to v3.22.1 (with an explicit version note that v3.22.0 was never tagged), and gains the two new entries with contributor attribution.

Diff: `CHANGELOG.md` + `package.json` (3.22.0 → 3.22.1) only. No code change. Suite: **332/0**.

Semver: still the minor-family bump from 3.21.1 (features #156/#158/#159 + #152's model entry); 3.22.0 is simply skipped — semver requires increasing, not contiguous, versions.

Release-kit delta vs #166's walk: #152's README "Available Models" row already present; #161 adds no env var/endpoint; Windows support deliberately **not** advertised (binary resolution only until #167 + real-Windows E2E).

### After merge
Tag `v3.22.1` at the squash commit → `release.yml` extracts the matching CHANGELOG section → GitHub Release. Tag push held for the maintainer's go.

### Reviewer checklist (Iron Rule 10)
- [ ] The two new CHANGELOG entries faithfully describe what #161/#152 actually merged (check the squash commits `d501e78`, `2721664`), with correct attribution.
- [ ] No `v3.22.0` tag exists on the remote (renumbering is safe — nothing published referenced it).
- [ ] No stale `3.22.0` in code (`grep`); `release.yml` will match the `## v3.22.1` heading.
- [ ] `npm test` → 332/0; diff is docs+version only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)