### PR TITLE
test: harden and instrument the ltBoot integration tests (#203, #199)

### DIFF
--- a/test-features.mjs
+++ b/test-features.mjs
@@ -997,7 +997,7 @@ function ltBoot(env, dir, nodeArgs = []) {
   // 'exit' fires when the process terminates, but its stdio pipes may still hold unread data —
   // 'close' is the one that guarantees both are drained. A test that terminates the child and
   // then asserts on buf.err/buf.out must wait for `closed`, not `exit != null`, or it can read
-  // an empty buffer. See ltAssertBoot below.
+  // an empty buffer.
   child.on("exit", (code, signal) => { buf.exit = code; buf.signal = signal; });
   child.on("close", () => { buf.closed = true; });
   // Without a listener, a spawn 'error' is re-thrown as an uncaught exception and takes down the
@@ -1010,7 +1010,11 @@ function ltBoot(env, dir, nodeArgs = []) {
 // as an intermittent ENOTEMPTY (4/200 in review). Node's own retry loop handles the window.
 function _ltRmRetry(dir) {
   try { _ltRm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 }); }
-  catch { /* a leaked temp dir must never fail a test — the OS reaps it */ }
+  catch (e) {
+    // Never throw: this runs in a finally, so a throw here would REPLACE the real assertion
+    // error and make a flake look like a regression. LT_DEBUG surfaces it without that risk.
+    if (process.env.LT_DEBUG) console.warn(`    [ltRmRetry] ${dir}: ${e.code || e.message}`);
+  }
 }
 // Every ltBoot assertion failure should be self-diagnosing. The historical failure text was
 // `expected a local-tools FATAL, got: ` — an empty string, which says nothing about whether the

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -991,7 +991,7 @@ function ltBoot(env, dir, nodeArgs = []) {
            CLAUDE_BIND: "127.0.0.1", CLAUDE_AUTH_MODE: "none", CLAUDE_CACHE_TTL: "0", CLAUDE_TIMEOUT: "4000", ...env },
     stdio: ["ignore", "pipe", "pipe"],
   });
-  const buf = { out: "", err: "", exit: undefined, signal: undefined, closed: false, spawnErr: null, t0: Date.now() };
+  const buf = { out: "", err: "", exit: undefined, signal: undefined, closed: false, closeMs: undefined, spawnErr: null, t0: Date.now() };
   child.stdout.on("data", d => { buf.out += d; });
   child.stderr.on("data", d => { buf.err += d; });
   // 'exit' fires when the process terminates, but its stdio pipes may still hold unread data —
@@ -1037,7 +1037,7 @@ function ltDiag(buf) {
   // with empty stderr is equally consistent with both, and they have unrelated root causes.
   // node= is here because a Node-version-specific stderr warning (22's SQLite ExperimentalWarning)
   // once masqueraded as "server did not start" for ~23 of 50 runs on a Linux box.
-  const ms = buf.closeMs !== undefined ? `${buf.closeMs}ms` : (buf.t0 ? `${Date.now() - buf.t0}ms(still open)` : "?");
+  const ms = buf.closeMs !== undefined ? `${buf.closeMs}ms` : `${Date.now() - buf.t0}ms(still open)`;
   return `exit=${buf.exit} signal=${buf.signal} closed=${buf.closed} closeMs=${ms} node=${process.version}` +
          (buf.spawnErr ? ` spawnErr=${buf.spawnErr.code || buf.spawnErr.message}` : "") +
          ` | stderr(${buf.err.length}B)=${JSON.stringify(buf.err.slice(0, 240))}` +
@@ -1134,6 +1134,16 @@ test("integration: safe single-user config BOOTS past the gate and announces loc
       `startup must announce local tools when active — ${ltDiag(buf)}`);
     assert.ok(buf.out.includes("Local tools: ON"),
       `startup must announce local tools when active — ${ltDiag(buf)}`);
+    // Nails ltHeadTail's head budget to the thing it exists to capture. Without this the
+    // coupling is silent: every added banner line pushes "Local tools: ON" later (Models:
+    // alone is ~18B per model), and the day it crosses 900 the diagnostic degrades back to
+    // the exact blind spot this PR fixed — with no test going red. Measured offset here is
+    // 581 of a 1118B banner, so the margin is ~17 more models.
+    const _ltOffset = buf.out.indexOf("Local tools: ON");
+    assert.ok(_ltOffset < 900,
+      `ltHeadTail's head budget (900B) no longer reaches the local-tools announcement — it is ` +
+      `now at byte ${_ltOffset}. The banner grew. Raise the head in ltHeadTail, or ltDiag will ` +
+      `silently stop showing the one line that distinguishes "booted" from "refused".`);
   } finally { child.kill("SIGKILL"); _ltRmRetry(dir); }
 });
 

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -1005,6 +1005,13 @@ function ltBoot(env, dir, nodeArgs = []) {
   child.on("error", e => { buf.spawnErr = e; });
   return { child, buf };
 }
+// child.kill("SIGKILL") kills server.mjs but NOT the fake `claude` grandchildren it spawned, and
+// those can still be writing sp.txt / spawns.txt into `dir` while rmSync walks it — which surfaced
+// as an intermittent ENOTEMPTY (4/200 in review). Node's own retry loop handles the window.
+function _ltRmRetry(dir) {
+  try { _ltRm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 }); }
+  catch { /* a leaked temp dir must never fail a test — the OS reaps it */ }
+}
 // Every ltBoot assertion failure should be self-diagnosing. The historical failure text was
 // `expected a local-tools FATAL, got: ` — an empty string, which says nothing about whether the
 // child never wrote, wrote to the other stream, died on a signal, or was never spawned.
