### PR TITLE
fix(prompt): OCP_LOCAL_TOOLS wrapper no longer hard-codes a tool list (closes #185)

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -204,7 +204,7 @@ const OCP_SYSTEM_PROMPT_WRAPPER = `You are accessed via the OCP HTTP proxy. You 
 // default wrapper above is byte-for-byte unchanged. Selecting the positive wrapper does NOT expand
 // the tool surface (governed independently by --allowedTools/--disallowedTools) — it only changes the
 // prompt — and is boot-gated below (multi/non-loopback/anon → refuse) mirroring OCP_TUI_FULL_TOOLS.
-const OCP_LOCAL_TOOLS_WRAPPER = `You are accessed via the OCP HTTP proxy running on the operator's own machine. You have full access to the local filesystem, working directory, and shell through your available tools (Bash, Read, Write, Edit, Glob, Grep, etc.). Use them as needed to complete the operator's requests.`;
+const OCP_LOCAL_TOOLS_WRAPPER = `You are accessed via the OCP HTTP proxy running on the operator's own machine. Unlike the shared-gateway posture, you may use your available local tools to act on the operator's machine as the task requires. Use only the tools you actually have — do not assume filesystem, shell, or other access beyond the tool set provided to you in this session.`;
 
 // OCP_LOCAL_TOOLS is inert in TUI mode: the interactive (non-`-p`) path composes its own prompt via
 // callClaudeTui/messagesToPrompt and never calls extractSystemPrompt, so the wrapper is only ever

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -910,7 +910,7 @@ test("appendOperatorPrompt: operator value is trimmed before appending", () => {
 console.log("\nOCP_LOCAL_TOOLS wrapper + safety gate:");
 
 const NEG = "You do NOT have access to any local filesystem";
-const POS = "You have full access to the local filesystem";
+const POS = "you may use your available local tools";
 
 test("selectPromptWrapper: default (disabled) returns the negative wrapper BYTE-IDENTICAL", () => {
   // Mutation-proof: flip the ternary and the default path leaks the positive wrapper.
@@ -967,7 +967,7 @@ import { fileURLToPath as _ltF2P } from "node:url";
 const LT_SERVER = _ltF2P(new URL("./server.mjs", import.meta.url));
 const LT_POSIX = process.platform !== "win32"; // fake is a /bin/sh script; CI is POSIX
 const LT_NEG_MARK = "You do NOT have access to any local filesystem";
-const LT_POS_MARK = "You have full access to the local filesystem";
+const LT_POS_MARK = "you may use your available local tools";
 // Fake claude: record the --system-prompt it was spawned with, bump an optional spawn counter,
 // then emit a minimal valid stream-json response so the request completes (and caches).
 const LT_FAKE = `#!/bin/sh


### PR DESCRIPTION
Closes #185 (LOW, from the #182 fact-check). The positive local-tools wrapper hard-coded "full access to … through your available tools (Bash, Read, Write, Edit, Glob, Grep, etc.)" — over-promising when `CLAUDE_ALLOWED_TOOLS` is narrowed. Reworded to flip the **posture** only (defer to the actual granted tool set), no enumeration, no shell/write capability claim. The model already learns its real tools from claude's tool defs, so the list was redundant + fragile.

- No const reordering, no CONFIG_EPOCH structural change (epoch-fold test still passes → toggling still invalidates cache).
- Test markers updated (selectPromptWrapper unit + boot-server integration).
- **Rule 2**: OCP-owned prompt composition, no wire change → no `cli.js` citation. Blacklist clean. Suite **449/0**.

### Reviewer checklist (Iron Rule 10)
- [ ] New wrapper text asserts no specific tool/capability the model may not hold; still a clear positive-posture flip vs the negative wrapper.
- [ ] Integration test (boot server + fake claude) confirms the positive wrapper still reaches the `-p` spawn; epoch-fold invalidation intact.
- [ ] Default (OCP_LOCAL_TOOLS unset) path byte-identical — negative wrapper unchanged.
- [ ] `npm test` 449/0.