### PR TITLE
fix: reconcile active request counter

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -1004,6 +1004,27 @@ const stats = {
 };
 const recentErrors = []; // last 20 errors
 
+function reconcileActiveRequestCounter(reason = "unspecified") {
+  const live = activeProcesses.size;
+  if (stats.activeRequests !== live) {
+    logEvent("warn", "active_request_counter_reconciled", {
+      reason,
+      before: stats.activeRequests,
+      liveProcesses: live,
+    });
+    stats.activeRequests = live;
+  }
+}
+
+function releaseActiveRequestCounter(reason = "unspecified") {
+  if (stats.activeRequests > 0) {
+    stats.activeRequests--;
+  } else {
+    logEvent("warn", "active_request_counter_underflow_prevented", { reason });
+    stats.activeRequests = 0;
+  }
+}
+
 // Per-model request stats
 const modelStats = new Map(); // cliModel → { requests, errors, timeouts, totalElapsed, maxElapsed, totalPromptChars, maxPromptChars }
 
@@ -1298,8 +1319,14 @@ function spawnClaudeProcess(model, messages, conversationId, keyName, releaseSlo
     spawnOpts.cwd = decision.home; // neutral cwd: no project CLAUDE.md/skills
   }
 
-  const proc = spawn(CLAUDE, cliArgs, spawnOpts);
-  activeProcesses.add(proc);
+  let proc;
+  try {
+    proc = spawn(CLAUDE, cliArgs, spawnOpts);
+    activeProcesses.add(proc);
+  } catch (err) {
+    releaseActiveRequestCounter("spawn_throw");
+    throw err;
+  }
 
   const t0 = Date.now();
   let gotFirstByte = false;
