### PR TITLE
fix(doctor): restart the service when the tree is at latest but the service is stale (no git pull)

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Setup, the ~6-second latency floor, real-SSE streaming (`OCP_TUI_STREAM`), the w
 
 ## Upgrading
 
-Run **`ocp update`** — it smart-picks the path. A **patch bump** (e.g. `v3.21.0 → v3.21.1`) takes the light path (git pull + npm install + restart); a **cross-minor** jump (e.g. `v3.18 → v3.22`) takes the full path (pre-flight, snapshot, `setup.mjs` with plist env-merge, restart, post-flight `/health` + `/v1/models` verification). `ocp update --check` shows available updates without applying.
+Run **`ocp update`** — it smart-picks the path. If the tree is already at the latest release but the **running service** is stale (e.g. a previous update was interrupted before it restarted), it takes a **restart-only** path: no git/npm changes, just a restart + post-flight `/health` verification. A **patch bump** (e.g. `v3.21.0 → v3.21.1`) takes the light path (git pull + npm install + restart); a **cross-minor** jump (e.g. `v3.18 → v3.22`) takes the full path (pre-flight, snapshot, `setup.mjs` with plist env-merge, restart, post-flight `/health` + `/v1/models` verification). `ocp update --check` shows available updates without applying.
 
 Manual flags, rollback (`ocp update --rollback`), snapshots, and the OpenClaw model auto-sync (v3.11.0+): **[docs/upgrading.md](docs/upgrading.md)**.
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -13,6 +13,11 @@ The simplest path: ask your AI.
 
 What `ocp update` does:
 