@@ -1018,6 +1025,13 @@ async function ltWait(cond, ms = 9000) {
   const start = Date.now();
   while (Date.now() - start < ms) { if (cond()) return true; await new Promise(r => setTimeout(r, 40)); }
   return false;
+}
+async function ltFreePort() {
+  const srv = _ltNetServer();
+  await new Promise(r => srv.listen(0, "127.0.0.1", r));
+  const p = srv.address().port;
+  await new Promise(r => srv.close(r));
+  return p;
 }
 async function ltPost(port, body) {
   try {
@@ -1041,7 +1055,7 @@ test("integration: OCP_LOCAL_TOOLS=1 → the -p spawn receives the POSITIVE wrap
     const sp = _ltRead(cap, "utf8");
     assert.ok(sp.includes(LT_POS_MARK), `expected POSITIVE wrapper in --system-prompt, got: ${sp.slice(0,90)}`);
     assert.ok(!sp.includes(LT_NEG_MARK), "positive wrapper must REPLACE the negative one, not append");
-  } finally { child.kill("SIGKILL"); _ltRm(dir, { recursive: true, force: true }); }
+  } finally { child.kill("SIGKILL"); _ltRmRetry(dir); }
 });
 
 test("integration: flag OFF → the -p spawn receives the EXACT negative wrapper (default path byte-for-byte)", async () => {
@@ -1056,7 +1070,7 @@ test("integration: flag OFF → the -p spawn receives the EXACT negative wrapper
     const sp = _ltRead(cap, "utf8");
     // No system messages + no CLAUDE_SYSTEM_PROMPT → the wrapper is passed verbatim.
     assert.equal(sp, `You are accessed via the OCP HTTP proxy. You do NOT have access to any local filesystem, working directory, shell, git status, or machine environment. Do not infer or invent such information from any context you observe. Respond only based on the conversation provided.`);
-  } finally { child.kill("SIGKILL"); _ltRm(dir, { recursive: true, force: true }); }
+  } finally { child.kill("SIGKILL"); _ltRmRetry(dir); }
 });
 
 test("integration: boot gate REFUSES each unsafe config (multi / non-loopback / anon key)", async () => {
@@ -1074,12 +1088,12 @@ test("integration: boot gate REFUSES each unsafe config (multi / non-loopback / 
       try {
         // Wait for `closed`, not `exit`: the assertion below reads buf.err, and stderr is only
         // guaranteed drained at 'close'. This is the ordering #203 was filed for.
-        assert.ok(await ltWait(() => buf.closed), `[${c.label}] process never closed — ${ltDiag(buf)}`);
+        assert.ok(await ltWait(() => buf.closed || buf.spawnErr), `[${c.label}] process never closed — ${ltDiag(buf)}`);
         assert.notEqual(buf.exit, 0, `[${c.label}] must exit non-zero — ${ltDiag(buf)}`);
         assert.ok(/FATAL[\s\S]*OCP_LOCAL_TOOLS/.test(buf.err), `[${c.label}] expected a local-tools FATAL — ${ltDiag(buf)}`);
       } finally { child.kill("SIGKILL"); }
     }
-  } finally { _ltRm(dir, { recursive: true, force: true }); }
+  } finally { _ltRmRetry(dir); }
 });
 
 test("integration: safe single-user config BOOTS past the gate and announces local tools", async () => {
@@ -1088,9 +1102,15 @@ test("integration: safe single-user config BOOTS past the gate and announces loc
   const port = await ltFreePort();
   const { child, buf } = ltBoot({ OCP_LOCAL_TOOLS: "1", CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port) }, dir); // loopback + none
   try {
-    assert.ok(await ltWait(() => buf.out.includes("listening on")), `safe config must boot, got: ${buf.err.slice(0,200)}`);
-    assert.ok(buf.out.includes("Local tools: ON"), "startup must announce local tools when active");
-  } finally { child.kill("SIGKILL"); _ltRm(dir, { recursive: true, force: true }); }
+    // Same race as #199, one line over: "Local tools: ON" is written 14 console.log calls AFTER
+    // "listening on", so gating on the boot marker and then asserting the announcement can read a
+    // buffer holding only the first chunk. Wait for the line actually under assertion. Measured by
+    // review at 9/200 before this change and 0/200 after — it was the suite's top flake.
+    assert.ok(await ltWait(() => buf.out.includes("Local tools: ON") || buf.closed || buf.spawnErr),
+      `startup must announce local tools when active — ${ltDiag(buf)}`);
+    assert.ok(buf.out.includes("Local tools: ON"),
+      `startup must announce local tools when active — ${ltDiag(buf)}`);
+  } finally { child.kill("SIGKILL"); _ltRmRetry(dir); }
 });
 
 test("integration: TUI mode → flag is announced INERT (not 'ON'), boot not refused", async () => {
@@ -1113,7 +1133,7 @@ test("integration: TUI mode → flag is announced INERT (not 'ON'), boot not ref
       `must warn that OCP_LOCAL_TOOLS is inert under TUI — ${ltDiag(buf)}`);
     assert.ok(!buf.out.includes("Local tools: ON"),
       `must NOT claim local tools are ON in TUI mode (the wrapper is unused there) — ${ltDiag(buf)}`);
-  } finally { child.kill("SIGKILL"); _ltRm(dir, { recursive: true, force: true }); }
+  } finally { child.kill("SIGKILL"); _ltRmRetry(dir); }
 });
 
 test("integration: toggling OCP_LOCAL_TOOLS invalidates the standard response cache (epoch fold)", async () => {
@@ -1135,7 +1155,7 @@ test("integration: toggling OCP_LOCAL_TOOLS invalidates the standard response ca
     const on = await bootOnce({ OCP_LOCAL_TOOLS: "1" }, await ltFreePort());  // same DB, epoch(positive) → must MISS → re-spawn
     assert.equal(off, 1, "first request (cache empty) must spawn claude");
     assert.equal(on, 1, "after toggling the flag the identical request must NOT be served from the old cache (epoch differs → re-spawn)");
-  } finally { _ltRm(dir, { recursive: true, force: true }); }
+  } finally { _ltRmRetry(dir); }
 });
 
 // ── active-request counter is paired to the process lifecycle (#180 / #193) ──
