### PR TITLE
fix(server): pair the active-request counter with the process lifecycle (supersedes #180)

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -1371,7 +1371,6 @@ function spawnClaudeProcess(model, messages, conversationId, keyName, releaseSlo
     promptChars = stdinPayload.length;
   }
 
-  stats.activeRequests++;
   stats.totalRequests++;
   stats.oneOffRequests++;
   if (conversationId) {
@@ -1414,6 +1413,13 @@ function spawnClaudeProcess(model, messages, conversationId, keyName, releaseSlo
 
   const proc = spawn(CLAUDE, cliArgs, spawnOpts);
   activeProcesses.add(proc);
+  // Counter drift (#180, reported by @konceptnet): increment ONLY after the spawn has
+  // succeeded and the process is registered. cleanup() below is the SOLE decrement site and is
+  // wired to this proc's exit/close/error events, so increment and decrement are now
+  // structurally paired to one process lifecycle. Incrementing before the spawn (as this did)
+  // leaked +1 permanently on any synchronous throw in between — buildCliArgs, env assembly, the
+  // spawn decision, or spawn() itself — because cleanup() was not yet attached to anything.
+  stats.activeRequests++;
 
   const t0 = Date.now();
   let gotFirstByte = false;

--- a/server.mjs
+++ b/server.mjs
@@ -1414,11 +1414,15 @@ function spawnClaudeProcess(model, messages, conversationId, keyName, releaseSlo
   const proc = spawn(CLAUDE, cliArgs, spawnOpts);
   activeProcesses.add(proc);
   // Counter drift (#180, reported by @konceptnet): increment ONLY after the spawn has
-  // succeeded and the process is registered. cleanup() below is the SOLE decrement site and is
-  // wired to this proc's exit/close/error events, so increment and decrement are now
-  // structurally paired to one process lifecycle. Incrementing before the spawn (as this did)
-  // leaked +1 permanently on any synchronous throw in between — buildCliArgs, env assembly, the
-  // spawn decision, or spawn() itself — because cleanup() was not yet attached to anything.
+  // succeeded and the process is registered. Incrementing before the spawn (as this did) leaked
+  // +1 permanently on any synchronous throw in between — buildCliArgs, env assembly, the spawn
+  // decision, or spawn() itself — because nothing was yet attached that could undo it.
+  //
+  // cleanup() is the SOLE decrement site, but note how it is reached: only 'exit' is wired HERE
+  // (below); 'close' and 'error' are wired by each CALLER (callClaude / callClaudeStreaming).
+  // That caller wiring is REQUIRED, not belt-and-braces — a FAILED spawn emits 'error' and
+  // 'close' but never 'exit', so without it a spawn failure would never decrement. A future
+  // third caller of spawnClaudeProcess must wire them too.
   stats.activeRequests++;
 
   const t0 = Date.now();

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -959,7 +959,8 @@ test("localToolsSafetyError: multi is checked before loopback/anon (most severe 
 // a request — and boot-gate refusals are asserted by the process exit code. Without these, the
 // wiring (extractSystemPrompt using SYSTEM_PROMPT_WRAPPER, the boot gate, the epoch fold) can be
 // silently reverted with the unit suite still green — the maintainer's #1 rejection pattern.
-import { spawn as _ltSpawn } from "node:child_process";
+import { spawn as _ltSpawn, execFileSync as _ltExecFile } from "node:child_process";
+import { createServer as _ltNetServer } from "node:net";
 import { writeFileSync as _ltWrite, chmodSync as _ltChmod, readFileSync as _ltRead, existsSync as _ltExists, rmSync as _ltRm, mkdtempSync as _ltMkdtemp } from "node:fs";
 import { tmpdir as _ltTmp } from "node:os";
 import { fileURLToPath as _ltF2P } from "node:url";
@@ -984,8 +985,8 @@ exit 0
 
 function ltMkdir() { return _ltMkdtemp(join(_ltTmp(), "ocp-lt-")); }
 function ltFake(dir) { const p = join(dir, "claude"); _ltWrite(p, LT_FAKE); _ltChmod(p, 0o755); return p; }
-function ltBoot(env, dir) {
-  const child = _ltSpawn(process.execPath, [LT_SERVER], {
+function ltBoot(env, dir, nodeArgs = []) {
+  const child = _ltSpawn(process.execPath, [...nodeArgs, LT_SERVER], {
     env: { ...process.env, NODE_ENV: "test", OCP_DIR_OVERRIDE: dir, OCP_SKIP_AUTH_TEST: "1",
            CLAUDE_BIND: "127.0.0.1", CLAUDE_AUTH_MODE: "none", CLAUDE_CACHE_TTL: "0", CLAUDE_TIMEOUT: "4000", ...env },
     stdio: ["ignore", "pipe", "pipe"],
@@ -1111,69 +1112,82 @@ test("integration: toggling OCP_LOCAL_TOOLS invalidates the standard response ca
 // does `args.push("--allowedTools", ...ALLOWED_TOOLS)`, and a spread of enough elements throws
 // RangeError synchronously, right inside the window.
 //
-// The element count is DISCOVERED, not hard-coded: the throw threshold depends on stack size,
-// so a fixed number would silently stop triggering on a machine with a bigger stack and the
-// test would pass vacuously. We find a count that throws in THIS process, then use it for the
-// child (same binary, same default stack). The test also asserts the requests actually 500 —
-// if the trigger ever stops firing, that assert fails loudly instead of going quietly green.
-function ltSpreadThrowCount() {
-  for (const n of [1 << 16, 1 << 17, 1 << 18, 1 << 19]) {
-    try { const probe = []; probe.push("--allowedTools", ...Array(n).fill("x")); }
-    catch { return n; }
-  }
-  return null;
+// Getting there on Linux needs one more turn of the screw. The spread's cost is per ELEMENT,
+// so the naive form needs ~124k elements ≈ 250KB in one env var — and Linux caps a single env
+// string at MAX_ARG_STRLEN (32 * PAGE_SIZE = 131072 on x86-64), so execve rejects it (E2BIG).
+// Encoding around it fails too: empty items are 1 byte each, but `.filter(Boolean)`
+// (server.mjs:355) strips them, so ALLOWED_TOOLS ends up empty and the spread branch is never
+// entered at all.
+//
+// The lever is the stack: the throw threshold scales with it, and ltBoot spawns the server, so
+// the test owns its argv. Running the child under --stack-size=200 drops the threshold ~5x
+// (~24k elements ≈ 48KB), which fits Linux's limit with room to spare.
+//
+// The threshold is DISCOVERED, in a child under the SAME --stack-size (measuring it in this
+// process would report the parent's stack, which is not the one that matters), then taken with
+// 1.5x margin and hard-asserted under MAX_ARG_STRLEN. A hard-coded count would silently stop
+// triggering on another machine and the test would pass vacuously.
+const LT_STACK = 200;                 // child V8 stack (KB); lowers the spread-throw threshold
+const LT_MAX_ARG_STRLEN = 131072;     // Linux, x86-64: 32 * 4096
+function ltSpreadThrowCount(stackKb) {
+  // Binary-search the smallest element count whose spread throws, inside a child running with
+  // the stack the server will actually use.
+  const src = `const t=n=>{try{const a=[];a.push("--allowedTools",...Array(n).fill("x"));return false}catch{return true}};` +
+              `let lo=500,hi=400000;if(!t(hi)){console.log(0)}else{while(lo<hi){const m=(lo+hi)>>1;t(m)?hi=m:lo=m+1}console.log(lo)}`;
+  try {
+    return Number(String(_ltExecFile(process.execPath, [`--stack-size=${stackKb}`, "-e", src], { encoding: "utf8" })).trim()) || 0;
+  } catch { return 0; }
+}
+async function ltFreePort() {
+  const srv = _ltNetServer();
+  await new Promise(r => srv.listen(0, "127.0.0.1", r));
+  const p = srv.address().port;
+  await new Promise(r => srv.close(r));
+  return p;
 }
 async function ltPostStatus(port, body) {
   try {
     const r = await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
       method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body),
     });
-    return r.status;
-  } catch { return 0; }
+    return { status: r.status, text: await r.text() };
+  } catch { return { status: 0, text: "" }; }
 }
 
 console.log("\nactive-request counter pairing (#180 / #193):");
 
 test("integration: a synchronous pre-spawn throw must not leak stats.activeRequests", async () => {
   if (!LT_POSIX) return;
-  const n = ltSpreadThrowCount();
-  assert.ok(n, "could not find an element count whose spread throws — adjust ltSpreadThrowCount");
+  const thr = ltSpreadThrowCount(LT_STACK);
+  assert.ok(thr > 0, `no spread-throw threshold found under --stack-size=${LT_STACK}`);
+  const n = Math.ceil(thr * 1.5);                       // margin over the measured threshold
+  const entry = Array(n).fill("x").join(",");
+  const bytes = Buffer.byteLength(entry);
+  // Hard gate: if this ever stops fitting, fail loudly rather than regress to an E2BIG skip.
+  assert.ok(bytes <= LT_MAX_ARG_STRLEN,
+    `env entry ${bytes}B exceeds MAX_ARG_STRLEN ${LT_MAX_ARG_STRLEN}B — lower LT_STACK`);
+  const port = await ltFreePort();
   const dir = ltMkdir(); const fake = ltFake(dir);
-  // PORTABILITY: delivering the trigger needs an env var of ~2n bytes. Linux caps a SINGLE
-  // env string at MAX_ARG_STRLEN (32 * PAGE_SIZE = 131072), and n is ~130k here, so execve
-  // rejects it with E2BIG — this test cannot run on Linux, which includes CI. It runs on
-  // macOS/BSD. Skipping loudly rather than silently: a vacuous pass would be worse than no
-  // test, and the fix it guards is genuinely unprotected on CI (tracked in #197).
-  let child, buf;
-  try {
-    ({ child, buf } = ltBoot({
-      CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: "39370",
-      CLAUDE_ALLOWED_TOOLS: Array(n).fill("x").join(","),
-    }, dir));
-  } catch (e) {
-    if (e && (e.code === "E2BIG" || /E2BIG/.test(String(e.message)))) {
-      console.log(`    (SKIPPED on ${process.platform}: env of ${2 * n}B exceeds this OS's per-string execve limit — see #197)`);
-      _ltRm(dir, { recursive: true, force: true });
-      return;
-    }
-    throw e;
-  }
+  const { child, buf } = ltBoot({
+    CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port), CLAUDE_ALLOWED_TOOLS: entry,
+  }, dir, [`--stack-size=${LT_STACK}`]);
   let spawnErr = null;
-  child.on("error", e => { spawnErr = e; });   // E2BIG can arrive here instead of throwing
+  child.on("error", e => { spawnErr = e; });
   try {
     const up = await ltWait(() => buf.out.includes("listening on") || spawnErr, 20000);
-    if (spawnErr && (spawnErr.code === "E2BIG" || /E2BIG/.test(String(spawnErr.message)))) {
-      console.log(`    (SKIPPED on ${process.platform}: env of ${2 * n}B exceeds this OS's per-string execve limit — see #197)`);
-      return;
-    }
-    assert.ok(up && !spawnErr, `did not start: ${spawnErr ? spawnErr.message : buf.err.slice(0, 200)}`);
+    assert.ok(up && !spawnErr, `did not start: ${spawnErr ? spawnErr.message : buf.err.slice(0, 300)}`);
     const req = { model: "haiku", messages: [{ role: "user", content: "leak-probe" }] };
-    const codes = [];
-    for (let i = 0; i < 3; i++) codes.push(await ltPostStatus(39370, req));
-    // Non-vacuous: if the spread stopped throwing these would be 200 and the counter would be
-    // 0 for the wrong reason. Assert the fault actually fired before trusting the counter.
-    assert.deepEqual(codes, [500, 500, 500], `expected the pre-spawn throw to surface as 500s, got ${codes}`);
-    const r = await fetch(`http://127.0.0.1:39370/status`);
+    const res = [];
+    for (let i = 0; i < 3; i++) res.push(await ltPostStatus(port, req));
+    // Non-vacuous on two axes: the requests must actually fail, AND the failure must be the
+    // stack overflow from the --allowedTools spread — not some unrelated 500 that a small
+    // stack happened to produce. Without the second check a different fault would still leave
+    // the counter at 0 and the test would "pass" for the wrong reason.
+    assert.deepEqual(res.map(r => r.status), [500, 500, 500],
+      `expected the pre-spawn throw to surface as 500s, got ${res.map(r => r.status)}`);
+    assert.ok(res.every(r => /call stack size exceeded/i.test(r.text)),
+      `500s must come from the spread's RangeError; got: ${res[0].text.slice(0, 200)}`);
+    const r = await fetch(`http://127.0.0.1:${port}/status`);
     const active = (await r.json()).requests.active;
     assert.equal(active, 0,
       `3 requests threw before their spawn; the counter must be back to 0, got ${active} (this is the #180 leak)`);

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -1139,12 +1139,34 @@ test("integration: a synchronous pre-spawn throw must not leak stats.activeReque
   const n = ltSpreadThrowCount();
   assert.ok(n, "could not find an element count whose spread throws — adjust ltSpreadThrowCount");
   const dir = ltMkdir(); const fake = ltFake(dir);
-  const { child, buf } = ltBoot({
-    CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: "39370",
-    CLAUDE_ALLOWED_TOOLS: Array(n).fill("x").join(","),
-  }, dir);
+  // PORTABILITY: delivering the trigger needs an env var of ~2n bytes. Linux caps a SINGLE
+  // env string at MAX_ARG_STRLEN (32 * PAGE_SIZE = 131072), and n is ~130k here, so execve
+  // rejects it with E2BIG — this test cannot run on Linux, which includes CI. It runs on
+  // macOS/BSD. Skipping loudly rather than silently: a vacuous pass would be worse than no
+  // test, and the fix it guards is genuinely unprotected on CI (tracked in #197).
+  let child, buf;
   try {
-    assert.ok(await ltWait(() => buf.out.includes("listening on"), 20000), `did not start: ${buf.err.slice(0, 200)}`);
+    ({ child, buf } = ltBoot({
+      CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: "39370",
+      CLAUDE_ALLOWED_TOOLS: Array(n).fill("x").join(","),
+    }, dir));
+  } catch (e) {
+    if (e && (e.code === "E2BIG" || /E2BIG/.test(String(e.message)))) {
+      console.log(`    (SKIPPED on ${process.platform}: env of ${2 * n}B exceeds this OS's per-string execve limit — see #197)`);
+      _ltRm(dir, { recursive: true, force: true });
+      return;
+    }
+    throw e;
+  }
+  let spawnErr = null;
+  child.on("error", e => { spawnErr = e; });   // E2BIG can arrive here instead of throwing
+  try {
+    const up = await ltWait(() => buf.out.includes("listening on") || spawnErr, 20000);
+    if (spawnErr && (spawnErr.code === "E2BIG" || /E2BIG/.test(String(spawnErr.message)))) {
+      console.log(`    (SKIPPED on ${process.platform}: env of ${2 * n}B exceeds this OS's per-string execve limit — see #197)`);
+      return;
+    }
+    assert.ok(up && !spawnErr, `did not start: ${spawnErr ? spawnErr.message : buf.err.slice(0, 200)}`);
     const req = { model: "haiku", messages: [{ role: "user", content: "leak-probe" }] };
     const codes = [];
     for (let i = 0; i < 3; i++) codes.push(await ltPostStatus(39370, req));

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -1104,6 +1104,60 @@ test("integration: toggling OCP_LOCAL_TOOLS invalidates the standard response ca
   } finally { _ltRm(dir, { recursive: true, force: true }); }
 });
 
+// ── active-request counter is paired to the process lifecycle (#180 / #193) ──
+// The counter used to be incremented ~40 lines before the spawn, while its only decrement
+// (cleanup()) is wired to that proc's events — so any SYNCHRONOUS throw in between leaked +1
+// permanently. Driving that fault needs no production hook and no test double: buildCliArgs
+// does `args.push("--allowedTools", ...ALLOWED_TOOLS)`, and a spread of enough elements throws
+// RangeError synchronously, right inside the window.
+//
+// The element count is DISCOVERED, not hard-coded: the throw threshold depends on stack size,
+// so a fixed number would silently stop triggering on a machine with a bigger stack and the
+// test would pass vacuously. We find a count that throws in THIS process, then use it for the
+// child (same binary, same default stack). The test also asserts the requests actually 500 —
+// if the trigger ever stops firing, that assert fails loudly instead of going quietly green.
+function ltSpreadThrowCount() {
+  for (const n of [1 << 16, 1 << 17, 1 << 18, 1 << 19]) {
+    try { const probe = []; probe.push("--allowedTools", ...Array(n).fill("x")); }
+    catch { return n; }
+  }
+  return null;
+}
+async function ltPostStatus(port, body) {
+  try {
+    const r = await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
+      method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body),
+    });
+    return r.status;
+  } catch { return 0; }
+}
+
+console.log("\nactive-request counter pairing (#180 / #193):");
+
+test("integration: a synchronous pre-spawn throw must not leak stats.activeRequests", async () => {
+  if (!LT_POSIX) return;
+  const n = ltSpreadThrowCount();
+  assert.ok(n, "could not find an element count whose spread throws — adjust ltSpreadThrowCount");
+  const dir = ltMkdir(); const fake = ltFake(dir);
+  const { child, buf } = ltBoot({
+    CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: "39370",
+    CLAUDE_ALLOWED_TOOLS: Array(n).fill("x").join(","),
+  }, dir);
+  try {
+    assert.ok(await ltWait(() => buf.out.includes("listening on"), 20000), `did not start: ${buf.err.slice(0, 200)}`);
+    const req = { model: "haiku", messages: [{ role: "user", content: "leak-probe" }] };
+    const codes = [];
+    for (let i = 0; i < 3; i++) codes.push(await ltPostStatus(39370, req));
+    // Non-vacuous: if the spread stopped throwing these would be 200 and the counter would be
+    // 0 for the wrong reason. Assert the fault actually fired before trusting the counter.
+    assert.deepEqual(codes, [500, 500, 500], `expected the pre-spawn throw to surface as 500s, got ${codes}`);
+    const r = await fetch(`http://127.0.0.1:39370/status`);
+    const active = (await r.json()).requests.active;
+    assert.equal(active, 0,
+      `3 requests threw before their spawn; the counter must be back to 0, got ${active} (this is the #180 leak)`);
+  } finally { child.kill("SIGKILL"); _ltRm(dir, { recursive: true, force: true }); }
+});
+
 // ── Upgrade Tests ──
 import { runUpgrade, postFlightOk } from "./scripts/upgrade.mjs";
 


### PR DESCRIPTION
Takes over **#180** by @konceptnet. The bug they reported is **real and confirmed**; this lands a fix with a different, simpler shape. Credit preserved via `Co-Authored-By:` on the commit.

> **Revised after review.** Three claims in the original body were falsified by an independent reviewer and have been corrected below — including my rejection rationale, which was wrong on the technical merits. See commit `718f1f4`.

## The bug

`stats.activeRequests` was incremented ~40 lines *before* the child process was spawned, but its only decrement site — `cleanup()` — is reached via that process's events. Any **synchronous throw in the window between them** (`buildCliArgs`, env assembly, applying the spawn decision, or `spawn()` itself) leaked **+1 permanently**. `/health` and `/stats` then over-report in-flight work forever, and the drift is monotonic.

## The fix

Move the increment to immediately after `activeProcesses.add(proc)`, so increment and decrement are structurally paired to exactly one process lifecycle. **No try/catch and no reconciliation pass is needed.** One file, +7/−1.

**Why deferring the increment is safe:** `stats.activeRequests` is observability-only. The old `if (activeRequests >= MAX_CONCURRENT) throw` admission check was replaced by the `releaseSlot` semaphore; the only remaining readers are `/health`, `/status`, `/usage` and the plugin display. Verified by the reviewer: no control-flow reader exists, and the moved span is fully synchronous so no `/health` can observe an intermediate state.

## Regression test — env-only trigger, zero production hooks

My original body claimed no real test was possible here. **That was wrong twice over**, and the test is now included.

`test-features.mjs:955` already provides `ltBoot`, a real-server integration fixture (spawns `server.mjs`, fake `claude` binary, HTTP) — I had used it myself in #191 and reasoned from "cannot import `server.mjs`" straight to "cannot test" without checking. And the synchronous throw is reachable **from env alone**: `buildCliArgs` does `args.push("--allowedTools", ...ALLOWED_TOOLS)`, and a spread of enough elements throws `RangeError` synchronously, inside the leak window.

| | 3 requests | `stats.activeRequests` |
|---|---|---|
| `origin/main` | `500 × 3` | **3** (leaked) |
| this branch | `500 × 3` | **0** |

The committed test **discovers** the element count rather than hard-coding it — the threshold is stack-size dependent, so a fixed number would silently stop triggering on another machine and pass vacuously — and asserts the requests actually return 500 before trusting the counter. **Mutation-proven:** moving the increment back before the spawn fails it with `got 3 (this is the #180 leak)`.

Suite: **450 passed, 0 failed.**

### The test runs on Linux CI — an earlier revision of this PR claimed it could not

I first concluded the trigger was undeliverable on Linux and made the test skip there. **That was wrong**, and the reviewer built the working version. Three errors, all the same shape — treating a darwin measurement as universal:

| my claim | reality |
|---|---|
| "empty items don't reach the throw threshold" | Right conclusion, **wrong reason**. The spread costs per *element*, not per byte — empty and `"x"` have an identical threshold. What actually kills the encoding is `.filter(Boolean)` (`server.mjs:355`), which strips empty entries so the spread branch is never entered. |
| "the threshold moves with stack size, so the margin does not exist" | **Backwards.** The stack dependence is the *lever*, and `ltBoot` spawns the server, so the test owns its argv. `--stack-size=200` drops the threshold ~5x. |
| "only one spread exists, so there is no alternative trigger" | Premise true, **conclusion irrelevant** — the goal was never a second spread, it was making the one spread throw with fewer elements. |

Measured: threshold **24,069** elements under `--stack-size=200`; 1.5x margin = 36,104 elements = **72,207 bytes**, **45% under** Linux's `MAX_ARG_STRLEN` of 131,072. The test hard-asserts that byte budget, so a future regression fails loudly instead of silently degrading to a skip.

**Confirmed by CI on Linux, not by arithmetic** — the earlier revision's claim was inference, and this is the check:

```
✓ integration: a synchronous pre-spawn throw must not leak stats.activeRequests
=== Results: 450 passed, 0 failed ===
```

No `SKIPPED` line. **This fix is now guarded in CI, not just on dev machines.**

**Non-vacuity proven in both directions:**

| mutation | result |
|---|---|
| restore the bug | ✗ `got 3 (this is the #180 leak)` |
| neuter the trigger (tools filtered to empty), bug still present | ✗ `expected 500s, got 200,200,200` |
| neither | 450 passed, 0 failed |

The second is the important one: it proves the test cannot pass for the wrong reason. The 500s must also carry `call stack size exceeded`, so an unrelated fault that happened to leave the counter at 0 is not mistaken for success.

## Why not the original approach — corrected

My round-1 objection was that reconciling to `activeProcesses.size` is racy because a request that incremented but hasn't registered its process is invisible in that Set. **That was wrong:** there is no `await` anywhere in that window, so the state is unobservable on Node's single thread and the race cannot occur.

The reason reconciliation is still unsafe, measured rather than inferred:

- the decrement is wired to `'exit'` while `activeProcesses.delete` is wired to `'close'`, and **`exit` precedes `close`** (measured `exit @2ms`, `close @2017ms` with a grandchild holding stdout). For that window `activeProcesses.size` is **larger** than the true in-flight count, so reconciling to it would **over**-report — the opposite direction from what I claimed.
- a throw *after* `activeProcesses.add` leaves permanent residue in the Set, which reconciliation would then inherit as a permanent over-count.

Corrected publicly on #180 as well — the contributor was owed an accurate rejection.

## Alignment — corrected

My original declaration cited **Rule 2**, which is a category error: `ALIGNMENT.md:17` scopes Rules 1–5 to **Class A** only, and Rule 2 is a prohibition, not an authorization. Every reader of `stats.activeRequests` is a **grandfathered Class B.2** endpoint.

> **Authorized by ADR 0006 (grandfathered as of v3.16.4).** The field **set** is unchanged — no field added, removed or renamed — only the **value** is made truthful. Behaviour-preserving; no new ADR required.

Precedent for this exact form is in the same file at `server.mjs:3271-3276` (the F6 `spawn.isolated` fix). The `cli.js` part stands: **no hit, declared** — `cli.js` has no equivalent operation, and spawn argv and protocol are byte-identical.

## Filed separately, not folded in (Iron Rule 11)

- `stats.errors` stays `0` across all of these 500s — synchronous throws from `spawnClaudeProcess` are never counted.
- `CLAUDE.md` hard-requirement #1 literally instructs "justify scope under `ALIGNMENT.md` Rule 2", which is what I followed. `CLAUDE.md` predates ADR 0006's Class B section; it needs its own governance PR.

Iron Rule 10: needs re-review of the corrections; author does not self-approve.