+- **Tree already at latest, but the running service is stale** (e.g. a previous `ocp update`
+  was interrupted after checking out the new tag but before restarting — issue #214):
+  restart-only path. No git or npm operations — the tree doesn't need touching, only the
+  service does. Just `cmd_restart` + a post-flight `/health` verification against the
+  version already on disk.
 - **Patch bump** (e.g. `v3.21.0 → v3.21.1`):
   light path (git pull + npm install + restart).
 - **Cross-minor** (e.g. `v3.18 → v3.22`):

--- a/ocp
+++ b/ocp
@@ -777,7 +777,19 @@ cmd_update() {
 
   # Doctor-driven path selection
   local doctor_json kind
-  doctor_json=$(node "$script_dir/scripts/doctor.mjs" --json 2>/dev/null)
+  # `|| true` is load-bearing, not decorative: doctor.mjs:310 does
+  # `process.exit(fail_count === 0 ? 0 : 1)` — ANY fail check (fix_service, fix_oauth,
+  # fresh_install) makes it exit 1. `ocp:7` runs under `set -euo pipefail`, so a bare
+  # `var=$(cmd)` assignment where cmd exits non-zero trips `set -e` immediately, killing
+  # `cmd_update` with ZERO output — exactly on the hosts that need it most (proxy down, token
+  # expired, pre-v3.4.0). `|| true` keeps the captured stdout (command substitution captures
+  # it regardless of exit code) while telling `set -e` this assignment's own exit status is
+  # fine to ignore. Splitting this out of the old single-pipeline form also incidentally fixes
+  # a pre-existing bug: piping node directly into python inside one `... || echo "unknown"`
+  # meant `pipefail` + the `||` fallback could BOTH fire on a doctor exit 1, concatenating
+  # python's real output with the literal string "unknown" (`kind` became a two-line
+  # "fix_service\nunknown", matching no case pattern and falling through to `*)`).
+  doctor_json=$(node "$script_dir/scripts/doctor.mjs" --json 2>/dev/null) || true
   kind=$(echo "$doctor_json" | python3 -c "import sys,json; print(json.load(sys.stdin)['next_action']['kind'])" 2>/dev/null || echo "unknown")
 
   # Issue #214 review finding: this function used to extract ONLY `kind` from the doctor JSON
@@ -888,7 +900,16 @@ _cmd_update_restart() {
   done
 
   echo "Tree is already at v$target; the running service is stale — restarting (no git changes)..."
-  cmd_restart
+  # Subshell + `|| true`, not a bare call (PR #217 review, MED-1): cmd_restart's success path
+  # ends by calling cmd_usage, and cmd_usage does `data=$(curl ... "$PROXY/usage") || { echo
+  # ...; exit 1; }` — a real `exit`, not a `return`. `exit` terminates the WHOLE shell process
+  # immediately; a bare `cmd_restart || true` at this call site would never even get a chance
+  # to run, because the process is already gone by the time `exit` would "return" here. Wrapping
+  # in `( ... )` contains that exit to the subshell — the restart itself still happens for real
+  # (all its side effects are external commands), but a slow/unreachable /usage call (e.g. right
+  # after a restart, before the proxy has warmed back up) can no longer take down post-flight
+  # verification with it, which is the one guarantee this whole path exists to provide.
+  ( cmd_restart ) || true
   echo "  Verifying restart..."
   if node "$script_dir/scripts/upgrade.mjs" --post-flight-only "v$target"; then
     return 0

--- a/ocp
+++ b/ocp
@@ -777,7 +777,7 @@ cmd_update() {
 
   # Doctor-driven path selection
   local doctor_json kind
-  # `|| true` is load-bearing, not decorative: doctor.mjs:310 does
+  # `|| true` is load-bearing, not decorative: doctor.mjs:374 does
   # `process.exit(fail_count === 0 ? 0 : 1)` — ANY fail check (fix_service, fix_oauth,
   # fresh_install) makes it exit 1. `ocp:7` runs under `set -euo pipefail`, so a bare
   # `var=$(cmd)` assignment where cmd exits non-zero trips `set -e` immediately, killing

--- a/ocp
+++ b/ocp
@@ -721,6 +721,7 @@ cmd_update_help() {
 ocp update — Smart upgrade dispatcher
 
 Runs `ocp doctor` internally to choose the right path:
+  • Tree at latest, service stale:  restart-only (no git/npm changes) + post-flight verify
   • Patch bump (same minor):     light path (git pull + npm install + restart)
   • Cross-minor (e.g. v3.10→v3.14): full path with snapshot + post-flight
   • Old version (< v3.4.0):       fresh-install (asks first; AI passes --yes)
@@ -775,13 +776,35 @@ cmd_update() {
   fi
 
   # Doctor-driven path selection
-  local kind
-  kind=$(node "$script_dir/scripts/doctor.mjs" --json 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin)['next_action']['kind'])" 2>/dev/null || echo "unknown")
+  local doctor_json kind
+  doctor_json=$(node "$script_dir/scripts/doctor.mjs" --json 2>/dev/null)
+  kind=$(echo "$doctor_json" | python3 -c "import sys,json; print(json.load(sys.stdin)['next_action']['kind'])" 2>/dev/null || echo "unknown")
+
+  # Issue #214 review finding: this function used to extract ONLY `kind` from the doctor JSON
+  # and threw the rest away (stdout piped straight into python, stderr to /dev/null) — so
+  # doctor's WARN-level checks (e.g. "tree at X, service serving Y — restarting") never reached
+  # the person running `ocp update`, even though doctor.mjs computed the exact message #214
+  # asked for. Surface any WARN check here, generically, before dispatching on kind.
+  if [[ -n "$doctor_json" ]]; then
+    echo "$doctor_json" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for c in d.get('checks', []):
+    if c.get('level') == 'WARN':
+        print(f\"⚠ {c.get('message', '')}\")
+" 2>/dev/null
+  fi
 
   case "$kind" in
     noop)
       echo "Already at latest. Nothing to do."
       return 0
+      ;;
+    restart)
+      _cmd_update_restart "$script_dir" "$@"
       ;;
     update)
       _cmd_update_light "$script_dir"
@@ -837,6 +860,42 @@ _cmd_update_light() {
 
   echo "  Restarting proxy..."
   cmd_restart > /dev/null 2>&1
+}
+
+# Issue #214: tree is already at latest, but the RUNNING SERVICE is stale — a previous update
+# half-completed (tree checked out to the new tag, then a later phase failed before the
+# restart ran). This path does NOT touch git. `_cmd_update_light`'s `git pull origin main
+# --ff-only` is NOT safe to reuse here: doctor's "tree == latest" is a VERSION-STRING
+# comparison against origin/main's package.json, not a commit comparison, so it can hold true
+# while origin/main HEAD has merged-but-unreleased commits ahead of the release tag. Pulling
+# in that state would fast-forward a production host off its release tag onto unreleased main
+# (PR #217 review, HIGH-2). This just restarts the already-correct tree and verifies it landed.
+_cmd_update_restart() {
+  local script_dir="$1"; shift
+  local target
+  target=$(python3 -c "import json; print(json.load(open('$script_dir/package.json'))['version'])" 2>/dev/null || echo "?")
+
+  # Honor --dry-run (PR #217 review, HIGH-1: the "update" reuse this replaced silently dropped
+  # every flag here, so `ocp update --dry-run` on a stale host skipped straight to a real
+  # restart despite the documented "preview the plan, don't mutate" contract).
+  local arg
+  for arg in "$@"; do
+    if [[ "$arg" == "--dry-run" ]]; then
+      echo "[dry-run] would restart the proxy and verify /health reports v$target."
+      echo "[dry-run] no git/npm operations — the tree is already at v$target."
+      return 0
+    fi
+  done
+
+  echo "Tree is already at v$target; the running service is stale — restarting (no git changes)..."
+  cmd_restart
+  echo "  Verifying restart..."
+  if node "$script_dir/scripts/upgrade.mjs" --post-flight-only "v$target"; then
+    return 0
+  else
+    echo "  Run \`ocp doctor\` or \`curl \$PROXY/health\` to inspect further."
+    return 1
+  fi
 }
 
 cmd_doctor_help() {

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -86,6 +86,15 @@ export async function runDoctor(opts = {}) {
 
   // --- service health check (mockable) ---
   let healthOk = true, oauthOk = true;
+  // Issue #214: the RUNNING SERVICE's version, as reported by /health, kept distinct from
+  // currentVersion (the tree's package.json, above). A partially-failed `ocp update` can
+  // `git checkout` the new tag and then fail before the restart phase runs, leaving the tree
+  // looking fully updated while the service still answers with the old code. null means
+  // "unknown" (skipNetwork, /health unreachable, or a body with no usable version field) —
+  // the noop decision below must degrade gracefully on unknown, same philosophy as
+  // upgrade.mjs's postFlightOk ("an empty/unknown target degrades ... rather than blocking an
+  // otherwise-good upgrade").
+  let serviceVersion = null;
   if (!opts.skipNetwork) {
     let health;
     if (opts.mockHealth !== undefined) {
@@ -114,6 +123,12 @@ export async function runDoctor(opts = {}) {
       } else {
         push("oauth_ok", "PASS", "OAuth token valid");
       }
+      // /health reports a bare semver (server.mjs `version: VERSION`, no leading "v"); only
+      // trust it when it actually parses as a version, so a missing/garbled field degrades to
+      // "unknown" (serviceVersion stays null) instead of being mistaken for a real mismatch.
+      if (typeof health.body.version === "string" && semverParts(health.body.version)) {
+        serviceVersion = health.body.version.startsWith("v") ? health.body.version : `v${health.body.version}`;
+      }
     }
   }
 
@@ -130,7 +145,25 @@ export async function runDoctor(opts = {}) {
     if (!cur) {
       kind = "fresh_install";
     } else if (semverCompare(currentVersion, latestVersion) === 0) {
-      kind = "noop";
+      // Issue #214: "tree == latest" alone is NOT "nothing to do" — the goal is the running
+      // service serving the tree's version. When serviceVersion is known (see health-check
+      // block above) and it differs from the tree, a previous update half-completed (tree
+      // checked out, restart phase never ran). Reuse kind="update" rather than invent a new
+      // enum value: it is already the exact remediation needed here (bash `cmd_update`'s
+      // "update" branch runs `_cmd_update_light`, which git-pulls — a no-op, tree is already
+      // current — and unconditionally restarts the service; `scripts/upgrade.mjs`'s "update"
+      // branch already no-ops sensibly too). A new kind would require every next_action.kind
+      // consumer (ocp's cmd_update case statement, upgrade.mjs's runUpgrade, any AI agent
+      // reading the JSON contract) to learn a value that maps to the same action anyway.
+      // Push a WARN (not FAIL) so ready_to_upgrade stays true — runUpgrade()'s pre-flight
+      // guard only tolerates ready_to_upgrade=false for kind="fresh_install".
+      if (serviceVersion && semverCompare(serviceVersion, currentVersion) !== 0) {
+        kind = "update";
+        push("service_version_matches_tree", "WARN",
+          `tree at ${currentVersion.replace(/^v/, "")}, service serving ${serviceVersion.replace(/^v/, "")} — restarting`);
+      } else {
+        kind = "noop";
+      }
     } else if (lat && cur.major === lat.major && cur.minor === lat.minor) {
       kind = "update";
     } else {

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -91,9 +91,12 @@ export async function runDoctor(opts = {}) {
   // `git checkout` the new tag and then fail before the restart phase runs, leaving the tree
   // looking fully updated while the service still answers with the old code. null means
   // "unknown" (skipNetwork, /health unreachable, or a body with no usable version field) —
-  // the noop decision below must degrade gracefully on unknown, same philosophy as
-  // upgrade.mjs's postFlightOk ("an empty/unknown target degrades ... rather than blocking an
-  // otherwise-good upgrade").
+  // the decision below must degrade gracefully on unknown, same philosophy as upgrade.mjs's
+  // postFlightOk ("an empty/unknown target degrades ... rather than blocking an otherwise-good
+  // upgrade"). Stored as the bare string /health returns (no "v" prefix): semverParts()/
+  // semverCompare() strip a leading "v" themselves, so prefixing here would be purely
+  // cosmetic — an earlier version of this fix added one and it was dead weight (PR #217
+  // review: survived mutation because nothing downstream reads the prefix).
   let serviceVersion = null;
   if (!opts.skipNetwork) {
     let health;
@@ -127,12 +130,12 @@ export async function runDoctor(opts = {}) {
       // trust it when it actually parses as a version, so a missing/garbled field degrades to
       // "unknown" (serviceVersion stays null) instead of being mistaken for a real mismatch.
       if (typeof health.body.version === "string" && semverParts(health.body.version)) {
-        serviceVersion = health.body.version.startsWith("v") ? health.body.version : `v${health.body.version}`;
+        serviceVersion = health.body.version;
       }
     }
   }
 
-  // --- determine next_action.kind (priority: fresh_install > fix_service > fix_oauth > noop > update > upgrade) ---
+  // --- determine next_action.kind (priority: fresh_install > fix_service > fix_oauth > noop/restart > update > upgrade) ---
   let kind;
   if (!fromSupported) {
     kind = "fresh_install";
@@ -147,20 +150,48 @@ export async function runDoctor(opts = {}) {
     } else if (semverCompare(currentVersion, latestVersion) === 0) {
       // Issue #214: "tree == latest" alone is NOT "nothing to do" — the goal is the running
       // service serving the tree's version. When serviceVersion is known (see health-check
-      // block above) and it differs from the tree, a previous update half-completed (tree
-      // checked out, restart phase never ran). Reuse kind="update" rather than invent a new
-      // enum value: it is already the exact remediation needed here (bash `cmd_update`'s
-      // "update" branch runs `_cmd_update_light`, which git-pulls — a no-op, tree is already
-      // current — and unconditionally restarts the service; `scripts/upgrade.mjs`'s "update"
-      // branch already no-ops sensibly too). A new kind would require every next_action.kind
-      // consumer (ocp's cmd_update case statement, upgrade.mjs's runUpgrade, any AI agent
-      // reading the JSON contract) to learn a value that maps to the same action anyway.
-      // Push a WARN (not FAIL) so ready_to_upgrade stays true — runUpgrade()'s pre-flight
-      // guard only tolerates ready_to_upgrade=false for kind="fresh_install".
-      if (serviceVersion && semverCompare(serviceVersion, currentVersion) !== 0) {
-        kind = "update";
-        push("service_version_matches_tree", "WARN",
-          `tree at ${currentVersion.replace(/^v/, "")}, service serving ${serviceVersion.replace(/^v/, "")} — restarting`);
+      // block above) and OLDER than the tree, a previous update half-completed (tree checked
+      // out, restart phase never ran): the service needs a restart, with NO git operations
+      // (the tree is already correct).
+      //
+      // kind="restart" is a DISTINCT value from "update" — PR #217's first draft reused
+      // "update" and was rejected in review for two reasons, both load-bearing:
+      //   1. "update"'s bash handler (_cmd_update_light) runs `git pull origin main --ff-only`.
+      //      That is NOT a no-op in general: doctor's latestVersion comes from the VERSION
+      //      NUMBER in origin/main's package.json, not from origin/main's commit. Between
+      //      releases, main accumulates merged-but-unreleased commits while package.json stays
+      //      put, so "tree == latest" (by version string) can hold while origin/main HEAD is
+      //      genuinely ahead of the release tag. Routing that state through "update" would
+      //      silently fast-forward a production host off its release tag onto unreleased main,
+      //      then restart into it — worse than the bug this issue reports.
+      //   2. _cmd_update_light drops every CLI flag ("$@" is never forwarded to it), so
+      //      `ocp update --dry-run` on a stale host would have skipped straight to a real
+      //      mutating restart despite the documented "preview the plan, don't mutate" contract.
+      // "restart" has its own bash handler (_cmd_update_restart) that never touches git and
+      // honors --dry-run.
+      //
+      // When serviceVersion is NEWER than the tree (e.g. the tree was rolled back, or someone
+      // is running a newer/test build), do NOT restart: that would silently DOWNGRADE a
+      // running service to match an older tree, which is exactly the class of surprise
+      // auto-mutation this issue is about. Surface it (WARN) but leave kind="noop" — the same
+      // "nothing forced" default as before this fix.
+      //
+      // Either way, push a WARN (not FAIL) so ready_to_upgrade stays true when kind="restart" —
+      // runUpgrade()'s pre-flight guard only tolerates ready_to_upgrade=false for
+      // kind="fresh_install".
+      if (serviceVersion) {
+        const serviceCmp = semverCompare(serviceVersion, currentVersion);
+        if (serviceCmp < 0) {
+          kind = "restart";
+          push("service_version_matches_tree", "WARN",
+            `tree at ${currentVersion.replace(/^v/, "")}, service serving ${serviceVersion.replace(/^v/, "")} — restarting`);
+        } else if (serviceCmp > 0) {
+          kind = "noop";
+          push("service_version_matches_tree", "WARN",
+            `tree at ${currentVersion.replace(/^v/, "")}, service serving ${serviceVersion.replace(/^v/, "")} (NEWER than tree) — not auto-restarting`);
+        } else {
+          kind = "noop";
+        }
       } else {
         kind = "noop";
       }

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -395,6 +395,16 @@ if (_isMain()) {
   const postFlightOnlyIdx = args.indexOf("--post-flight-only");
   if (postFlightOnlyIdx !== -1) {
     const postFlightTarget = args[postFlightOnlyIdx + 1];
+    // Fail CLOSED on a missing/malformed target (PR #217 review, LOW): postFlightOk() treats
+    // an empty/unknown target as "degrade to the auth-only check" by design (so a genuinely
+    // unknown release target never blocks a good upgrade elsewhere) — but that same degrade
+    // means an accidentally-omitted target here would report success against ANY version.
+    // `ocp`'s bash caller always passes "v$target" explicitly, so this only guards a
+    // hand-invoked or future misuse of the public flag, not anything reachable today.
+    if (!postFlightTarget || postFlightTarget.startsWith("--")) {
+      console.error(`✗ --post-flight-only requires a target version argument, e.g. --post-flight-only v3.26.0`);
+      process.exit(1);
+    }
     const result = await runPostFlightCheck(postFlightTarget);
     if (result.ok) {
       console.log(`✓ service now serving v${result.target}`);

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -3,7 +3,9 @@
  * scripts/upgrade.mjs — OCP unified upgrade dispatcher.
  *
  * Paths:
- *   noop          current == latest, exit 0
+ *   noop          current == latest AND service already serving it, exit 0
+ *   restart       current == latest but the RUNNING SERVICE is stale (issue #214); no git/npm
+ *                 changes — cmd_restart + post-flight only; delegated to bash cmd_update
  *   light         same major.minor, patch bump only (existing fast path; delegated to bash)
  *   full          cross-minor (snapshot + setup.mjs + post-flight)
  *   fresh_install from-version < v3.4.0 (--yes required for non-interactive)
@@ -29,6 +31,39 @@ export function postFlightOk(body, target) {
   if (body?.auth?.ok !== true) return false;
   const want = String(target || "").replace(/^v/, "");
   return !want || body?.version === want;
+}
+
+// Issue #214 remediation (kind="restart"): bash's cmd_restart() already performs the actual
+// restart — it has richer fallback logic than anything worth duplicating here (launchd →
+// systemd → manual nohup, see `ocp`). What it lacked was verification: its failure path only
+// echoes and still returns 0, so a failed restart reported success while the service kept
+// serving the old version (review finding MED-1 on PR #217 — this was the "reports success
+// while serving old code" complaint from #214, only partly fixed by detection alone). This
+// polls /health and reuses postFlightOk() — the SAME acceptance predicate runFullUpgrade's
+// post-flight phase uses — rather than a second hand-rolled check. Exported so `ocp update`'s
+// bash "restart" path can invoke it via the CLI entrypoint below (`--post-flight-only`).
+// opts.mockProbe (test hook, mirrors doctor.mjs's opts.mockHealth / runFullUpgrade's
+// opts.mockExec convention): a zero-arg function called instead of the real curl, returning a
+// /health body object or throwing (to simulate unreachable) — makes the retry loop testable
+// without a live server or real sleeps.
+export async function runPostFlightCheck(target, opts = {}) {
+  const port = process.env.CLAUDE_PROXY_PORT || String(DEFAULT_PORT);
+  const attempts = opts.attempts ?? 10;
+  const intervalMs = opts.intervalMs ?? 1000;
+  const probe = opts.mockProbe || (() => {
+    const out = execSync(`curl -sf --max-time 2 http://127.0.0.1:${port}/health`).toString();
+    return JSON.parse(out);
+  });
+  let ok = false, lastSeen = null;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const body = probe();
+      lastSeen = body.version;
+      if (postFlightOk(body, target)) { ok = true; break; }
+    } catch { /* retry */ }
+    if (i < attempts - 1) await new Promise(r => setTimeout(r, intervalMs));
+  }
+  return { ok, lastSeen, target: String(target || "").replace(/^v/, "") };
 }
 
 export async function runUpgrade(opts = {}) {
@@ -68,6 +103,8 @@ export async function runUpgrade(opts = {}) {
       plan.push(`[plan] phase 5: post-flight /health + /v1/models`);
     } else if (kind === "update") {
       plan.push(`[plan] light path: git pull + npm install + restart`);
+    } else if (kind === "restart") {
+      plan.push(`[plan] restart-only path: NO git/npm changes (tree already at ${doctor.current_version}) — cmd_restart + post-flight verify`);
     } else if (kind === "fresh_install") {
       plan.push(`[plan] fresh-install ai_executable[]:`);
       for (const cmd of doctor.next_action.ai_executable) plan.push(`  - ${cmd}`);
@@ -78,6 +115,15 @@ export async function runUpgrade(opts = {}) {
   // --- non-dry-run paths ---
   if (kind === "update") {
     return { path: "update", executed: true, changed: true, plan: [...plan, "[light] delegated to bash cmd_update existing logic"] };
+  }
+
+  if (kind === "restart") {
+    // Placeholder for parity with "update" above: the real work (cmd_restart + post-flight)
+    // happens in bash's _cmd_update_restart, which `ocp`'s cmd_update case statement calls
+    // directly — this function is only reached here if something calls runUpgrade()
+    // programmatically (bypassing the bash CLI) with a mockDoctor/live doctor reporting
+    // kind="restart".
+    return { path: "restart", executed: true, changed: true, plan: [...plan, "[restart] delegated to bash cmd_update existing logic (cmd_restart + post-flight, no git)"] };
   }
 
   if (kind === "upgrade") {
@@ -341,6 +387,25 @@ if (_isMain()) {
     const cand = args[rb + 1];
     if (cand && !cand.startsWith("--")) snapshotPath = cand;
   }
+
+  // Issue #214's "restart" path: bash's _cmd_update_restart() calls `cmd_restart` itself
+  // (richer fallback logic than belongs here) and then shells out to THIS one-shot mode to
+  // verify the restart actually took, reusing postFlightOk() instead of a second predicate.
+  // Distinct from the runUpgrade() flow below — no doctor call, no plan, just poll + exit code.
+  const postFlightOnlyIdx = args.indexOf("--post-flight-only");
+  if (postFlightOnlyIdx !== -1) {
+    const postFlightTarget = args[postFlightOnlyIdx + 1];
+    const result = await runPostFlightCheck(postFlightTarget);
+    if (result.ok) {
+      console.log(`✓ service now serving v${result.target}`);
+      process.exit(0);
+    } else {
+      console.error(`✗ service did not reach v${result.target} within the post-flight budget`
+        + (result.lastSeen ? ` (last saw version=${result.lastSeen} — a stale process may still hold the port; check \`ss -ltnp\` / \`lsof -i\`)` : " (unreachable)"));
+      process.exit(1);
+    }
+  }
+
   try {
     const result = await runUpgrade({ dryRun, yes, rollback, list, gc, snapshotPath, target });
     if (result.plan) for (const line of result.plan) console.log(line);

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -838,6 +838,83 @@ test("doctor falls back to currentVersion when origin/main unreachable (no stale
   assert.equal(result.next_action.kind, "noop");
 });
 
+// ── Issue #214: doctor's noop must reflect the RUNNING SERVICE's version, not just the tree ──
+// Root cause: a partially-failed `ocp update` can `git checkout` the new tag and then fail
+// before the restart phase runs. The tree now looks fully updated, but the service (per
+// /health) still answers with the OLD version. Before this fix, the next `ocp update` run
+// compared tree==latest, found them equal, and reported kind="noop" — silently leaving the
+// stale service running. These five tests pin the cases enumerated in the issue. The fix
+// reuses kind="update" (rather than inventing a new enum value) for the "tree==latest but
+// service stale" case: bash `cmd_update`'s "update" branch already runs `_cmd_update_light`,
+// which git-pulls (a no-op — the tree is already current) and unconditionally restarts the
+// service, and `scripts/upgrade.mjs`'s "update" branch already no-ops sensibly too — so every
+// existing next_action.kind consumer already behaves correctly with no further changes.
+console.log("\nDoctor next_action.kind reflects running-service version (#214):");
+
+test("#214: tree==latest, service reports the same version → genuinely noop", async () => {
+  const result = await runDoctor({
+    skipNetwork: false,
+    mockVersion: "v3.26.0",
+    mockLatest: "v3.26.0",
+    mockHealth: { status: 200, body: { version: "3.26.0", auth: { ok: true } } }
+  });
+  assert.equal(result.next_action.kind, "noop");
+  assert.equal(result.ready_to_upgrade, true);
+  assert.ok(!result.checks.some(c => c.id === "service_version_matches_tree"),
+    "no stale-service warning expected when versions match");
+});
+
+test("#214: tree==latest, service reports an OLDER version → NOT noop, restarts via update kind", async () => {
+  const result = await runDoctor({
+    skipNetwork: false,
+    mockVersion: "v3.26.0",
+    mockLatest: "v3.26.0",
+    mockHealth: { status: 200, body: { version: "3.25.0", auth: { ok: true } } }
+  });
+  assert.equal(result.next_action.kind, "update");
+  // WARN, not FAIL: ready_to_upgrade must stay true, or runUpgrade()'s pre-flight guard
+  // (which only tolerates ready_to_upgrade=false for kind="fresh_install") would throw
+  // instead of letting the restart proceed.
+  assert.equal(result.ready_to_upgrade, true);
+  const warning = result.checks.find(c => c.id === "service_version_matches_tree");
+  assert.ok(warning, "expected a service_version_matches_tree check");
+  assert.equal(warning.level, "WARN");
+  assert.equal(warning.message, "tree at 3.26.0, service serving 3.25.0 — restarting");
+});
+
+test("#214: tree==latest, /health unreachable → NOT noop (still fix_service)", async () => {
+  const result = await runDoctor({
+    skipNetwork: false,
+    mockVersion: "v3.26.0",
+    mockLatest: "v3.26.0",
+    mockHealth: { error: "ECONNREFUSED" }
+  });
+  assert.equal(result.next_action.kind, "fix_service");
+  assert.notEqual(result.next_action.kind, "noop");
+});
+
+test("#214: tree==latest, /health reachable but no version field → degrades gracefully to noop", async () => {
+  const result = await runDoctor({
+    skipNetwork: false,
+    mockVersion: "v3.26.0",
+    mockLatest: "v3.26.0",
+    mockHealth: { status: 200, body: { auth: { ok: true } } } // no `version` key
+  });
+  assert.equal(result.next_action.kind, "noop");
+  assert.equal(result.ready_to_upgrade, true);
+});
+
+test("#214: tree==latest, /health version field unparseable → degrades gracefully to noop", async () => {
+  const result = await runDoctor({
+    skipNetwork: false,
+    mockVersion: "v3.26.0",
+    mockLatest: "v3.26.0",
+    mockHealth: { status: 200, body: { version: "not-a-semver", auth: { ok: true } } }
+  });
+  assert.equal(result.next_action.kind, "noop");
+  assert.equal(result.ready_to_upgrade, true);
+});
+
 // ── System-prompt operator append (CLAUDE_SYSTEM_PROMPT wiring) ─────────────
 // The var was documented + echoed on /health but never reached a request (dead
 // since APPEND_SYSTEM_PROMPT was retired — caught in PR #170 review). The wiring

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -769,7 +769,7 @@ test("doctor detects from-version < v3.4.0 → fresh_install", async () => {
 
 test("doctor next_action.kind enum is one of allowed values", async () => {
   const result = await runDoctor({ skipNetwork: true, mockVersion: "v3.10.0", mockLatest: "v3.14.0" });
-  const ALLOWED = ["noop", "update", "upgrade", "fresh_install", "fix_oauth", "fix_service"];
+  const ALLOWED = ["noop", "restart", "update", "upgrade", "fresh_install", "fix_oauth", "fix_service"];
   assert.ok(ALLOWED.includes(result.next_action.kind), `kind=${result.next_action.kind} not in enum`);
 });
 
@@ -843,12 +843,24 @@ test("doctor falls back to currentVersion when origin/main unreachable (no stale
 // before the restart phase runs. The tree now looks fully updated, but the service (per
 // /health) still answers with the OLD version. Before this fix, the next `ocp update` run
 // compared tree==latest, found them equal, and reported kind="noop" — silently leaving the
-// stale service running. These five tests pin the cases enumerated in the issue. The fix
-// reuses kind="update" (rather than inventing a new enum value) for the "tree==latest but
-// service stale" case: bash `cmd_update`'s "update" branch already runs `_cmd_update_light`,
-// which git-pulls (a no-op — the tree is already current) and unconditionally restarts the
-// service, and `scripts/upgrade.mjs`'s "update" branch already no-ops sensibly too — so every
-// existing next_action.kind consumer already behaves correctly with no further changes.
+// stale service running.
+//
+// RETRACTED CLAIM (PR #217, first draft): that draft reused kind="update" for the
+// "tree==latest but service stale" case, reasoning that `_cmd_update_light`'s `git pull` was
+// "a no-op here since the tree is already current". That reasoning was wrong and was rejected
+// in review: doctor's "tree == latest" is a comparison of VERSION STRINGS (tree's
+// package.json vs origin/main's package.json), not of commits. Between releases, origin/main
+// can accumulate merged-but-unreleased commits while package.json stays put — so
+// "tree == latest" can hold while origin/main HEAD is genuinely ahead of the release tag, and
+// `git pull origin main --ff-only` would fast-forward a production host off its release tag
+// onto unreleased code. Reusing "update" also silently dropped `ocp update --dry-run` and
+// `--target` (`_cmd_update_light` never forwards "$@"), so a stale host would skip straight to
+// a real mutating restart despite the documented "preview the plan, don't mutate" contract.
+//
+// Fixed shape: a new, distinct kind="restart" that never touches git — bash's
+// `_cmd_update_restart` only calls `cmd_restart` + verifies via `postFlightOk`. The consumer
+// cost of the new enum value was one `case` arm in `ocp` and one entry in this file's
+// `ALLOWED` list — see the audit table in the PR body.
 console.log("\nDoctor next_action.kind reflects running-service version (#214):");
 
 test("#214: tree==latest, service reports the same version → genuinely noop", async () => {
@@ -864,14 +876,14 @@ test("#214: tree==latest, service reports the same version → genuinely noop", 
     "no stale-service warning expected when versions match");
 });
 
-test("#214: tree==latest, service reports an OLDER version → NOT noop, restarts via update kind", async () => {
+test("#214: tree==latest, service reports an OLDER version → NOT noop, restart kind (no git)", async () => {
   const result = await runDoctor({
     skipNetwork: false,
     mockVersion: "v3.26.0",
     mockLatest: "v3.26.0",
     mockHealth: { status: 200, body: { version: "3.25.0", auth: { ok: true } } }
   });
-  assert.equal(result.next_action.kind, "update");
+  assert.equal(result.next_action.kind, "restart");
   // WARN, not FAIL: ready_to_upgrade must stay true, or runUpgrade()'s pre-flight guard
   // (which only tolerates ready_to_upgrade=false for kind="fresh_install") would throw
   // instead of letting the restart proceed.
@@ -880,6 +892,28 @@ test("#214: tree==latest, service reports an OLDER version → NOT noop, restart
   assert.ok(warning, "expected a service_version_matches_tree check");
   assert.equal(warning.level, "WARN");
   assert.equal(warning.message, "tree at 3.26.0, service serving 3.25.0 — restarting");
+});
+
+test("#214: tree==latest, service reports a NEWER version → NOT auto-restarted (would downgrade)", async () => {
+  // e.g. after a tree rollback, or someone running a newer/test build. Auto-restarting here
+  // would silently DOWNGRADE a running service to match an older tree — the exact class of
+  // surprise auto-mutation this issue is about. Surfaced (WARN) but not acted on: kind stays
+  // "noop". Coverage gap flagged in PR #217 review: changing the comparison from `!== 0` to
+  // `< 0` (i.e. only reacting to a STALE/older service) is required to survive this test —
+  // the naive `!== 0` mutation treated a newer service as needing a "restart" too, which would
+  // have downgraded it.
+  const result = await runDoctor({
+    skipNetwork: false,
+    mockVersion: "v3.26.0",
+    mockLatest: "v3.26.0",
+    mockHealth: { status: 200, body: { version: "3.27.0", auth: { ok: true } } }
+  });
+  assert.equal(result.next_action.kind, "noop");
+  assert.equal(result.ready_to_upgrade, true);
+  const warning = result.checks.find(c => c.id === "service_version_matches_tree");
+  assert.ok(warning, "expected a service_version_matches_tree check even though kind stays noop");
+  assert.equal(warning.level, "WARN");
+  assert.equal(warning.message, "tree at 3.26.0, service serving 3.27.0 (NEWER than tree) — not auto-restarting");
 });
 
 test("#214: tree==latest, /health unreachable → NOT noop (still fix_service)", async () => {
@@ -1455,7 +1489,7 @@ test("integration: a config change invalidates the STRUCTURED cache too (closes 
 });
 
 // ── Upgrade Tests ──
-import { runUpgrade, postFlightOk } from "./scripts/upgrade.mjs";
+import { runUpgrade, postFlightOk, runPostFlightCheck } from "./scripts/upgrade.mjs";
 
 console.log("\nUpgrade:");
 
@@ -1481,6 +1515,91 @@ test("postFlightOk: auth failure rejects regardless of version", () => {
 test("postFlightOk: unknown/empty target degrades to the auth-only check (never blocks)", () => {
   assert.equal(postFlightOk({ auth: { ok: true }, version: "3.22.1" }, ""), true);
   assert.equal(postFlightOk({ auth: { ok: true }, version: "3.22.1" }, undefined), true);
+});
+
+// ── runPostFlightCheck (issue #214, MED-1 on PR #217 review) ────────────────
+// `_cmd_update_restart`'s bash-side `cmd_restart` has a swallowed-failure bug (its own
+// failure path only echoes and still returns 0), so a failed restart previously reported
+// success while the service kept serving the old version — the exact "reports success while
+// serving old code" complaint from #214, only partly fixed by detection alone. This function
+// is the fix: it polls /health and reuses postFlightOk() (tested above) rather than a second
+// hand-rolled predicate. opts.mockProbe/attempts/intervalMs make the retry loop itself
+// testable without a live server or real sleeps.
+console.log("\nrunPostFlightCheck (#214):");
+
+test("runPostFlightCheck: succeeds immediately when the first probe already matches target", async () => {
+  let calls = 0;
+  const result = await runPostFlightCheck("v3.26.0", {
+    attempts: 5, intervalMs: 0,
+    mockProbe: () => { calls++; return { auth: { ok: true }, version: "3.26.0" }; }
+  });
+  assert.equal(result.ok, true);
+  assert.equal(calls, 1, "must not keep polling once the target is already reached");
+});
+
+test("runPostFlightCheck: retries past a stale/unreachable probe and succeeds once the target lands", async () => {
+  let calls = 0;
+  const result = await runPostFlightCheck("v3.26.0", {
+    attempts: 5, intervalMs: 0,
+    mockProbe: () => {
+      calls++;
+      if (calls === 1) throw new Error("ECONNREFUSED"); // service mid-restart
+      if (calls === 2) return { auth: { ok: true }, version: "3.25.0" }; // old process still holding the port
+      return { auth: { ok: true }, version: "3.26.0" }; // new process finally serving
+    }
+  });
+  assert.equal(result.ok, true);
+  assert.equal(calls, 3);
+});
+
+test("runPostFlightCheck: exhausts attempts and reports ok:false + lastSeen when the target never lands", async () => {
+  let calls = 0;
+  const result = await runPostFlightCheck("v3.26.0", {
+    attempts: 3, intervalMs: 0,
+    mockProbe: () => { calls++; return { auth: { ok: true }, version: "3.25.0" }; }
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.lastSeen, "3.25.0");
+  assert.equal(calls, 3, "must try exactly `attempts` times, no more no less");
+});
+
+test("runPostFlightCheck: exhausts attempts and reports ok:false + lastSeen:null when totally unreachable", async () => {
+  const result = await runPostFlightCheck("v3.26.0", {
+    attempts: 3, intervalMs: 0,
+    mockProbe: () => { throw new Error("ECONNREFUSED"); }
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.lastSeen, null);
+});
+
+// ── runUpgrade() with kind="restart" (issue #214) ────────────────────────────
+// Mirrors the existing "update"-kind placeholder branch. Distinct from "update": no git/npm
+// text in the dry-run plan, since this path (unlike "update") never touches git — see the
+// doctor.mjs decision-block comment for why that distinction is load-bearing (HIGH-2 on PR
+// #217 review: reusing "update" here would have risked pulling unreleased origin/main commits
+// onto a production host).
+console.log("\nrunUpgrade kind=restart (#214):");
+
+test("runUpgrade restart --dry-run: plan has NO git/npm text, executed:false", async () => {
+  const result = await runUpgrade({
+    dryRun: true,
+    mockDoctor: { ready_to_upgrade: true, next_action: { kind: "restart" },
+                  current_version: "v3.26.0", latest_version: "v3.26.0" }
+  });
+  assert.equal(result.executed, false);
+  assert.ok(result.plan.some(line => line.includes("restart-only")));
+  assert.ok(!result.plan.some(line => /git pull|npm install|git checkout/.test(line)),
+    "restart path must never mention git/npm — it doesn't touch either");
+});
+
+test("runUpgrade restart (non-dry-run): reports path=restart, changed:true, delegates to bash", async () => {
+  const result = await runUpgrade({
+    mockDoctor: { ready_to_upgrade: true, next_action: { kind: "restart" },
+                  current_version: "v3.26.0", latest_version: "v3.26.0" }
+  });
+  assert.equal(result.path, "restart");
+  assert.equal(result.executed, true);
+  assert.equal(result.changed, true);
 });
 
 test("upgrade --dry-run prints plan, no side effects", async () => {


### PR DESCRIPTION
## Defect

`ocp update` short-circuits to `kind="noop"` ("Already at latest. Nothing to do.") purely by
comparing the tree's `package.json` version to the remote `origin/main` version. It never
consults `/health.version` — the version the **running service** actually reports.

Reproduction from the issue (v3.26.0 fleet update, live host):

```
$ ocp update            # fails in `reconfigure` after `git checkout v3.26.0` — claude not on PATH
$ ocp update             # retry: tree is now at the new tag
Already at latest. Nothing to do.
$ git log --oneline -1          a17b6c0 chore(release): v3.26.0     <- new (tree)
$ jq -r .version package.json   3.26.0                              <- new (tree)
$ curl :3456/health | jq .version
3.25.0                                                              <- OLD, service never restarted
```

The host reports success on every cheap check while serving stale code — exactly the case
`ocp update`'s idempotency guarantee (retry after partial failure) exists for.

## Root cause

`scripts/doctor.mjs`'s noop branch (previously ~line 133) compared only
`currentVersion` (tree) vs `latestVersion` (remote):

```js
} else if (semverCompare(currentVersion, latestVersion) === 0) {
  kind = "noop";
}
```

`/health` was already being fetched a few lines above (for the `service_running` /
`oauth_ok` checks, and already mockable via `opts.mockHealth`), but `health.body.version`
was never read.

---

## ⚠️ RETRACTION (round 2) — the first commit on this branch was wrong

The first version of this fix reused `kind="update"` for the "tree==latest but service stale"
case. **Independent review caught two HIGH-severity defects in that approach; both claims
below are retracted, not quietly edited:**

1. **"`_cmd_update_light`'s `git pull` is a no-op here"** — **FALSE.** doctor's
   `tree == latest` comparison is a comparison of **version strings**
   (`package.json` in the tree vs. `package.json` at `origin/main`), **not commits**. Between
   releases, `origin/main` accumulates merged-but-unreleased commits while `package.json`'s
   version field stays put — so `tree == latest` can hold true while `origin/main` HEAD is
   genuinely ahead of the release tag. Routing that state through `kind="update"` would have
   made `_cmd_update_light` run `git pull origin main --ff-only` for real, silently
   fast-forwarding a production host **off its release tag onto unreleased code**, then
   restarting into it — a worse outcome than the bug #214 reports.
2. **"Reusing `update` is free / a 1-line change"** — **FALSE.** `_cmd_update_light` never
   forwards `"$@"` to itself, so `ocp update --dry-run` on a stale host would have skipped
   straight past the documented "preview the plan, don't mutate" contract (`ocp:731`) into a
   real, mutating restart. Same root cause silently drops `--target`.

Both are fixed by the redesign below, not by re-adding flag handling to the "update" path.

---

## ⚠️ CORRECTIONS (round 3) — two false statements in the round-2 body

Round-3 review flagged two inaccuracies in the text above/below, both now fixed rather than
silently edited:

1. **"#216 and #218 landed on `main`... without a version bump"** — **#218 is false.**
   `gh pr view 218` → still `OPEN`, not merged. Only **#216** actually landed
   (`612be371544b84b8036defedca600a70da2509b6`, merged, no version bump) — which is sufficient
   on its own to demonstrate the HIGH-2 precondition (tree==latest by version string while
   `origin/main` HEAD moves), but citing a second, non-existent example was wrong and is
   retracted. Fixed above by removing the #218 reference entirely.
2. **"`postFlightOk`'s own pre-existing tests were independently re-verified TRUE by the
   reviewer"** — **false framing.** The reviewer did not re-run or re-verify `postFlightOk`'s
   own test file; it verified two narrower, different things: `runUpgrade()`'s pre-flight guard
   at `upgrade.mjs:47-49` (`if (!doctor.ready_to_upgrade && kind !== "fresh_install") throw`),
   and the `/health` response's field shape (`version` is a top-level bare-semver string, per
   `server.mjs`'s `version: VERSION`). Neither of those is "postFlightOk's tests." Corrected in
   the Tests section below.

---

## ⚠️ FIXES (round 3) — one HIGH, one MED, one LOW, all in the bash layer

Round-3 review re-derived and reproduced all 8 mutations from round 2, confirmed HIGH-1/HIGH-2
genuinely closed, and called the round-2 retraction "honest and accurate, not downplayed" — but
found a **new HIGH** in the rewrite itself, unrelated to #214's original bug:

### HIGH — the `set -e` guard on the doctor invocation was dropped

```bash
# round 2 (broken): bare assignment
doctor_json=$(node "$script_dir/scripts/doctor.mjs" --json 2>/dev/null)
```

`scripts/doctor.mjs:310` does `process.exit(fail_count === 0 ? 0 : 1)` — **any** FAIL check
(service down, OAuth invalid, pre-v3.4.0) makes it exit 1. `ocp:7` runs the whole script under
`set -euo pipefail`. A bare `var=$(cmd)` assignment where `cmd` exits non-zero trips `set -e`
immediately — `cmd_update` died with **zero output**, on exactly the hosts that need the tool
most. Fixed with `doctor_json=$(node ... --json 2>/dev/null) || true` — command substitution
captures stdout regardless of the command's exit status, so the JSON is preserved; the `|| true`
just tells `set -e` this particular assignment's exit status is fine to ignore. This also
incidentally fixes a **pre-existing** `main` bug: the old single-pipeline form
(`node ... | python3 ... || echo "unknown"`) could have both `pipefail` *and* the `||` fallback
fire on a doctor exit 1, concatenating python's real output with the literal string `"unknown"`
(`kind` became a two-line `"fix_service\nunknown"`, matching no `case` pattern, falling through
to the `*)` "Unknown doctor kind" arm).

### MED-1 — `cmd_restart`'s hard `exit 1` could skip post-flight entirely

`cmd_restart`'s success path ends by calling `cmd_usage`, and `cmd_usage` does
`data=$(curl ... "$PROXY/usage") || { echo "..."; exit 1; }` — a real `exit`, not `return`. A
bare `cmd_restart || true` at the `_cmd_update_restart` call site would not have helped: `exit`
terminates the whole process before control would ever "return" to that `||`. Fixed with
`( cmd_restart ) || true` — the subshell contains the `exit` to itself; the restart's real side
effects (launchd/systemd/nohup calls) still happen for real, but a slow/unreachable `/usage`
call (plausible right after a restart, before the proxy has warmed back up) can no longer take
post-flight verification down with it.

### LOW — `--post-flight-only` with no argument failed open

`postFlightOk(body, undefined)` degrades to the auth-only check by design (so an unknown release
target never blocks a good upgrade elsewhere) — but that same degrade meant an
accidentally-omitted `--post-flight-only` target would print `✓ service now serving v` and exit
0 against *any* running version. `ocp`'s bash caller always passes `"v$target"` explicitly so
this was never reachable through the normal flow, but it's a public flag now. Fixed: missing or
flag-shaped (`--...`) targets now print an error and exit 1.

### MED-3 — doc drift

`cmd_update_help()` was updated in round 2, but `README.md:306` and `docs/upgrading.md:16-22`
still enumerated only three `ocp update` paths (patch/cross-minor/fresh-install). Both now
document the restart-only path. (My round-2 consumer-audit grep was `--include='*.md'` on
`next_action` specifically — correct about what it examined, but neither of these passages
contains that string, so the audit missed them. Same shape of gap as the original v1 audit
error.)

### MED-2 — bash wiring had no permanent test coverage; filed as a follow-up

Tracked as **#225**. See the Tests section below for what round 3 covers with a manual
verification pass, and what's deferred to that issue.

---

## Fix — shape chosen and why

`kind="restart"` is a **distinct enum value**, not a reuse of `"update"`. It never touches git.
Design:

- `scripts/doctor.mjs`: when `tree == latest` and the running service's version (captured from
  `/health.version`, only trusted when it actually parses as a semver) is **older** than the
  tree, `kind = "restart"` with a WARN check stating which side is stale:
  `tree at 3.26.0, service serving 3.25.0 — restarting`. When the service is **newer** than the
  tree (e.g. after a tree rollback, or someone running a newer/test build), the fix does **not**
  auto-restart — that would silently *downgrade* a running service, the same class of surprise
  auto-mutation this issue is about. It's surfaced as a WARN (`... (NEWER than tree) — not
  auto-restarting`) but `kind` stays `"noop"`. When the service version is unknown (unreachable,
  missing, or unparseable), it degrades gracefully to `"noop"` — same philosophy as
  `upgrade.mjs`'s `postFlightOk` ("an empty/unknown target degrades ... rather than blocking an
  otherwise-good upgrade").
- `ocp`'s `cmd_update` gets a new `restart)` case arm → `_cmd_update_restart`, which:
  - **honors `--dry-run`** — prints a plan and returns without touching anything;
  - otherwise calls the existing `cmd_restart` (its launchd → systemd → manual-nohup fallback
    chain is more robust than anything worth duplicating here), wrapped `( cmd_restart ) || true`
    (round 3, MED-1), then verifies via a new `runPostFlightCheck()` in `scripts/upgrade.mjs`;
  - **never runs git**.
- `runPostFlightCheck()` polls `/health` and reuses `postFlightOk()` — the **same** acceptance
  predicate `runFullUpgrade`'s post-flight phase already uses (issue #173) — rather than a
  second hand-rolled check. This is the fix for the "reports success while serving old code"
  half of #214 that detection alone didn't close.
- `cmd_update` no longer discards doctor's other output: it used to extract only `kind` from the
  JSON (stdout piped straight into python, stderr to `/dev/null`), so the WARN message — #214's
  literal "say which one is stale" ask — never reached the person running `ocp update`. It now
  echoes any WARN-level check before dispatching on `kind`.
- Removed dead code: an earlier draft normalized `serviceVersion` with a `"v"` prefix; review
  showed this had zero effect (`semverParts()`/`semverCompare()` strip a leading `"v"`
  themselves) and it survived mutation testing. Removed rather than re-justified.

### Consumer audit

`grep -rn 'next_action' --include='*.mjs' --include='*.md' --include='ocp' .`

| Consumer | Change | Notes |
|---|---|---|
| `ocp`'s `cmd_update` case statement | **New `restart)` arm** → `_cmd_update_restart` | Honors `--dry-run`; no git |
| `scripts/upgrade.mjs`'s `runUpgrade()` dry-run branch | **New `else if (kind === "restart")`** plan text | `restart` doesn't go through `scripts/upgrade.mjs` via the bash CLI (bash intercepts at `kind=restart` before ever invoking it) — this branch only matters if `runUpgrade()` is called programmatically |
| `scripts/upgrade.mjs`'s `runUpgrade()` non-dry-run branch | **New `if (kind === "restart")` placeholder**, mirrors `"update"`'s | Avoids a confusing `"path restart not yet implemented"` throw if called programmatically with `kind="restart"` |
| `test-features.mjs`'s `ALLOWED` enum | **Added `"restart"`** | `["noop","restart","update","upgrade","fresh_install","fix_oauth","fix_service"]` |
| `docs/troubleshooting.md:10,14`, `README.md:349,531` (generic `next_action` mentions) | No change needed | Reference `next_action` generically, enumerate no `kind` values |
| `README.md:306`, `docs/upgrading.md:16-22` (path enumeration, no `next_action` string) | **Updated (round 3, MED-3)** | These enumerate the *paths* `ocp update` takes without using the word `next_action` — missed by the `next_action`-grep in round 2, caught in round 3 review |
| `cmd_update_help()` inline docstring | Updated | Documents the new restart-only path alongside the existing three |

### Case-by-case (as enumerated in the issue, now 5 outcomes)

| Case | Result |
|---|---|
| tree == latest, service == tree | `kind="noop"` — genuinely nothing to do |
| tree == latest, service OLDER than tree | `kind="restart"` — `cmd_restart` + post-flight verify, **no git** |
| tree == latest, service NEWER than tree | `kind="noop"` + WARN — auto-restarting here would be a silent downgrade, so it doesn't happen automatically |
| `/health` unreachable | **Already handled pre-fix** — `healthOk` gate fires `kind="fix_service"` *before* the noop/restart/update/upgrade branch is ever reached. Regression test pins this priority ordering. |
| `/health` reachable, no/unparseable `version` field | Degrades gracefully to `noop` — does not block a good upgrade |

---

## Tests

### JS (`test-features.mjs`, run via `npm test`) — unchanged since round 2, all still green

Two clearly-commented sections, kept in their respective existing "Doctor:" / "Upgrade:" console
groups:

**"Issue #214: doctor's noop must reflect the RUNNING SERVICE's version..."** (6 tests, call
`runDoctor()` with `mockHealth`/`mockVersion`/`mockLatest`, assert on `next_action.kind`,
`ready_to_upgrade`, `checks[]`):
1. same version → noop
2. OLDER service version → NOT noop, `kind="restart"`, no git
3. NEWER service version → NOT auto-restarted (would downgrade), noop + WARN
4. `/health` unreachable → NOT noop (still `fix_service`)
5. no `version` field → degrades gracefully to noop
6. unparseable `version` field → degrades gracefully to noop

**"runPostFlightCheck (#214)"** (4 tests, using `opts.mockProbe`/`attempts`/`intervalMs` — no
live server, no real sleeps):
7. succeeds immediately, doesn't over-poll
8. retries past a throw + a stale reading, succeeds once the target lands
9. exhausts attempts, reports `ok:false` + `lastSeen` when the target never lands
10. exhausts attempts, reports `ok:false` + `lastSeen:null` when totally unreachable

**"runUpgrade kind=restart (#214)"** (2 tests, using `mockDoctor`):
11. dry-run plan has no git/npm text, `executed:false`
12. non-dry-run reports `path:"restart"`, `changed:true`

All behavioral — none grep source. `postFlightOk`'s own pre-existing tests (issue #173) are
unchanged by this PR (see the round-3 correction above for what the reviewer actually verified
about them — it verified the `runUpgrade()` guard and the `/health` field shape, not this test
file itself).

### Bash (`ocp`) — round 3: manual, mutation-proven verification; NOT part of `npm test`

Round 2 shipped with only a `bash -n` syntax check and a single safe `--dry-run` smoke test,
disclosed as an honest gap. Round-3 review reproduced 7 additional mutations by hand against a
~12-line stub rig and found 5 of them **survived** (uncovered): the case arm's existence, the
`--dry-run` guard, the no-git guarantee itself (the actual point of this whole redesign), the
`--post-flight-only` CLI entry, and the WARN-output block.

I did not build a permanent harness in this PR (filed as **#225**, a separate reviewable unit per
Iron Rule 11), but I did extend the manual verification to close the gap for everything reachable
without unsafe environment control, using the reviewer's own technique — `source` only the
function definitions (everything before `# ── dispatch`, which otherwise calls `exit` and would
terminate whatever process sources it), then define stub functions for `node`, `cmd_restart`,
`git` **after** sourcing (never before — see Safety note below).

**What this covers**: HIGH (set -e/doctor-FAIL survival), N3 (case arm exists), N4 (`--dry-run`
guard), N5 (**the money test** — restart path never calls `git`), N7 (WARN reaches the
operator), MED-1 (a `cmd_restart` that hard-`exit`s doesn't kill post-flight).

**What this does NOT cover, and why (deferred to #225)**: N6, the `--post-flight-only` CLI entry
in `scripts/upgrade.mjs`. A faithful test requires either invoking the real CLI end-to-end — which
this sandbox's own safety guard correctly blocks any `$HOME` override for (HOME controls where
`doctor.mjs`/`runDoctor()`'s default `ocpDir` resolves, which controls where its internal
`git fetch` writes) — or refactoring `scripts/upgrade.mjs` to accept an injectable `ocpDir`.
Neither is a same-PR-sized change; #225 tracks it.

**Mutation table (bash layer)** — same protocol as the JS table below: backed up to a plain file
first, mutated, verified to produce a FAILING check with an actionable message, restored **from
that backup file** (never `git checkout`, verified via `diff` after restore), reverified green
(13/13) before the next mutation:

| # | Mutation | Checks killed | Evidence |
|---|---|---|---|
| Bash-M1 | Revert the HIGH fix (`\|\| true`) | HIGH ×2 | Reproduces the reviewer's exact finding: `--- actual output ---` is **empty** |
| Bash-M2 | Delete the `restart)` case arm (N3) | N3 ×1 + N5 ×2 (collateral — both depend on the case arm existing) | `Unknown doctor kind: restart. Run \`ocp doctor --json\` to inspect.` |
| Bash-M3 | Rename the `--dry-run` guard's match string (N4) | N4 ×3 | Falls straight through to a real `cmd_restart` + post-flight call |
| Bash-M4 | Route `restart)` to `_cmd_update_light` instead of `_cmd_update_restart` (N5, the money test) | N5 ×3 | `MUTATION-DETECTOR_N5_GIT_CALLED: pull origin main --ff-only` — git *was* invoked |
| Bash-M5 | Delete the WARN-output block (N7) | N7 ×1 | WARN message no longer appears in `cmd_update`'s output |
| Bash-M6 | Revert the MED-1 fix (`( cmd_restart ) \|\| true` → bare `cmd_restart`) | MED-1 ×2 | A `cmd_restart` stub that `exit`s kills the whole check — `"Verifying restart"` never prints |

All 6 mutations reverted and the 13/13 baseline reconfirmed green before the next, each restore
verified via `diff` against the pre-mutation backup.

### Safety note for this verification pass

While reviewing round 2, a reviewer accidentally took the reviewing host's production OCP down:
it defined a `cmd_restart` stub **before** `source`-ing the real `ocp` functions, so sourcing
overwrote the stub with the real function, and the real restart chain ran for real
(`launchctl bootout` succeeded, `bootstrap` failed, `nohup` fallback pointed at a scratch dir —
the proxy was down until noticed). This verification pass defines all stubs **after** sourcing,
uses no `$HOME` override, invokes no real `git`/`launchctl`/`systemctl`/`pkill`/`nohup`/`curl`,
and never invokes the real dispatch/CLI entrypoint (past the `# ── dispatch` boundary) against
this host.

## Suite count

```
$ npm test | tail -3
=== Results: 475 passed, 0 failed ===
```

(462 pre-existing + 1 net-new from #216, which merged into `main` during round-2 review, + 12
new from this PR's JS tests, all green, rebased onto current `origin/main`.) Plus 13/13 passing
in the round-3 manual bash verification described above (not part of this count — not run by
`npm test`).

## Alignment

`server.mjs` is **untouched** by this PR — the fix lives entirely in `scripts/doctor.mjs`, the
`ocp` CLI wrapper, `scripts/upgrade.mjs`, and their test coverage. No `cli.js` citation applies
(`ALIGNMENT.md` Rules 1–5 govern the Class A `cli.js`-mirror surface only); this is an
OCP-internal CLI decision, not a wire operation OCP forwards from `cli.js`.

## What I deliberately did NOT do

- Did not touch the unrelated `PATH`/`CLAUDE_BIN` resolution issue the reporter flagged as
  "the trigger that exposed the real bug" — the issue itself calls that out as separate and
  "probably not worth fixing" on its own; out of scope for this PR.
- Did not fix `_cmd_update_light`'s own MED-1-shaped bug for the genuine patch-bump `"update"`
  path (only its own `cmd_restart` call, not the one this PR's `kind="restart"` path uses, which
  is fixed). That's a real, separate latent defect that predates this issue; bundling it would
  violate Iron Rule 11 (minimum reviewable unit).
- Did not implement `--target` for the new restart path. Traced it: `scripts/upgrade.mjs`'s CLI
  entrypoint parses `--target` into a variable that `runUpgrade()` never reads anywhere
  (`grep -n "opts.target" scripts/upgrade.mjs` — zero hits) — it's already dead for every kind,
  not something this PR regresses.
- Did not build a permanent bash test harness in this PR — filed as **#225** per Iron Rule 11,
  with the specific gaps (N6, and promoting this PR's manual rig to something `npm test` runs)
  documented there.
- Did not fix the doctor `currentVersion` (`join(homedir(), "ocp")`) vs. `_cmd_update_restart`'s
  `target` (`$script_dir/package.json`) discrepancy flagged in round-3 review (LOW) — they agree
  under a standard install (both resolve to the same path) and diverge only for a non-standard
  one; fixing it is a `scripts/doctor.mjs` CLI-flag change (an `--ocpDir` override) orthogonal to
  #214's fix and not requested as a merge condition.
- Did not fix `_cmd_update_restart`'s python single-quote interpolation of `$script_dir` (LOW —
  a path containing `'` would silently yield `target="?"`); not requested as a merge condition
  and OCP installs are not expected to live at single-quote-containing paths today.

Closes #214


---

## Added before merge — a side effect this PR has that the body did not mention

Round-3 review flagged it and I verified it. The `|| true` fix does more than stop `cmd_update` dying silently: it also **reconnects the `upgrade|fresh_install)` case arm**, which has been dead on `main` (doctor exits 1 → `pipefail` + the `||` fallback both fire → `kind` becomes the two-line string `"fix_service\nunknown"` → falls through to `*)`).

That arm is supposed to work, so reconnecting it is correct. But it leads to `runFreshInstall`, which executes doctor's `ai_executable` list verbatim — and that list contains `mv ~/.ocp ~/.ocp.backup-$(date +%s)` and **`rm -rf ${ocpDir}`** (`scripts/doctor.mjs:150-151`, executed at `scripts/upgrade.mjs:206`). Verified live that the `--yes` gate still holds (`✗ fresh_install requires --yes for non-interactive execution`), so nothing runs unattended.

The path has been unreachable for an unknown period and has therefore **never been execution-verified in that state**. Filed as **#227** for a smoke test on a throwaway host. Recorded here rather than left for someone to discover, since it is a destructive path becoming reachable as a side effect of an unrelated fix.

Also in `f74f459`: the new comment at `ocp:780` cited `doctor.mjs:310`, which is the line number *before* this PR — this PR's own additions move `process.exit` to **374**. Corrected.