@@ -1170,13 +1190,6 @@ function ltSpreadThrowCount(stackKb) {
   try {
     return Number(String(_ltExecFile(process.execPath, [`--stack-size=${stackKb}`, "-e", src], { encoding: "utf8" })).trim()) || 0;
   } catch { return 0; }
-}
-async function ltFreePort() {
-  const srv = _ltNetServer();
-  await new Promise(r => srv.listen(0, "127.0.0.1", r));
-  const p = srv.address().port;
-  await new Promise(r => srv.close(r));
-  return p;
 }
 async function ltPostStatus(port, body) {
   try {
@@ -1224,7 +1237,7 @@ test("integration: a synchronous pre-spawn throw must not leak stats.activeReque
     const active = (await r.json()).requests.active;
     assert.equal(active, 0,
       `3 requests threw before their spawn; the counter must be back to 0, got ${active} (this is the #180 leak)`);
-  } finally { child.kill("SIGKILL"); _ltRm(dir, { recursive: true, force: true }); }
+  } finally { child.kill("SIGKILL"); _ltRmRetry(dir); }
 });
 
 // ── Cache keys hash the RESOLVED model, not the alias string (#194) ──────────
@@ -1264,7 +1277,7 @@ test("integration: an alias and its canonical target share ONE cache slot (norma
     await new Promise(r => setTimeout(r, 600));
     assert.equal(Number(_ltRead(counter, "utf8")) || 0, 1,
       "the canonical id must hit the slot the alias populated — a 2nd spawn means the key still hashes the raw alias");
-  } finally { child.kill("SIGKILL"); _ltRm(dir, { recursive: true, force: true }); }
+  } finally { child.kill("SIGKILL"); _ltRmRetry(dir); }
 });
 
 test("integration: an alias and its canonical target share ONE cache slot (STRUCTURED path)", async () => {
@@ -1283,7 +1296,7 @@ test("integration: an alias and its canonical target share ONE cache slot (STRUC
     await new Promise(r => setTimeout(r, 600));
     assert.equal(Number(_ltRead(counter, "utf8")) || 0, 1,
       "structured cache key must resolve the alias too — this is the path the epoch-only fix missed");
-  } finally { child.kill("SIGKILL"); _ltRm(dir, { recursive: true, force: true }); }
+  } finally { child.kill("SIGKILL"); _ltRmRetry(dir); }
 });
 
 // MODEL_MAP is models[] + aliases + legacyAliases, so resolving covers legacyAliases for free.
@@ -1304,7 +1317,7 @@ test("integration: a legacyAlias shares ONE cache slot with its canonical target
     await new Promise(r => setTimeout(r, 600));
     assert.equal(Number(_ltRead(counter, "utf8")) || 0, 1,
       "legacyAliases live in MODEL_MAP too — resolving must collapse them onto the canonical slot");
-  } finally { child.kill("SIGKILL"); _ltRm(dir, { recursive: true, force: true }); }
+  } finally { child.kill("SIGKILL"); _ltRmRetry(dir); }
 });
 
 test("integration: a config change invalidates the STRUCTURED cache too (closes the #177 gap)", async () => {
@@ -1327,7 +1340,7 @@ test("integration: a config change invalidates the STRUCTURED cache too (closes 
     const on = await bootOnce({ OCP_LOCAL_TOOLS: "1" }, await ltFreePort());   // same DB, epoch differs → must re-spawn
     assert.equal(off, 1, "first structured request (cache empty) must spawn claude");
     assert.equal(on, 1, "structured cache must honor CONFIG_EPOCH — before #194 it omitted the epoch entirely and served the stale answer");
-  } finally { _ltRm(dir, { recursive: true, force: true }); }
+  } finally { _ltRmRetry(dir); }
 });
 
 // ── Upgrade Tests ──

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -991,11 +991,28 @@ function ltBoot(env, dir, nodeArgs = []) {
            CLAUDE_BIND: "127.0.0.1", CLAUDE_AUTH_MODE: "none", CLAUDE_CACHE_TTL: "0", CLAUDE_TIMEOUT: "4000", ...env },
     stdio: ["ignore", "pipe", "pipe"],
   });
-  const buf = { out: "", err: "", exit: undefined };
+  const buf = { out: "", err: "", exit: undefined, signal: undefined, closed: false, spawnErr: null };
   child.stdout.on("data", d => { buf.out += d; });
   child.stderr.on("data", d => { buf.err += d; });