@@ -1309,7 +1336,9 @@ function spawnClaudeProcess(model, messages, conversationId, keyName, releaseSlo
     if (cleaned) return;
     cleaned = true;
     clearTimeout(overallTimer);
-    stats.activeRequests--;
+    activeProcesses.delete(proc);
+    releaseActiveRequestCounter("process_cleanup");
+    reconcileActiveRequestCounter("process_cleanup");
     // FIX ⑥: free the concurrency slot for a queued waiter. releaseSlot is itself idempotent,
     // and cleanup() is guarded by `cleaned`, so the slot is released exactly once on the first
     // exit path reached (proc 'exit' fires before 'close'; 'error' covers spawn failure).
@@ -1451,7 +1480,6 @@ async function callClaude(model, messages, conversationId, keyName, res) {
     proc.stderr.on("data", (d) => (stderr += d));
 
     proc.on("close", (code, signal) => {
-      activeProcesses.delete(proc);
       const elapsed = Date.now() - t0;
       cleanup();
       // Tolerate null exit code when result event was seen (sandbox-wrap noise, same
@@ -2893,6 +2921,7 @@ const server = createServer(async (req, res) => {
 
   // GET /health — comprehensive diagnostics
   if (req.url === "/health") {
+    reconcileActiveRequestCounter("health_snapshot");
     let binaryOk = false;
     try { accessSync(CLAUDE, constants.X_OK); binaryOk = true; } catch {}
 
@@ -3026,6 +3055,7 @@ const server = createServer(async (req, res) => {
   // GET /status — combined usage + health summary; uses operator token; admin only
   if (req.url === "/status" && req.method === "GET") {
     if (!isAdmin) return jsonResponse(res, 403, { error: { message: "admin only", type: "auth_error" } });
+    reconcileActiveRequestCounter("status_snapshot");
     return handleStatus(req, res);
   }
 

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -4166,3 +4166,13 @@ runAsyncTests().then(() => Promise.all(pendingAsync)).then(() => {
   closeDb();
   process.exit(1);
 });
+
+
+test("server activeRequests counter is reconciled against live child processes", () => {
+  const src = spotReadFileSync(new URL("./server.mjs", import.meta.url), "utf8");
+  assert.ok(src.includes("function reconcileActiveRequestCounter("), "reconcile helper must exist");
+  assert.ok(src.includes("activeProcesses.delete(proc);\n    releaseActiveRequestCounter(\"process_cleanup\");\n    reconcileActiveRequestCounter(\"process_cleanup\");"), "cleanup must delete process and reconcile the counter");
+  assert.ok(src.includes("releaseActiveRequestCounter(\"spawn_throw\");"), "synchronous spawn failure must release the numeric counter");
+  assert.ok(src.includes("reconcileActiveRequestCounter(\"health_snapshot\");"), "/health must self-heal stale activeRequests before reporting");
+  assert.ok(src.includes("reconcileActiveRequestCounter(\"status_snapshot\");"), "/status must self-heal stale activeRequests before reporting");
+});


### PR DESCRIPTION
## Summary

Fixes stale `stats.activeRequests` drift in the `-p` / `stream-json` child-process path.

The gateway already uses `claudeSemaphore` as the authoritative concurrency gate, but the legacy numeric `stats.activeRequests` counter could drift if process lifecycle paths did not update it in the same order as `activeProcesses`. This patch reconciles that numeric counter against the live child-process set and self-heals before `/health` and `/status` report it.

## Endpoint Class (REQUIRED)

- [ ] **Class A** — forwards a `cli.js` operation (e.g., `/v1/messages`, `/api/oauth/*`, or the Anthropic-side wire call inside `/usage`)
- [x] **Class B** — extends an OCP-owned compatibility endpoint (per ADR 0006). Sub-bucket:
  - [ ] B.1 — OpenAI-compatibility surface (`/v1/chat/completions`, `/v1/models`)
  - [x] B.2 — OCP-administrative surface (`/health`, `/dashboard`, `/sessions`, `/logs`, `/status`, `/settings`, `/api/keys*`, `/api/usage`, `/cache*`)
- [ ] **Hybrid** — touches both classes
- [ ] **Not endpoint-touching** — refactor / docs / tooling that does not modify any request handler

## Claude Code Alignment Evidence (REQUIRED)

### If Class A

- [ ] **Corresponding `cli.js` reference.** Not applicable; this PR does not modify a Class A endpoint.

- [ ] **If `cli.js` does not perform this operation**, not applicable; this is Class B.

- [ ] **Commit message citations.** Not applicable; this PR makes no Class A `cli.js` claims.

### If Class B

- [x] **Authorizing ADR.** ADR 0006 — `/health` and `/status` are grandfathered B.2 OCP-administrative endpoints as of v3.16.4.

- [x] **Specification citation.** Existing B.2 handler code in `server.mjs` for `/health` and `/status`; this is a behaviour-preserving refactor/self-healing fix for existing fields, not a new endpoint or field.

- [x] **No invention beyond the specification.** This PR does not introduce a new endpoint, method, field, or wire-level API contract. It only makes the existing `stats.activeRequests` value truthful by reconciling it with live child processes.

## Type of change

- [x] Bug fix (alignment with existing `cli.js` behavior, or with the cited spec / ADR for Class B)
- [ ] Feature
- [ ] Refactor
- [ ] Deletion
- [ ] Documentation / governance

## What changed

- adds `reconcileActiveRequestCounter()` against the live `activeProcesses` set
- adds guarded `releaseActiveRequestCounter()` to prevent underflow
- moves `activeProcesses.delete(proc)` into the idempotent `cleanup()` path
- reconciles the numeric counter during process cleanup
- releases the numeric counter if synchronous `spawn()` throws
- reconciles before reporting `/health` and `/status`
- adds a regression guard in `test-features.mjs`

## Why

In production we observed `/health` reporting saturated concurrency even after live work had drained:

```text
activeRequests=12
maxConcurrent=12
sessions=[]
```

That caused legitimate calls to see `concurrency limit reached` despite no matching live request list. The hotfix proved the issue: after reconciliation, `activeRequests` returned to zero after bursts and requests succeeded again.

## Validation

- `node --check server.mjs`
- `npm test` → `350 passed, 0 failed`
- live OCP smoke test against `/v1/chat/completions` on the patched deployment
- Hermes CLI smoke test through the OCP gateway succeeded

## Reviewer checklist

Reviewers: this section is for you, not the author. Do not approve until every box is checked.

- [ ] If Class A, I opened `cli.js` at the cited line range and confirmed the operation matches. If Class B, I opened the OpenAI spec at the cited section (B.1) or the authorizing ADR (B.2) and confirmed the behaviour described in this PR matches the cited reference.
- [ ] I ran (or confirmed CI ran) `.github/workflows/alignment.yml` and it passed.
- [ ] I am not the commit author of any commit in this PR (Iron Rule 10).
- [ ] If the PR asserts scope without a `cli.js` citation (Class A) or without an ADR (Class B), I confirmed the justification is sound per `ALIGNMENT.md` Rule 2 and ADR 0006.
- [ ] If the PR is Class B and adds a new endpoint or new method, I confirmed the authorizing ADR lands in the same merge or before this PR.

## Related

- `ALIGNMENT.md` Rule(s) invoked: Rule 3 / ADR 0006 Class B mapping
- Authorizing ADR (Class B only): ADR 0006
- Related issue / prior PR: production incident observed on OCP gateway active request drift
- Historical lesson reference (if relevant): none

### User-visible change self-check (铁律第五律 5.3)

- [ ] This PR has user-visible changes → README has corresponding documentation (paste diff link or line range)
- [x] This PR has no user-visible API or documentation change → existing `/health` and `/status` fields are corrected, not added or renamed

### Privacy self-check (for PUBLIC repos) — Iron Rule adjacent

- [x] This PR does not introduce real names, nicknames, or handles that identify specific individuals. All references use role-based terms (`project maintainer`, `contributor`, `user`, `reviewer`).
- [x] This PR does not introduce literal personal paths (`/Users/<username>/`, `/home/<username>/`). Uses `$HOME/` or `~/` instead.
- [x] This PR does not introduce personal machine hostnames. Uses role-based names or generic descriptors.
- [x] This PR does not introduce personal email addresses beyond automated placeholders like `noreply@<vendor>.com`.
