### PR TITLE
ci: fix release.yml's no-CHANGELOG path, which would have failed the release job (#202)

### DIFF
--- a/.github/workflows/alignment.yml
+++ b/.github/workflows/alignment.yml
@@ -9,14 +9,6 @@ on:
       - 'lib/**'
       - 'ocp'
       - 'ocp-connect'
-      # models.json is NOT inert data: it drives MODEL_MAP and VALID_MODELS, the default
-      # request model, and — since ADR 0009 — the global MAX_PROMPT_CHARS truncation budget.
-      # A models.json-only PR can therefore change server.mjs's runtime behavior, and before
-      # this the guardrail simply did not run on one (#198). models.schema.json is included
-      # for the same reason one level up: loosening the schema is what would let a bad
-      # models.json through.
-      - 'models.json'
-      - 'models.schema.json'
       - '.github/workflows/alignment.yml'
 
 jobs:

--- a/.github/workflows/alignment.yml
+++ b/.github/workflows/alignment.yml
@@ -9,6 +9,14 @@ on:
       - 'lib/**'
       - 'ocp'
       - 'ocp-connect'
+      # models.json is NOT inert data: it drives MODEL_MAP and VALID_MODELS, the default
+      # request model, and — since ADR 0009 — the global MAX_PROMPT_CHARS truncation budget.
+      # A models.json-only PR can therefore change server.mjs's runtime behavior, and before
+      # this the guardrail simply did not run on one (#198). models.schema.json is included
+      # for the same reason one level up: loosening the schema is what would let a bad
+      # models.json through.
+      - 'models.json'
+      - 'models.schema.json'
       - '.github/workflows/alignment.yml'
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,24 +21,31 @@ jobs:
       - name: Extract CHANGELOG section
         id: notes
         run: |
+          set -euo pipefail
           VERSION="${{ steps.ver.outputs.version }}"
+          NOTES=/tmp/release-notes.md
           # Extract section for this version from CHANGELOG.md
           # Pattern: "## v${VERSION}" through the next "## " or EOF
           if [ ! -f CHANGELOG.md ]; then
             echo "No CHANGELOG.md found; using minimal release notes"
-            echo "notes=Release v${VERSION}" >> $GITHUB_OUTPUT
+            # MUST write the file, not just an output: the create step consumes a FILE, so an
+            # early exit here used to leave --notes-file pointing at a path that never existed,
+            # turning "degrade to minimal notes" into a failed release job (#202).
+            echo "Release v${VERSION}" > "$NOTES"
+            echo "notes_file=$NOTES" >> $GITHUB_OUTPUT
             exit 0
           fi
           awk -v ver="v${VERSION}" '
             $0 ~ "^## " ver { found=1; print; next }
             found && /^## v/ { exit }
             found { print }
-          ' CHANGELOG.md > /tmp/release-notes.md
-          if [ ! -s /tmp/release-notes.md ]; then
+          ' CHANGELOG.md > "$NOTES"
+          if [ ! -s "$NOTES" ]; then
             echo "No matching section in CHANGELOG for v${VERSION}; using minimal notes"
-            echo "Release v${VERSION}" > /tmp/release-notes.md
+            echo "Release v${VERSION}" > "$NOTES"
           fi
-          echo "notes_file=/tmp/release-notes.md" >> $GITHUB_OUTPUT
+          echo "--- release notes (${VERSION}) ---"; cat "$NOTES"
+          echo "notes_file=$NOTES" >> $GITHUB_OUTPUT
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -49,5 +56,5 @@ jobs:
           fi
           gh release create "v${{ steps.ver.outputs.version }}" \
             --title "v${{ steps.ver.outputs.version }}" \
-            --notes-file /tmp/release-notes.md \
+            --notes-file "${{ steps.notes.outputs.notes_file }}" \
             --latest


### PR DESCRIPTION
Closes #202. **Scope reduced after review** — the `alignment.yml` half of this PR was reverted; see below.

## The bug

`release.yml`'s no-CHANGELOG fallback wrote an output named `notes` and **exited without creating `/tmp/release-notes.md`**, while the create step hard-codes `--notes-file /tmp/release-notes.md`. The one path that exists to "degrade to minimal notes" instead produced a **failed release job**.

Verified by extracting the step's actual script out of the YAML and **running it**, not by reading it:

| | CHANGELOG absent (the #202 path) |
|---|---|
| **pre-fix** | exit 0, `GITHUB_OUTPUT="notes=Release v3.25.0"`, `/tmp/release-notes.md` **missing** → `gh release create --notes-file` would fail |
| **post-fix** | exit 0, `notes_file` set, file present (`Release v3.25.0`) |

With a CHANGELOG present, behavior is unchanged (first line `## v3.25.0 — 2026-07-27`).

## The fix

Write the file in that branch, **and** remove the hard-coded-path coupling: both branches now set `notes_file`, and the create step consumes `steps.notes.outputs.notes_file`. That output already existed and was never read — the two only agreed by accident.

Also added `set -euo pipefail` and an echo of the resolved notes before creating the release, so a wrong-looking body is visible in the job log rather than only on the published release.

**On `set -euo pipefail` being the risky part** — the reviewer checked this specifically and found no regression: the step contains **no pipeline at all** (the `awk` is a redirect, not a pipe), so `pipefail` is inert; `-e` was already in force via GitHub's default `bash -e {0}`; and `-u` only touches `VERSION`/`NOTES` (locally assigned) and `GITHUB_OUTPUT` (always set by the runner) — with `GITHUB_OUTPUT` unset, old and new both exit 1 anyway.

## Reverted: the alignment.yml change (#198)

I originally added `models.json` to `alignment.yml`'s `paths:` filter. **The reviewer proved that was theatre, and I verified it myself before reverting:**

- the alignment job **body references `models.json` zero times** — only the filter I added mentioned it
- **`test.yml` has no paths filter**, so it already runs on every PR
- on a deliberately corrupted `models.json` (`contextWindow: 1000000`, a typo'd `openclawName`), `npm test` catches it — **455 passed, 2 failed** — while the blacklist job passes clean

So the real guard already existed and always ran. Adding the path would only have made a job execute that inspects nothing about `models.json`, then report a green **Alignment Guardrail** — implying a check that never happened. Strictly worse than not running.

**#198's premise was also wrong**, and that's on me: the blacklist greps `server.mjs` for known hallucinated tokens. A models.json-only PR cannot introduce a token into `server.mjs`, so `CLAUDE.md` hard-requirement #2 is **inapplicable** on such a PR, not vacuous. I read "the guardrail didn't run" as a coverage gap without checking what the guardrail actually inspects. Closing #198 with that correction.

Iron Rule 10: needs re-review of the reduced scope.