### PR TITLE
fix(server): hash the resolved model in cache keys; give the structured path its epoch

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -393,15 +393,8 @@ const NO_CONTEXT = process.env.CLAUDE_NO_CONTEXT === "true";
 // Deliberately boot-time-only: runtime-mutable settings (e.g. maxPromptChars via the settings
 // API) are excluded because a const epoch cannot track them; truncation also only drops
 // context rather than changing the instruction set.
-// The ALIAS MAP is folded in for the same reason. Cache keys hash the model string exactly as
-// the client sent it (`const model = parsed.model || aliases.sonnet`), so a request for "opus"
-// is cached under the literal "opus" — not under the canonical id it resolved to. models.json is
-// read once at boot, so repointing an alias (e.g. opus: 4-8 -> 5) only takes effect on restart,
-// and the SQLite response_cache outlives that restart. Without the alias map in the epoch, an
-// operator running CLAUDE_CACHE_TTL > 0 keeps being served the OLD model's answers for the alias
-// until TTL expiry — silently defeating the repoint. Same bug class as #176.
 const CONFIG_EPOCH = cryptoCreateHash("sha256")
-  .update(JSON.stringify([SYSTEM_PROMPT, SYSTEM_PROMPT_WRAPPER, ALLOWED_TOOLS, NO_CONTEXT, modelsConfig.aliases]))
+  .update(JSON.stringify([SYSTEM_PROMPT, SYSTEM_PROMPT_WRAPPER, ALLOWED_TOOLS, NO_CONTEXT]))
   .digest("hex").slice(0, 16);
 // Kill-switch for the FIX-③ default-path spawn-home isolation (see resolveSpawnHome /
 // spawnHomeMode below). When "1", the -p/stream-json spawn always runs in the operator's