-  child.on("exit", code => { buf.exit = code; });
+  // 'exit' fires when the process terminates, but its stdio pipes may still hold unread data —
+  // 'close' is the one that guarantees both are drained. A test that terminates the child and
+  // then asserts on buf.err/buf.out must wait for `closed`, not `exit != null`, or it can read
+  // an empty buffer. See ltAssertBoot below.
+  child.on("exit", (code, signal) => { buf.exit = code; buf.signal = signal; });
+  child.on("close", () => { buf.closed = true; });
+  // Without a listener, a spawn 'error' is re-thrown as an uncaught exception and takes down the
+  // whole runner instead of failing one test.
+  child.on("error", e => { buf.spawnErr = e; });
   return { child, buf };
+}
+// Every ltBoot assertion failure should be self-diagnosing. The historical failure text was
+// `expected a local-tools FATAL, got: ` — an empty string, which says nothing about whether the
+// child never wrote, wrote to the other stream, died on a signal, or was never spawned.
+function ltDiag(buf) {
+  return `exit=${buf.exit} signal=${buf.signal} closed=${buf.closed}` +
+         (buf.spawnErr ? ` spawnErr=${buf.spawnErr.code || buf.spawnErr.message}` : "") +
+         ` | stderr(${buf.err.length}B)=${JSON.stringify(buf.err.slice(0, 200))}` +
+         ` | stdout(${buf.out.length}B)=${JSON.stringify(buf.out.slice(-200))}`;
 }
 async function ltWait(cond, ms = 9000) {
   const start = Date.now();
@@ -1015,10 +1032,11 @@ console.log("\nOCP_LOCAL_TOOLS integration (boot server.mjs):");
 test("integration: OCP_LOCAL_TOOLS=1 → the -p spawn receives the POSITIVE wrapper (kills the no-op mutation)", async () => {
   if (!LT_POSIX) return; // sh fake — skip on Windows CI
   const dir = ltMkdir(); const cap = join(dir, "sp.txt"); const fake = ltFake(dir);
-  const { child, buf } = ltBoot({ OCP_LOCAL_TOOLS: "1", CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: "39321", SP_CAPTURE: cap }, dir);
+  const port = await ltFreePort();
+  const { child, buf } = ltBoot({ OCP_LOCAL_TOOLS: "1", CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port), SP_CAPTURE: cap }, dir);
   try {
     assert.ok(await ltWait(() => buf.out.includes("listening on") || buf.exit != null), `server did not start: ${buf.err.slice(0,200)}`);
-    await ltPost(39321, { model: "sonnet", messages: [{ role: "user", content: "hi" }] });
+    await ltPost(port, { model: "sonnet", messages: [{ role: "user", content: "hi" }] });
     assert.ok(await ltWait(() => _ltExists(cap)), "fake claude was spawned and captured --system-prompt");
     const sp = _ltRead(cap, "utf8");
     assert.ok(sp.includes(LT_POS_MARK), `expected POSITIVE wrapper in --system-prompt, got: ${sp.slice(0,90)}`);
@@ -1029,10 +1047,11 @@ test("integration: OCP_LOCAL_TOOLS=1 → the -p spawn receives the POSITIVE wrap
 test("integration: flag OFF → the -p spawn receives the EXACT negative wrapper (default path byte-for-byte)", async () => {
   if (!LT_POSIX) return;
   const dir = ltMkdir(); const cap = join(dir, "sp.txt"); const fake = ltFake(dir);
-  const { child, buf } = ltBoot({ CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: "39322", SP_CAPTURE: cap }, dir); // OCP_LOCAL_TOOLS unset
+  const port = await ltFreePort();
+  const { child, buf } = ltBoot({ CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port), SP_CAPTURE: cap }, dir); // OCP_LOCAL_TOOLS unset
   try {
     assert.ok(await ltWait(() => buf.out.includes("listening on") || buf.exit != null), `server did not start: ${buf.err.slice(0,200)}`);
-    await ltPost(39322, { model: "sonnet", messages: [{ role: "user", content: "hi" }] });
+    await ltPost(port, { model: "sonnet", messages: [{ role: "user", content: "hi" }] });
     assert.ok(await ltWait(() => _ltExists(cap)), "fake claude captured --system-prompt");
     const sp = _ltRead(cap, "utf8");
     // No system messages + no CLAUDE_SYSTEM_PROMPT → the wrapper is passed verbatim.
@@ -1049,12 +1068,15 @@ test("integration: boot gate REFUSES each unsafe config (multi / non-loopback / 
     { label: "anon", env: { PROXY_ANONYMOUS_KEY: "pub" } },
   ];
   try {
-    for (const [i, c] of cases.entries()) {
-      const { child, buf } = ltBoot({ OCP_LOCAL_TOOLS: "1", CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(39330 + i), ...c.env }, dir);
+    for (const c of cases) {
+      const port = await ltFreePort();
+      const { child, buf } = ltBoot({ OCP_LOCAL_TOOLS: "1", CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port), ...c.env }, dir);
       try {
-        assert.ok(await ltWait(() => buf.exit != null), `[${c.label}] expected the process to exit`);
-        assert.notEqual(buf.exit, 0, `[${c.label}] must exit non-zero`);
-        assert.ok(/FATAL[\s\S]*OCP_LOCAL_TOOLS/.test(buf.err), `[${c.label}] expected a local-tools FATAL, got: ${buf.err.slice(0,160)}`);
+        // Wait for `closed`, not `exit`: the assertion below reads buf.err, and stderr is only
+        // guaranteed drained at 'close'. This is the ordering #203 was filed for.
+        assert.ok(await ltWait(() => buf.closed), `[${c.label}] process never closed — ${ltDiag(buf)}`);
+        assert.notEqual(buf.exit, 0, `[${c.label}] must exit non-zero — ${ltDiag(buf)}`);
+        assert.ok(/FATAL[\s\S]*OCP_LOCAL_TOOLS/.test(buf.err), `[${c.label}] expected a local-tools FATAL — ${ltDiag(buf)}`);
       } finally { child.kill("SIGKILL"); }
     }
   } finally { _ltRm(dir, { recursive: true, force: true }); }
@@ -1063,7 +1085,8 @@ test("integration: boot gate REFUSES each unsafe config (multi / non-loopback / 
 test("integration: safe single-user config BOOTS past the gate and announces local tools", async () => {
   if (!LT_POSIX) return;
   const dir = ltMkdir(); const fake = ltFake(dir);
-  const { child, buf } = ltBoot({ OCP_LOCAL_TOOLS: "1", CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: "39340" }, dir); // loopback + none
+  const port = await ltFreePort();
+  const { child, buf } = ltBoot({ OCP_LOCAL_TOOLS: "1", CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port) }, dir); // loopback + none
   try {
     assert.ok(await ltWait(() => buf.out.includes("listening on")), `safe config must boot, got: ${buf.err.slice(0,200)}`);
     assert.ok(buf.out.includes("Local tools: ON"), "startup must announce local tools when active");
@@ -1075,11 +1098,21 @@ test("integration: TUI mode → flag is announced INERT (not 'ON'), boot not ref
   const dir = ltMkdir(); const fake = ltFake(dir);
   // Non-loopback would normally trip the local-tools gate; under TUI the flag is inert so the
   // gate must NOT fire on its behalf. Use loopback here to isolate TUI's own guards from ours.
-  const { child, buf } = ltBoot({ OCP_LOCAL_TOOLS: "1", CLAUDE_TUI_MODE: "true", CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: "39341" }, dir);
+  const port = await ltFreePort();
+  const { child, buf } = ltBoot({ OCP_LOCAL_TOOLS: "1", CLAUDE_TUI_MODE: "true", CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port) }, dir);
   try {
-    assert.ok(await ltWait(() => buf.out.includes("listening on") || buf.exit != null), `did not start: ${buf.err.slice(0,200)}`);
-    assert.ok(!buf.out.includes("Local tools: ON"), "must NOT claim local tools are ON in TUI mode (the wrapper is unused there)");
-    assert.ok(/ignored in TUI mode/.test(buf.out + buf.err), "must warn that OCP_LOCAL_TOOLS is inert under TUI");
+    // Wait for the line actually under assertion, not for a proxy signal. "listening on" and the
+    // inert-flag warning are written independently, so gating on the former and then asserting
+    // the latter is a race — the flake #199 was filed for. Still bounded by the same timeout, and
+    // the boot markers are kept in the predicate so a failed boot ends the wait immediately
+    // rather than burning it.
+    const ready = await ltWait(() => /ignored in TUI mode/.test(buf.out + buf.err)
+                                  || buf.closed || buf.spawnErr);
+    assert.ok(ready, `no inert-flag warning appeared — ${ltDiag(buf)}`);
+    assert.ok(/ignored in TUI mode/.test(buf.out + buf.err),
+      `must warn that OCP_LOCAL_TOOLS is inert under TUI — ${ltDiag(buf)}`);
+    assert.ok(!buf.out.includes("Local tools: ON"),
+      `must NOT claim local tools are ON in TUI mode (the wrapper is unused there) — ${ltDiag(buf)}`);
   } finally { child.kill("SIGKILL"); _ltRm(dir, { recursive: true, force: true }); }
 });
 
@@ -1098,8 +1131,8 @@ test("integration: toggling OCP_LOCAL_TOOLS invalidates the standard response ca
     } finally { child.kill("SIGKILL"); }
   };
   try {
-    const off = await bootOnce({}, 39350);                       // caches "OK" under epoch(negative)
-    const on = await bootOnce({ OCP_LOCAL_TOOLS: "1" }, 39351);  // same DB, epoch(positive) → must MISS → re-spawn
+    const off = await bootOnce({}, await ltFreePort());                       // caches "OK" under epoch(negative)
+    const on = await bootOnce({ OCP_LOCAL_TOOLS: "1" }, await ltFreePort());  // same DB, epoch(positive) → must MISS → re-spawn
     assert.equal(off, 1, "first request (cache empty) must spawn claude");
     assert.equal(on, 1, "after toggling the flag the identical request must NOT be served from the old cache (epoch differs → re-spawn)");
   } finally { _ltRm(dir, { recursive: true, force: true }); }
@@ -1219,14 +1252,15 @@ console.log("\nCache key resolves the model alias (#194):");
 test("integration: an alias and its canonical target share ONE cache slot (normal path)", async () => {
   if (!LT_POSIX) return;
   const dir = ltMkdir(); const fake = ltFake(dir); const counter = join(dir, "spawns.txt");
-  const { child, buf } = ltBoot({ CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: "39360", CLAUDE_CACHE_TTL: "60000", SP_COUNTER: counter }, dir);
+  const port = await ltFreePort();
+  const { child, buf } = ltBoot({ CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port), CLAUDE_CACHE_TTL: "60000", SP_COUNTER: counter }, dir);
   try {
     assert.ok(await ltWait(() => buf.out.includes("listening on")), `did not start: ${buf.err.slice(0, 200)}`);
     _ltWrite(counter, "0");
     const msgs = [{ role: "user", content: "alias-resolution-probe" }];
-    await ltPost(39360, { model: "sonnet", messages: msgs });                 // miss → spawn
+    await ltPost(port, { model: "sonnet", messages: msgs });                 // miss → spawn
     await ltWait(() => (Number(_ltRead(counter, "utf8")) || 0) >= 1, 3000);
-    await ltPost(39360, { model: "claude-sonnet-5", messages: msgs });        // same resolved model → HIT
+    await ltPost(port, { model: "claude-sonnet-5", messages: msgs });        // same resolved model → HIT
     await new Promise(r => setTimeout(r, 600));
     assert.equal(Number(_ltRead(counter, "utf8")) || 0, 1,
       "the canonical id must hit the slot the alias populated — a 2nd spawn means the key still hashes the raw alias");
@@ -1236,15 +1270,16 @@ test("integration: an alias and its canonical target share ONE cache slot (norma
 test("integration: an alias and its canonical target share ONE cache slot (STRUCTURED path)", async () => {
   if (!LT_POSIX) return;
   const dir = ltMkdir(); const fake = ltFakeJson(dir); const counter = join(dir, "spawns.txt");
-  const { child, buf } = ltBoot({ CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: "39361", CLAUDE_CACHE_TTL: "60000", SP_COUNTER: counter }, dir);
+  const port = await ltFreePort();
+  const { child, buf } = ltBoot({ CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port), CLAUDE_CACHE_TTL: "60000", SP_COUNTER: counter }, dir);
   try {
     assert.ok(await ltWait(() => buf.out.includes("listening on")), `did not start: ${buf.err.slice(0, 200)}`);
     _ltWrite(counter, "0");
     const rf = { type: "json_schema", json_schema: { name: "probe", schema: LT_SCHEMA } };
     const msgs = [{ role: "user", content: "structured-alias-probe" }];
-    await ltPost(39361, { model: "sonnet", messages: msgs, response_format: rf });
+    await ltPost(port, { model: "sonnet", messages: msgs, response_format: rf });
     await ltWait(() => (Number(_ltRead(counter, "utf8")) || 0) >= 1, 4000);
-    await ltPost(39361, { model: "claude-sonnet-5", messages: msgs, response_format: rf });
+    await ltPost(port, { model: "claude-sonnet-5", messages: msgs, response_format: rf });
     await new Promise(r => setTimeout(r, 600));
     assert.equal(Number(_ltRead(counter, "utf8")) || 0, 1,
       "structured cache key must resolve the alias too — this is the path the epoch-only fix missed");
@@ -1257,14 +1292,15 @@ test("integration: an alias and its canonical target share ONE cache slot (STRUC
 test("integration: a legacyAlias shares ONE cache slot with its canonical target", async () => {
   if (!LT_POSIX) return;
   const dir = ltMkdir(); const fake = ltFake(dir); const counter = join(dir, "spawns.txt");
-  const { child, buf } = ltBoot({ CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: "39364", CLAUDE_CACHE_TTL: "60000", SP_COUNTER: counter }, dir);
+  const port = await ltFreePort();
+  const { child, buf } = ltBoot({ CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port), CLAUDE_CACHE_TTL: "60000", SP_COUNTER: counter }, dir);
   try {
     assert.ok(await ltWait(() => buf.out.includes("listening on")), `did not start: ${buf.err.slice(0, 200)}`);
     _ltWrite(counter, "0");
     const msgs = [{ role: "user", content: "legacy-alias-probe" }];
-    await ltPost(39364, { model: "claude-haiku-4-5", messages: msgs });            // legacyAlias
+    await ltPost(port, { model: "claude-haiku-4-5", messages: msgs });            // legacyAlias
     await ltWait(() => (Number(_ltRead(counter, "utf8")) || 0) >= 1, 3000);
-    await ltPost(39364, { model: "claude-haiku-4-5-20251001", messages: msgs });   // canonical
+    await ltPost(port, { model: "claude-haiku-4-5-20251001", messages: msgs });   // canonical
     await new Promise(r => setTimeout(r, 600));
     assert.equal(Number(_ltRead(counter, "utf8")) || 0, 1,
       "legacyAliases live in MODEL_MAP too — resolving must collapse them onto the canonical slot");
@@ -1287,8 +1323,8 @@ test("integration: a config change invalidates the STRUCTURED cache too (closes 
     } finally { child.kill("SIGKILL"); }
   };
   try {
-    const off = await bootOnce({}, 39362);                        // caches under epoch(negative wrapper)
-    const on = await bootOnce({ OCP_LOCAL_TOOLS: "1" }, 39363);   // same DB, epoch differs → must re-spawn
+    const off = await bootOnce({}, await ltFreePort());                        // caches under epoch(negative wrapper)
+    const on = await bootOnce({ OCP_LOCAL_TOOLS: "1" }, await ltFreePort());   // same DB, epoch differs → must re-spawn
     assert.equal(off, 1, "first structured request (cache empty) must spawn claude");
     assert.equal(on, 1, "structured cache must honor CONFIG_EPOCH — before #194 it omitted the epoch entirely and served the stale answer");
   } finally { _ltRm(dir, { recursive: true, force: true }); }

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -991,7 +991,7 @@ function ltBoot(env, dir, nodeArgs = []) {
            CLAUDE_BIND: "127.0.0.1", CLAUDE_AUTH_MODE: "none", CLAUDE_CACHE_TTL: "0", CLAUDE_TIMEOUT: "4000", ...env },
     stdio: ["ignore", "pipe", "pipe"],
   });
-  const buf = { out: "", err: "", exit: undefined, signal: undefined, closed: false, spawnErr: null };
+  const buf = { out: "", err: "", exit: undefined, signal: undefined, closed: false, spawnErr: null, t0: Date.now() };
   child.stdout.on("data", d => { buf.out += d; });
   child.stderr.on("data", d => { buf.err += d; });
   // 'exit' fires when the process terminates, but its stdio pipes may still hold unread data —
@@ -999,7 +999,7 @@ function ltBoot(env, dir, nodeArgs = []) {
   // then asserts on buf.err/buf.out must wait for `closed`, not `exit != null`, or it can read
   // an empty buffer.
   child.on("exit", (code, signal) => { buf.exit = code; buf.signal = signal; });
-  child.on("close", () => { buf.closed = true; });
+  child.on("close", () => { buf.closed = true; buf.closeMs = Date.now() - buf.t0; });
   // Without a listener, a spawn 'error' is re-thrown as an uncaught exception and takes down the
   // whole runner instead of failing one test.
   child.on("error", e => { buf.spawnErr = e; });
@@ -1019,11 +1019,29 @@ function _ltRmRetry(dir) {
 // Every ltBoot assertion failure should be self-diagnosing. The historical failure text was
 // `expected a local-tools FATAL, got: ` — an empty string, which says nothing about whether the
 // child never wrote, wrote to the other stream, died on a signal, or was never spawned.
+// stdout is sampled HEAD+TAIL, not tail-only. The decisive string for "it booted instead of
+// refusing" is "Local tools: ON", and it lives in the boot banner — a tail-only sample answered
+// the wrong question for exactly the tests this exists to diagnose.
+//
+// The head is sized to the BANNER, not picked round: measured on this tree, the banner runs 1118B
+// with "Local tools: ON" at byte 581, so 900 clears it with ~5 banner lines of margin. That sizing
+// is what makes it robust — the banner is emitted first and is bounded, so however much request
+// noise follows, byte 581 stays in the head. A head of 120 does NOT reach it (verified: the string
+// landed in the elided middle), which is why this is not the obvious small window.
+// stderr stays head-only: a fatal is the first thing it writes.
+function ltHeadTail(s, head = 900, tail = 160) {
+  return s.length <= head + tail ? s : `${s.slice(0, head)}…[${s.length - head - tail}B]…${s.slice(-tail)}`;
+}
 function ltDiag(buf) {
-  return `exit=${buf.exit} signal=${buf.signal} closed=${buf.closed}` +
+  // closeMs disambiguates "died before reaching the gate" from "ran, then gated" — an exit=1
+  // with empty stderr is equally consistent with both, and they have unrelated root causes.
+  // node= is here because a Node-version-specific stderr warning (22's SQLite ExperimentalWarning)
+  // once masqueraded as "server did not start" for ~23 of 50 runs on a Linux box.
+  const ms = buf.closeMs !== undefined ? `${buf.closeMs}ms` : (buf.t0 ? `${Date.now() - buf.t0}ms(still open)` : "?");
+  return `exit=${buf.exit} signal=${buf.signal} closed=${buf.closed} closeMs=${ms} node=${process.version}` +
          (buf.spawnErr ? ` spawnErr=${buf.spawnErr.code || buf.spawnErr.message}` : "") +
-         ` | stderr(${buf.err.length}B)=${JSON.stringify(buf.err.slice(0, 200))}` +
-         ` | stdout(${buf.out.length}B)=${JSON.stringify(buf.out.slice(-200))}`;
+         ` | stderr(${buf.err.length}B)=${JSON.stringify(buf.err.slice(0, 240))}` +
+         ` | stdout(${buf.out.length}B)=${JSON.stringify(ltHeadTail(buf.out))}`;
 }
 async function ltWait(cond, ms = 9000) {
   const start = Date.now();
@@ -1106,10 +1124,12 @@ test("integration: safe single-user config BOOTS past the gate and announces loc
   const port = await ltFreePort();
   const { child, buf } = ltBoot({ OCP_LOCAL_TOOLS: "1", CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port) }, dir); // loopback + none
   try {
-    // Same race as #199, one line over: "Local tools: ON" is written 14 console.log calls AFTER
-    // "listening on", so gating on the boot marker and then asserting the announcement can read a
-    // buffer holding only the first chunk. Wait for the line actually under assertion. Measured by
-    // review at 9/200 before this change and 0/200 after — it was the suite's top flake.
+    // Same race as #199, one line over: "Local tools: ON" (server.mjs:3640) is written 12
+    // console.log calls after "listening on" (:3627) — 10 of them in this env, since the
+    // SYSTEM_PROMPT and MCP_CONFIG lines are conditional and unset here. Gating on the boot
+    // marker and then asserting the announcement can therefore read a buffer holding only the
+    // first chunk. Wait for the line actually under assertion. Measured by review at 8/200
+    // before this change and 0/200 after — it was the suite's top flake.
     assert.ok(await ltWait(() => buf.out.includes("Local tools: ON") || buf.closed || buf.spawnErr),
       `startup must announce local tools when active — ${ltDiag(buf)}`);
     assert.ok(buf.out.includes("Local tools: ON"),


### PR DESCRIPTION
Closes #199 and #209. **#203 stays open** — see the bottom.

Test-only. No production file differs from `main`.

## What this fixes, measured with a control arm

Full suite × 4 concurrent × 50 rounds = **200 runs per arm**, run by the reviewer against both `main` and this branch — so a post-change zero means something:

| category | `main` (control) | this branch |
|---|---|---|
| **runs with no failures** | **42 / 200** | **200 / 200** |
| #199 TUI inert-warning race | 7 | **0** |
| `:1092` announce `Local tools` race | 8 | **0** |
| EADDRINUSE on fixed ports | 246 | **0** |
| ENOTEMPTY teardown | 1 | **0** |
| #203 boot-gate | 0 | 0 |

Four of five categories reproduce on `main` and are eliminated. #203 reproduces on neither, on macOS.

## How these were found — the part worth keeping

`test-features.mjs:39-58` makes `test()` **fire-and-forget** for async bodies, so ~15 `ltBoot` integration tests run **concurrently** inside one suite run. That is the condition these races need.

My first attempt at this PR ran the scenario **in isolation** 150 times and concluded the flakes were unreproducible. That removed the very thing that causes them. The working method is **full suite × multiple concurrent processes**, and it is now written up in `AGENTS.md` (#207) so the next person doesn't repeat the mistake.

## The changes

1. **Wait for the line under assertion, not a proxy.** #199's test waited for `listening on` and then asserted `ignored in TUI mode` — a *different* stream (`console.log` → stdout vs `console.warn` → stderr, 14 lines apart), so nothing ordered them. `:1092` had the identical shape one line over, and my first pass fixed the former and left the latter as the suite's top flake.
2. **Wait for `close`, not `exit`,** where a test reads `buf.err` after termination. **Honest scope:** measured **inert on macOS** — 600/600 gate children had stderr fully drained at `exit`. It is kept because the ordering is simply correct, not because it was shown to fix anything here.
3. **Every fixed port removed.** 11 `ltBoot` sites and their `ltPost` calls use `ltFreePort()`. This was the single biggest category: **246 EADDRINUSE on the control arm**, driven by cross-process contention — and the old ports (39321–39364) sit *inside* Linux's default ephemeral range, so CI was more exposed than a Mac.
4. **`_ltRmRetry`** at all **11** teardown sites — orphaned fake-`claude` grandchildren can still write into the temp dir while `rmSync` walks it. It swallows failure by design: it runs in a `finally`, where a throw would **replace the real assertion error** and make a flake look like a regression. `LT_DEBUG=1` surfaces it when you want it.
5. **`ltDiag(buf)`** in the **two target tests** (**8** call sites) — exit / signal / closed / spawnErr plus both streams with byte counts. Not every assertion in the file; the rest still use their original messages.

## The instrumentation, demonstrated

| mutation | message now produced |
|---|---|
| neuter the non-loopback branch of `localToolsSafetyError` | `[non-loopback] process never closed — exit=undefined signal=undefined closed=false \| stderr(92B)="security: SecKeychainSearchCopyNext…" \| stdout(1147B)=…` |
| rename the TUI inert warning | `no inert-flag warning appeared — … stderr(295B)="⚠ OCP_LOCAL_TOOLS=1 is SILENCED-FOR-MUTATION …"` |

Before this, a real regression and a #199 false-red produced **byte-identical** text. That indistinguishability was the actual cost of these flakes, and it's what the diagnostics remove.

## Corrections to earlier revisions of this PR

Both stated as fact in an earlier body, both wrong:

- ~~"`ltDiag(buf)` is used in **every** assertion message"~~ → **8 call sites, in the two target tests only.**
- ~~"`39330+i` was **shared** across a 3-iteration loop"~~ → **it wasn't**; `i` is 0/1/2 so the ports differ. The real fixed-port risk is **cross-process**, which the control arm's 246 EADDRINUSE confirms.

## #203 — staying open

Not fixed here and not claimed to be. It has **never reproduced on macOS** (0/200 on both arms, plus 800 earlier runs), the `exit`→`close` mechanism is measured inert there, and all four sightings are on **Linux CI**.

~~I attempted the decisive Linux run on the Oracle VM and it failed *as an experiment*: Node 22's SQLite `ExperimentalWarning` broke ~23/50 runs with spurious `server did not start`, and CI is Node 24.~~

> **Correction (post-merge, from review of #211).** The Node 22 attribution above is WRONG. The boot predicate is `buf.out.includes("listening on") || buf.exit != null` — stdout only; `buf.err` appears in the assertion *message*, never in the condition, so a stderr warning cannot fail it. The suite passes 462/0 on Node 22.23.1 with the warning present. The Oracle failures were the **pre-#204 fixed-port noise floor** — the control arm above measured 246 EADDRINUSE and 42/200 clean on unmodified `main`. I read presence in an error message as causation. Node 22 is a usable arm. Full retraction on #203. Recorded on #203 as contaminated, with the next step written down — **Linux + Node 24**, most cheaply a `workflow_dispatch` loop.

Iron Rule 10: needs an independent reviewer; author does not self-approve.

