### PR TITLE
fix(tui): accept `shift+tab to cycle` as an input-ready marker

### DIFF
--- a/lib/tui/session.mjs
+++ b/lib/tui/session.mjs
@@ -182,8 +182,13 @@ function tuiCapturePane(tmux, tmuxName) {
 }
 
 // True once claude's input bar is rendered and ready for keystrokes.
+// Two known ready-state footers across claude versions: the classic `? for shortcuts`
+// hint, and the `shift+tab to cycle` hint (part of "⏵⏵ bypass permissions on (shift+tab
+// to cycle)") that newer claude 2.1.x renders in its place. Match EITHER — a matcher that
+// only knew the classic string silently reported "never ready" on those builds, timing out
+// every boot (tui_pane_not_ready) and, with the warm pool on, failing every pre-boot.
 function tuiInputReady(pane) {
-  return /\? for shortcuts/.test(pane);
+  return /\? for shortcuts|shift\+tab to cycle/.test(pane);
 }
 
 // True once the pasted prompt has POSITIVELY landed in the input box. We only trust
@@ -615,8 +620,9 @@ export async function bootTuiPane({
 //      A pooled pane is SINGLE-USE: it already carries its own fresh --session-id, it
 //      serves this one turn, and it is killed in the finally like any other pane.
 //   2. On a MISS: pre-trust the scratch cwd, boot an interactive `claude` in a fresh tmux
-//      session in the scratch cwd, poll capture-pane until the `? for shortcuts` input bar
-//      appears (bootTuiPane). BOOT_MS is the max wait, not a fixed delay.
+//      session in the scratch cwd, poll capture-pane until the input bar appears — see
+//      tuiInputReady for the ready-state footers matched (bootTuiPane). BOOT_MS is the max
+//      wait, not a fixed delay.
 //   3. Write prompt to a 0600 temp file (no shell injection from prompt content).
 //   4. Paste the prompt via tmux load-buffer + paste-buffer -p (bracketed paste) —
 //      reliable for large multi-line prompts where send-keys -l is not (issue #130).

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -3504,7 +3504,7 @@ if (process.env.OCP_TUI_LIVE === "1") {
 // Replicates tuiInputReady, tuiPromptLanded verbatim from lib/tui/session.mjs.
 // Keep in sync with the definitions there.
 function _tuiInputReady(pane) {
-  return /\? for shortcuts/.test(pane);
+  return /\? for shortcuts|shift\+tab to cycle/.test(pane);
 }
 function _tuiPromptLanded(pane, prompt) {
   const flatPane = pane.replace(/\s+/g, " ");
@@ -3522,7 +3522,12 @@ const TUI_READY_PANE = `❯ Try "how does <filepath> work?"
 const TUI_LANDED_PANE = `❯ Reply with exactly: PONG_TEST
   ? for shortcuts · ← for agents`;
 
-// Welcome splash shown before input bar is rendered — no `? for shortcuts`.
+// Newer claude 2.1.x renders the input bar with a `shift+tab to cycle` footer instead of
+// `? for shortcuts` — the matcher must accept it too, or the pane reads as never-ready.
+const TUI_READY_PANE_SHIFT_TAB = `❯ Try "how does <filepath> work?"
+  ⏵⏵ bypass permissions on (shift+tab to cycle)`;
+
+// Welcome splash shown before input bar is rendered — neither ready-state footer.
 const TUI_BOOT_PANE = `╭─ Claude Code v2.1.114 ─ Welcome back Tao! ─╮\n│ Tips for getting started │`;
 
 console.log("\nTUI readiness + paste-verify predicates (issue #130):");
@@ -3532,6 +3537,9 @@ test("tuiInputReady(READY_PANE) === true  (input bar rendered)", () => {
 });
 test("tuiInputReady(LANDED_PANE) === true  (input bar still present after paste)", () => {
   assert.equal(_tuiInputReady(TUI_LANDED_PANE), true);
+});
+test("tuiInputReady(READY_PANE_SHIFT_TAB) === true  (newer claude `shift+tab to cycle` footer)", () => {
+  assert.equal(_tuiInputReady(TUI_READY_PANE_SHIFT_TAB), true);
 });
 test("tuiInputReady(BOOT_PANE) === false  (welcome splash, no input bar yet)", () => {
   assert.equal(_tuiInputReady(TUI_BOOT_PANE), false);


### PR DESCRIPTION
## Summary

`tuiInputReady()` (`lib/tui/session.mjs`) decides when the spawned interactive `claude` pane is ready for keystrokes by scanning the captured pane for a ready-state footer. It matched only the classic `? for shortcuts` hint. Current `claude` 2.1.x no longer renders that string when idle — it shows `shift+tab to cycle` (part of `⏵⏵ bypass permissions on (shift+tab to cycle)`) instead.

On those builds every pane therefore reads as never-ready: cold boots time out (`tui_pane_not_ready`), and with the warm pane pool on (`OCP_TUI_POOL_SIZE>0`) every pre-boot fails — `bootFailures` climbs, warm hits stay at zero, and the whole pool feature silently no-ops with no error surfaced to the operator beyond the counter.

Fix: widen the matcher to `/\? for shortcuts|shift\+tab to cycle/` so it accepts either footer. The test replica of the predicate is kept verbatim and a positive test case for the new footer is added. **This is not an endpoint change** — it only affects terminal-readiness detection for the local spawn.

## Endpoint Class (REQUIRED)

- [x] **Not endpoint-touching** — a terminal-readiness predicate for the local interactive `claude` pane; no request handler or wire call is involved. Class A / Class B evidence sections are N/A (see Summary).

## Type of change

- [x] Bug fix (the warm pool / cold-boot readiness detection broke against the current claude input-bar UI)

## Related

- `ALIGNMENT.md` Rule(s) invoked: none (not endpoint-touching)

### User-visible change self-check

- [x] This PR has no user-visible changes → stated "no user-visible change" in summary above (internal readiness marker; no config or API surface changes).

### Privacy self-check (for PUBLIC repos)

- [x] Does not introduce real names, nicknames, or handles that identify specific individuals.
- [x] Does not introduce literal personal paths.
- [x] Does not introduce personal machine hostnames.
- [x] Does not introduce personal email addresses.