@@ -2811,6 +2804,16 @@ async function handleChatCompletions(req, res) {
 
   const messages = parsed.messages || parsed.input || [{ role: "user", content: parsed.prompt || "" }];
   const model = parsed.model || modelsConfig.aliases.sonnet;
+  // Cache keys must hash the RESOLVED model, never the string the client happened to use.
+  // `model` is whatever was sent — a canonical id, an alias ("opus"), or a legacyAlias
+  // ("claude-opus-4"). MODEL_MAP carries all three, and models.json is read once at boot, so
+  // repointing an alias only takes effect on restart — while the SQLite response_cache outlives
+  // it. Hashing the raw string would therefore keep serving the OLD model's answers under that
+  // alias until TTL expiry, silently defeating the repoint (the #176 hazard, for aliases).
+  // Resolving first also means "opus" and "claude-opus-5" correctly share one slot: identical
+  // spawn, identical answer. Only the cache KEY is resolved — `model` is still echoed back to
+  // the client verbatim, so the wire response is unchanged.
+  const cacheModel = MODEL_MAP[model] || model;
   const stream = parsed.stream;
 
   // Validate model against known models
@@ -2907,7 +2910,7 @@ async function handleChatCompletions(req, res) {
     const promptCharsS = messages.reduce((a, m) => a + contentToText(m.content).length, 0);
     let structuredHash = null;
     if (CACHE_TTL > 0 && !conversationId && !hasCacheControl(messages)) {
-      structuredHash = cacheHash(model, messages, { keyId: req._authKeyId, temperature: parsed.temperature, max_tokens: parsed.max_tokens, top_p: parsed.top_p, structured });
+      structuredHash = cacheHash(cacheModel, messages, { keyId: req._authKeyId, temperature: parsed.temperature, max_tokens: parsed.max_tokens, top_p: parsed.top_p, structured, configEpoch: CONFIG_EPOCH });
       try {
         const cached = getCachedResponse(structuredHash, CACHE_TTL);
         if (cached) {
@@ -2926,7 +2929,7 @@ async function handleChatCompletions(req, res) {
     // one-off structured request (not stateful sessions / client-side prompt caching), independent of
     // whether OCP response caching is enabled; when caching IS on, the same key gates cache read/write.
     const dedupKey = (!conversationId && !hasCacheControl(messages))
-      ? cacheHash(model, messages, { keyId: req._authKeyId, temperature: parsed.temperature, max_tokens: parsed.max_tokens, top_p: parsed.top_p, structured })
+      ? cacheHash(cacheModel, messages, { keyId: req._authKeyId, temperature: parsed.temperature, max_tokens: parsed.max_tokens, top_p: parsed.top_p, structured, configEpoch: CONFIG_EPOCH })
       : null;
     const runStructured = async () => {
       const c = await runStructuredCompletion(upstreamCall, model, messages, conversationId, req._authKeyName, res, structured);
@@ -2975,7 +2978,7 @@ async function handleChatCompletions(req, res) {
     } else {
       // D1: include keyId in hash to isolate per-key cache pools (v2 format).
       // configEpoch (#176): any boot-config change that shapes answers invalidates the cache.
-      const hash = cacheHash(model, messages, { keyId: req._authKeyId, temperature: parsed.temperature, max_tokens: parsed.max_tokens, top_p: parsed.top_p, configEpoch: CONFIG_EPOCH });
+      const hash = cacheHash(cacheModel, messages, { keyId: req._authKeyId, temperature: parsed.temperature, max_tokens: parsed.max_tokens, top_p: parsed.top_p, configEpoch: CONFIG_EPOCH });
       req._cacheHash = hash; // store for later write-back
       try {
         const cached = getCachedResponse(hash, CACHE_TTL);

--- a/server.mjs
+++ b/server.mjs
@@ -2813,7 +2813,11 @@ async function handleChatCompletions(req, res) {
   // Resolving first also means "opus" and "claude-opus-5" correctly share one slot: identical
   // spawn, identical answer. Only the cache KEY is resolved — `model` is still echoed back to
   // the client verbatim, so the wire response is unchanged.
-  const cacheModel = MODEL_MAP[model] || model;
+  // hasOwn, not a bare lookup: MODEL_MAP is a plain object, so `MODEL_MAP["constructor"]`
+  // would return an inherited FUNCTION. Unreachable today (the VALID_MODELS gate below 400s
+  // first, and it is built from Object.keys so it holds only own keys), but a bare lookup
+  // would hand cacheHash a function the day anyone widens that gate or moves this binding.
+  const cacheModel = Object.hasOwn(MODEL_MAP, model) ? MODEL_MAP[model] : model;
   const stream = parsed.stream;
 
   // Validate model against known models

--- a/server.mjs
+++ b/server.mjs
@@ -393,8 +393,15 @@ const NO_CONTEXT = process.env.CLAUDE_NO_CONTEXT === "true";
 // Deliberately boot-time-only: runtime-mutable settings (e.g. maxPromptChars via the settings
 // API) are excluded because a const epoch cannot track them; truncation also only drops
 // context rather than changing the instruction set.
+// The ALIAS MAP is folded in for the same reason. Cache keys hash the model string exactly as
+// the client sent it (`const model = parsed.model || aliases.sonnet`), so a request for "opus"
+// is cached under the literal "opus" — not under the canonical id it resolved to. models.json is
+// read once at boot, so repointing an alias (e.g. opus: 4-8 -> 5) only takes effect on restart,
+// and the SQLite response_cache outlives that restart. Without the alias map in the epoch, an
+// operator running CLAUDE_CACHE_TTL > 0 keeps being served the OLD model's answers for the alias
+// until TTL expiry — silently defeating the repoint. Same bug class as #176.
 const CONFIG_EPOCH = cryptoCreateHash("sha256")
-  .update(JSON.stringify([SYSTEM_PROMPT, SYSTEM_PROMPT_WRAPPER, ALLOWED_TOOLS, NO_CONTEXT]))
+  .update(JSON.stringify([SYSTEM_PROMPT, SYSTEM_PROMPT_WRAPPER, ALLOWED_TOOLS, NO_CONTEXT, modelsConfig.aliases]))
   .digest("hex").slice(0, 16);
 // Kill-switch for the FIX-③ default-path spawn-home isolation (see resolveSpawnHome /
 // spawnHomeMode below). When "1", the -p/stream-json spawn always runs in the operator's

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -1161,6 +1161,26 @@ test("integration: an alias and its canonical target share ONE cache slot (STRUC
   } finally { child.kill("SIGKILL"); _ltRm(dir, { recursive: true, force: true }); }
 });
 
+// MODEL_MAP is models[] + aliases + legacyAliases, so resolving covers legacyAliases for free.
+// The three tests above all use `sonnet` (a plain alias); this pins the legacyAlias leg explicitly
+// rather than leaving it covered only by construction.
+test("integration: a legacyAlias shares ONE cache slot with its canonical target", async () => {
+  if (!LT_POSIX) return;
+  const dir = ltMkdir(); const fake = ltFake(dir); const counter = join(dir, "spawns.txt");
+  const { child, buf } = ltBoot({ CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: "39364", CLAUDE_CACHE_TTL: "60000", SP_COUNTER: counter }, dir);
+  try {
+    assert.ok(await ltWait(() => buf.out.includes("listening on")), `did not start: ${buf.err.slice(0, 200)}`);
+    _ltWrite(counter, "0");
+    const msgs = [{ role: "user", content: "legacy-alias-probe" }];
+    await ltPost(39364, { model: "claude-haiku-4-5", messages: msgs });            // legacyAlias
+    await ltWait(() => (Number(_ltRead(counter, "utf8")) || 0) >= 1, 3000);
+    await ltPost(39364, { model: "claude-haiku-4-5-20251001", messages: msgs });   // canonical
+    await new Promise(r => setTimeout(r, 600));
+    assert.equal(Number(_ltRead(counter, "utf8")) || 0, 1,
+      "legacyAliases live in MODEL_MAP too — resolving must collapse them onto the canonical slot");
+  } finally { child.kill("SIGKILL"); _ltRm(dir, { recursive: true, force: true }); }
+});
+
 test("integration: a config change invalidates the STRUCTURED cache too (closes the #177 gap)", async () => {
   if (!LT_POSIX) return;
   const dir = ltMkdir(); const fake = ltFakeJson(dir); const counter = join(dir, "spawns.txt");

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -1104,6 +1104,86 @@ test("integration: toggling OCP_LOCAL_TOOLS invalidates the standard response ca
   } finally { _ltRm(dir, { recursive: true, force: true }); }
 });
 
+// ── Cache keys hash the RESOLVED model, not the alias string (#194) ──────────
+// models.json is read once at boot, so repointing an alias only takes effect on restart —
+// while the SQLite response_cache outlives it. Hashing the raw string would keep serving the
+// OLD model's answers under that alias until TTL expiry. Rather than mutate models.json
+// mid-suite, these assert the equivalent observable: an alias and its canonical target must
+// land on the SAME cache slot, which is true only if the key is resolved before hashing.
+// Mutation: change `cacheModel` back to `model` at the three cacheHash call sites in
+// server.mjs and both tests go red (2 spawns instead of 1).
+
+// Fake that emits schema-valid JSON, so the structured path caches a VALIDATED result
+// (the stock LT_FAKE returns "OK", which fails validation → refusal → never cached).
+const LT_FAKE_JSON = `#!/bin/sh
+if [ -n "$SP_COUNTER" ]; then c=$(cat "$SP_COUNTER" 2>/dev/null || echo 0); echo $((c+1)) > "$SP_COUNTER"; fi
+printf '%s\\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"{\\"ok\\":true}"}]}}'
+printf '%s\\n' '{"type":"result"}'
+exit 0
+`;
+function ltFakeJson(dir) { const p = join(dir, "claude-json"); _ltWrite(p, LT_FAKE_JSON); _ltChmod(p, 0o755); return p; }
+const LT_SCHEMA = { type: "object", properties: { ok: { type: "boolean" } }, required: ["ok"], additionalProperties: false };
+
+console.log("\nCache key resolves the model alias (#194):");
+
+test("integration: an alias and its canonical target share ONE cache slot (normal path)", async () => {
+  if (!LT_POSIX) return;
+  const dir = ltMkdir(); const fake = ltFake(dir); const counter = join(dir, "spawns.txt");
+  const { child, buf } = ltBoot({ CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: "39360", CLAUDE_CACHE_TTL: "60000", SP_COUNTER: counter }, dir);
+  try {
+    assert.ok(await ltWait(() => buf.out.includes("listening on")), `did not start: ${buf.err.slice(0, 200)}`);
+    _ltWrite(counter, "0");
+    const msgs = [{ role: "user", content: "alias-resolution-probe" }];
+    await ltPost(39360, { model: "sonnet", messages: msgs });                 // miss → spawn
+    await ltWait(() => (Number(_ltRead(counter, "utf8")) || 0) >= 1, 3000);
+    await ltPost(39360, { model: "claude-sonnet-5", messages: msgs });        // same resolved model → HIT
+    await new Promise(r => setTimeout(r, 600));
+    assert.equal(Number(_ltRead(counter, "utf8")) || 0, 1,
+      "the canonical id must hit the slot the alias populated — a 2nd spawn means the key still hashes the raw alias");
+  } finally { child.kill("SIGKILL"); _ltRm(dir, { recursive: true, force: true }); }
+});
+
+test("integration: an alias and its canonical target share ONE cache slot (STRUCTURED path)", async () => {
+  if (!LT_POSIX) return;
+  const dir = ltMkdir(); const fake = ltFakeJson(dir); const counter = join(dir, "spawns.txt");
+  const { child, buf } = ltBoot({ CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: "39361", CLAUDE_CACHE_TTL: "60000", SP_COUNTER: counter }, dir);
+  try {
+    assert.ok(await ltWait(() => buf.out.includes("listening on")), `did not start: ${buf.err.slice(0, 200)}`);
+    _ltWrite(counter, "0");
+    const rf = { type: "json_schema", json_schema: { name: "probe", schema: LT_SCHEMA } };
+    const msgs = [{ role: "user", content: "structured-alias-probe" }];
+    await ltPost(39361, { model: "sonnet", messages: msgs, response_format: rf });
+    await ltWait(() => (Number(_ltRead(counter, "utf8")) || 0) >= 1, 4000);
+    await ltPost(39361, { model: "claude-sonnet-5", messages: msgs, response_format: rf });
+    await new Promise(r => setTimeout(r, 600));
+    assert.equal(Number(_ltRead(counter, "utf8")) || 0, 1,
+      "structured cache key must resolve the alias too — this is the path the epoch-only fix missed");
+  } finally { child.kill("SIGKILL"); _ltRm(dir, { recursive: true, force: true }); }
+});
+
+test("integration: a config change invalidates the STRUCTURED cache too (closes the #177 gap)", async () => {
+  if (!LT_POSIX) return;
+  const dir = ltMkdir(); const fake = ltFakeJson(dir); const counter = join(dir, "spawns.txt");
+  const rf = { type: "json_schema", json_schema: { name: "probe", schema: LT_SCHEMA } };
+  const req = { model: "sonnet", messages: [{ role: "user", content: "structured-epoch-probe" }], response_format: rf };
+  const bootOnce = async (env, port) => {
+    const { child, buf } = ltBoot({ CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port), CLAUDE_CACHE_TTL: "60000", SP_COUNTER: counter, ...env }, dir);
+    try {
+      assert.ok(await ltWait(() => buf.out.includes("listening on")), `did not start: ${buf.err.slice(0, 200)}`);
+      _ltWrite(counter, "0");
+      await ltPost(port, req);
+      await ltWait(() => (Number(_ltRead(counter, "utf8")) || 0) >= 1, 4000);
+      return Number(_ltRead(counter, "utf8")) || 0;
+    } finally { child.kill("SIGKILL"); }
+  };
+  try {
+    const off = await bootOnce({}, 39362);                        // caches under epoch(negative wrapper)
+    const on = await bootOnce({ OCP_LOCAL_TOOLS: "1" }, 39363);   // same DB, epoch differs → must re-spawn
+    assert.equal(off, 1, "first structured request (cache empty) must spawn claude");
+    assert.equal(on, 1, "structured cache must honor CONFIG_EPOCH — before #194 it omitted the epoch entirely and served the stale answer");
+  } finally { _ltRm(dir, { recursive: true, force: true }); }
+});
+
 // ── Upgrade Tests ──
 import { runUpgrade, postFlightOk } from "./scripts/upgrade.mjs";
 


### PR DESCRIPTION
**Reworked after review.** The first attempt on this branch folded `modelsConfig.aliases` into `CONFIG_EPOCH`. An independent reviewer **falsified it with a live repro**, and was right: the structured-output cache key never reads `CONFIG_EPOCH` at all, so adding inputs to the epoch could not possibly fix it. My original PR body claimed the fix "covers the normal, structured **and** singleflight paths" — **that claim was false**, and I've replaced the approach rather than patch the wording.

Same-release constraint with #192 still applies (either merge order is fine).

## Two defects

**1. Cache keys hashed the model string as the client sent it.** `model` is whatever arrived — a canonical id, an alias (`"opus"`), or a legacyAlias (`"claude-opus-4"`); `MODEL_MAP` carries all three, and all three are client-addressable (verified: a live server returns 200 for each). `models.json` is read once at boot, so repointing an alias only takes effect on **restart**, while the SQLite `response_cache` outlives it — serving the **old model's** answers under that alias until TTL expiry.

**2. The structured and dedup keys omitted `configEpoch` entirely** (`server.mjs:2910`, `:2929`), so **#177 never actually covered the structured path**. Changing `SYSTEM_PROMPT` — the original #176 scenario — still served structured answers composed under the old config. Latent for structured-output clients (Home Assistant AI Tasks et al.) since #153 landed.

## The fix

All three `cacheHash` call sites now hash `cacheModel = MODEL_MAP[model] || model`, and the structured + dedup keys now pass `configEpoch: CONFIG_EPOCH`.

Resolving the model was chosen over the epoch fold because it is **strictly better on three counts**, not merely different:

| | epoch fold (first attempt) | resolve the model (this) |
|---|---|---|
| normal path | fixed | fixed |
| **structured / dedup paths** | **not fixed** (they never read the epoch) | fixed |
| `legacyAliases` | not covered | covered for free |
| invalidation blast radius | **whole cache flushed** on any alias edit | only the repointed alias's entries change key |

Only the cache **key** is resolved — `model` is still echoed to the client verbatim, so the wire response is unchanged.

## Tests: +3, all mutation-proven

The previous attempt shipped with **zero** coverage — reverting it left the suite at 449/0, which the reviewer demonstrated. That was a fair hit, and it was compounded by my claiming a real test wasn't possible here. It was: `test-features.mjs:987` already has an `ltBoot` child-process harness, and line 1085 already uses it to test **epoch cache invalidation**. A fake `CLAUDE_BIN` means zero quota cost.

Rather than mutate `models.json` mid-suite, the tests assert the equivalent observable: **an alias and its canonical target must land on the same cache slot**, which holds only if the key is resolved before hashing.

| mutation | result |
|---|---|
| revert `cacheModel` → `model` at the 3 sites | **2 failures** (both alias tests) |
| drop `configEpoch` from the structured hash | **1 failure** (#177-gap test) |
| restored | **452 passed, 0 failed** |

## Blast radius — previously undisclosed, flagged by review

On upgrade, alias-addressed cache rows change key once and orphan, reaped by the TTL cleanup within one window. This is the **same shape as the v3.13.0 `v1`→`v2` hash upgrade already documented in README** ("they orphan and are reaped by the TTL cleanup interval within one window — no migration script required"), so the release note should carry an equivalent line. Literal-id rows are unaffected. `CLAUDE_CACHE_TTL` defaults to `0`, so a default deployment sees nothing.

## Severity

**P2, not P1.** Cache off by default; additionally requires no `conversationId` and no `cache_control`; only alias-addressed requests can go stale; TTL-bounded and self-healing (24h max by schema, 5 min in the documented example).

## Alignment

**`cli.js` citation: NOT APPLICABLE** — no `cli.js`-derived wire behavior is touched. Scope justified under `ALIGNMENT.md` **Rule 2** as OCP-owned cache bookkeeping; `cli.js` has no response cache. The endpoint is **Class B.1 under ADR 0006**, which authorizes the OpenAI-compat surface this caching sits behind. (The prior review noted #177 cited only Rule 2 for the same surface; citing ADR 0006 here is the more precise form.)

Iron Rule 10: needs re-review; author does not self-approve.