### PR TITLE
fix(setup): reconfigure phase must not enable/start the service (closes #226)

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,7 @@ Top-level files a contributor or operator may need to know:
 | `dashboard.html` | Static dashboard served from `/dashboard`. |
 | `scripts/sync-openclaw.mjs` | Idempotent OpenClaw registry sync invoked by `ocp update`. See ADR 0004. |
 | `scripts/lib/service-mode.mjs` | Pure decision layer for `setup.mjs`'s auto-start step — first install vs. `--reconfigure-only` (issue #226). |
+| `scripts/lib/install-autostart.mjs` | Injectable `installAutoStart()` — setup.mjs's auto-start install (legacy-unit migration, unit write, enable/start/bootstrap), extracted so tests can observe real run/fs calls instead of asserting on source text (issue #226). |
 | `.claude/skills/` | Project-specific Claude Code skills. |
 | `ocp-plugin/` | OpenClaw gateway plugin (optional installation). |
 | `docs/lan-mode.md` | LAN & multi-user operations manual (server/client setup, keys, quotas, anonymous access, security model). |

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Setup, the ~6-second latency floor, real-SSE streaming (`OCP_TUI_STREAM`), the w
 
 ## Upgrading
 
-Run **`ocp update`** — it smart-picks the path. If the tree is already at the latest release but the **running service** is stale (e.g. a previous update was interrupted before it restarted), it takes a **restart-only** path: no git/npm changes, just a restart + post-flight `/health` verification. A **patch bump** (e.g. `v3.21.0 → v3.21.1`) takes the light path (git pull + npm install + restart); a **cross-minor** jump (e.g. `v3.18 → v3.22`) takes the full path (pre-flight, snapshot, `setup.mjs` with plist env-merge, restart, post-flight `/health` + `/v1/models` verification). `ocp update --check` shows available updates without applying.
+Run **`ocp update`** — it smart-picks the path. If the tree is already at the latest release but the **running service** is stale (e.g. a previous update was interrupted before it restarted), it takes a **restart-only** path: no git/npm changes, just a restart + post-flight `/health` verification. A **patch bump** (e.g. `v3.21.0 → v3.21.1`) takes the light path (git pull + npm install + restart); a **cross-minor** jump (e.g. `v3.18 → v3.22`) takes the full path (pre-flight, snapshot, `setup.mjs --reconfigure-only` — writes the service unit/plist with env-merge but does not itself start anything — then a dedicated restart phase, then post-flight `/health` + `/v1/models` verification). `ocp update --check` shows available updates without applying.
 
 Manual flags, rollback (`ocp update --rollback`), snapshots, and the OpenClaw model auto-sync (v3.11.0+): **[docs/upgrading.md](docs/upgrading.md)**.
 
@@ -559,6 +559,7 @@ Top-level files a contributor or operator may need to know:
 | `ocp` / `ocp-connect` | User-facing CLI wrappers (server-side / client-side respectively). |
 | `dashboard.html` | Static dashboard served from `/dashboard`. |
 | `scripts/sync-openclaw.mjs` | Idempotent OpenClaw registry sync invoked by `ocp update`. See ADR 0004. |
+| `scripts/lib/service-mode.mjs` | Pure decision layer for `setup.mjs`'s auto-start step — first install vs. `--reconfigure-only` (issue #226). |
 | `.claude/skills/` | Project-specific Claude Code skills. |
 | `ocp-plugin/` | OpenClaw gateway plugin (optional installation). |
 | `docs/lan-mode.md` | LAN & multi-user operations manual (server/client setup, keys, quotas, anonymous access, security model). |

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -31,9 +31,15 @@ What `ocp update` does:
   Running the installer's reconfigure step with a bare `setup.mjs` (no flag) would
   start/enable the unit itself, before the restart phase gets a chance to run — on the host
   that motivated issue #215, that reproduces the orphan process #215 describes and re-arms
-  its boot race, regardless of how carefully the restart phase resolves ownership. A first
-  install (`node setup.mjs`, no flags) is unaffected and still enables + starts the service,
-  which is that path's actual job.
+  its boot race. **This alone does not stop the #215 orphan**, though: the restart phase
+  that runs next is, as of this writing, still a hard-coded `systemctl --user restart
+  ocp-proxy.service` — it does not yet resolve which unit actually owns the port (that fix,
+  #221, is a separate PR). So on the #215 host specifically, the restart phase still starts
+  `ocp-proxy` unconditionally a few steps later; --reconfigure-only removes the boot-race
+  re-arm (`enable`) and phase 4 racing ahead of phase 5 (its premature `start`), which is
+  half of the #215/#226 defect family, not the orphan itself. A first install
+  (`node setup.mjs`, no flags) is unaffected and still enables + starts the service, which
+  is that path's actual job.
 - **Old version** (< v3.4.0):
   fresh-install. Pre-v3.4 lacked admin-key/usage-db, so there is nothing to
   migrate. Your OAuth token (managed by the Claude Code CLI, not OCP) is

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -21,8 +21,19 @@ What `ocp update` does:
 - **Patch bump** (e.g. `v3.21.0 → v3.21.1`):
   light path (git pull + npm install + restart).
 - **Cross-minor** (e.g. `v3.18 → v3.22`):
-  full path: pre-flight check, snapshot, `setup.mjs` (with plist env-merge),
-  service restart, post-flight `/health` and `/v1/models` verification.
+  full path: pre-flight check, snapshot, `setup.mjs --reconfigure-only` (with plist
+  env-merge), service restart, post-flight `/health` and `/v1/models` verification.
+  `--reconfigure-only` (issue #226) writes the service unit/plist but does not itself start
+  the service now — starting is the dedicated restart phase's job, which runs next. On
+  Linux it also leaves the unit's boot-enablement (`systemctl enable`) untouched rather than
+  re-asserting it, so a host where an operator has deliberately disabled the OCP-managed
+  unit (because a different unit already owns the port) stays disabled across an upgrade.
+  Running the installer's reconfigure step with a bare `setup.mjs` (no flag) would
+  start/enable the unit itself, before the restart phase gets a chance to run — on the host
+  that motivated issue #215, that reproduces the orphan process #215 describes and re-arms
+  its boot race, regardless of how carefully the restart phase resolves ownership. A first
+  install (`node setup.mjs`, no flags) is unaffected and still enables + starts the service,
+  which is that path's actual job.
 - **Old version** (< v3.4.0):
   fresh-install. Pre-v3.4 lacked admin-key/usage-db, so there is nothing to
   migrate. Your OAuth token (managed by the Claude Code CLI, not OCP) is

--- a/scripts/lib/install-autostart.mjs
+++ b/scripts/lib/install-autostart.mjs
@@ -1,0 +1,301 @@
+// scripts/lib/install-autostart.mjs — setup.mjs's "Step 7" (auto-start install), extracted
+// into an injectable, importable function.
+//
+// Review history (issue #226, PR #229): the first cut at testing this step used source-shape
+// regex assertions reading setup.mjs's actual text, on the premise that setup.mjs's top-level
+// side effects make it unimportable/unexecutable. That premise is real, but the conclusion
+// ("so assert on source text instead") was wrong, and AGENTS.md's "Testing discipline: what
+// counts as a test" section (not its server.mjs-specific section — this one is general,
+// covering ocp-connect and bash `cmd_restart` alike) says why: "a test asserting on the source
+// text of the thing it tests is not a test — it passes when the code is deleted and re-added
+// wrong, and breaks on reformatting." That failure mode wasn't hypothetical here: a review
+// mutation emptied a gate (`if (!servicePlan.reconfigureOnly) { }`) while leaving the migration
+// code in an adjacent, now-unguarded block — the region-slice regex still found every string it
+// was looking for (co-location, not containment) and passed at 506/0. The actual fix, per that
+// review, is this file: move the imperative body into something an injected `run`/fs layer can
+// observe, the same seam `scripts/upgrade.mjs` already uses (`opts.mockExec`) and `doctor.mjs`
+// uses (`opts.mockHealth`) — NOT `scripts/lib/restart-unit.mjs`, which does not exist on `main`
+// (it ships only in #221, a separate, still-unmerged PR; an earlier draft of this module
+// wrongly cited it as precedent).
+//
+// installAutoStart() performs every action setup.mjs's Step 7 used to perform inline: legacy-
+// unit migration (gated on !servicePlan.reconfigureOnly — issue #226 review finding H1),
+// writing the plist/systemd unit (with existing-file env-merge), and the platform-specific
+// enable/start/bootstrap actions (gated per servicePlan, from scripts/lib/service-mode.mjs).
+// Every side-effecting primitive is an injected parameter with the real Node function as its
+// default, so setup.mjs's actual invocation is unchanged in behavior, while tests can pass
+// recording fakes and assert on exactly which commands/files were touched — not on whether a
+// string appears near another string in the source.
+import { mergePlistEnv, mergeSystemdEnv } from "./plist-merge.mjs";
+import { execSync as realExecSync } from "node:child_process";
+import {
+  existsSync as realExistsSync,
+  mkdirSync as realMkdirSync,
+  writeFileSync as realWriteFileSync,
+  readFileSync as realReadFileSync,
+  chmodSync as realChmodSync,
+  unlinkSync as realUnlinkSync,
+} from "node:fs";
+import { join } from "node:path";
+
+// Escape a value for safe inclusion in a plist <string>…</string> body. Moved here from
+// setup.mjs (was only ever used by the plist-building code this module now owns).
+export function xmlEscape(v) {
+  return String(v).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
+}
+
+/**
+ * @param {object} opts
+ * @param {"darwin"|"linux"|string} opts.platform
+ * @param {object} opts.servicePlan - from scripts/lib/service-mode.mjs's resolveServicePlan()
+ * @param {{HOME:string, OPENCLAW_DIR:string, serverPath:string, startPath:string}} opts.paths
+ * @param {{PORT:number, BIND_ADDRESS:string, AUTH_MODE_CONFIG:string, CLAUDE_BIN_INJECT:?string, OCP_ADMIN_KEY_INJECT:?string, PROXY_ANON_KEY_INJECT:?string}} opts.config
+ * @param {(cmd:string)=>string} [opts.run] - execSync replacement (shell-out seam)
+ * @param {Function} [opts.writeFile] - writeFileSync replacement
+ * @param {Function} [opts.readFile] - readFileSync replacement (existing-unit-file read, for env-merge)
+ * @param {Function} [opts.existsPath] - existsSync replacement
+ * @param {Function} [opts.makeDir] - mkdirSync replacement
+ * @param {Function} [opts.chmodPath] - chmodSync replacement
+ * @param {Function} [opts.unlinkPath] - unlinkSync replacement
+ * @param {(msg:string)=>void} [opts.log]
+ * @param {(msg:string)=>void} [opts.warn]
+ * @param {(msg:string)=>void} [opts.print] - banner-level console.log replacement
+ */
+export function installAutoStart(opts) {
+  const {
+    platform,
+    servicePlan,
+    paths,
+    config,
+    run = realExecSync,
+    writeFile = realWriteFileSync,
+    readFile = realReadFileSync,
+    existsPath = realExistsSync,
+    makeDir = realMkdirSync,
+    chmodPath = realChmodSync,
+    unlinkPath = realUnlinkSync,
+    log = (msg) => console.log(`  ✓ ${msg}`),
+    warn = (msg) => console.log(`  ⚠ ${msg}`),
+    print = (msg) => console.log(msg),
+  } = opts;
+
+  const { HOME, OPENCLAW_DIR, serverPath, startPath } = paths;
+  const { PORT, BIND_ADDRESS, AUTH_MODE_CONFIG, CLAUDE_BIN_INJECT, OCP_ADMIN_KEY_INJECT, PROXY_ANON_KEY_INJECT } = config;
+
+  print("\n🔄 Installing auto-start on login...\n");
+
+  const platformSupported = platform === "darwin" || platform === "linux";
+
+  // Use stable symlink path instead of versioned Cellar path (e.g. /opt/homebrew/opt/node/bin/node
+  // instead of /opt/homebrew/Cellar/node/25.8.0/bin/node) so the plist survives node upgrades.
+  let nodeBin = process.execPath;
+  if (platform === "darwin" && nodeBin.includes("/Cellar/")) {
+    const stable = nodeBin.replace(/\/Cellar\/[^/]+\/[^/]+\//, "/opt/");
+    if (existsPath(stable)) {
+      nodeBin = stable;
+      log(`Using stable node path: ${nodeBin}`);
+    }
+  }
+
+  // Ensure logs dir exists
+  const logsDir = join(OPENCLAW_DIR, "logs");
+  if (!existsPath(logsDir)) makeDir(logsDir, { recursive: true });
+
+  // Use neutral service names to avoid OpenClaw gateway's extra-service detection.
+  // OpenClaw scans LaunchAgent plists and systemd units for "openclaw" / "clawdbot"
+  // markers and flags them as conflicting gateway-like services. Using "dev.ocp.*"
+  // and "ocp-proxy" keeps the proxy invisible to that heuristic.
+  const OCP_HOME = join(HOME, ".ocp");
+  const ocpLogsDir = join(OCP_HOME, "logs");
+  // mode 0700: with `recursive`, this call can create ~/.ocp ITSELF on a fresh install, and
+  // without an explicit mode that parent lands at the umask default (world-listable 0755).
+  if (!existsPath(ocpLogsDir)) makeDir(ocpLogsDir, { recursive: true, mode: 0o700 });
+
+  // Uninstall legacy service names if present (upgrade path). Gated on !reconfigureOnly
+  // (issue #226 review, finding H1): stopping, disabling, and deleting a service is exactly
+  // the phase-5-shaped action this PR exists to keep out of phase 4 — regardless of WHICH
+  // unit it targets, "only write config" cannot also mean "and stop/disable/delete a
+  // different one". Left ungated, a host that auto-started via the legacy unit would end this
+  // run with NO enabled unit at all (legacy disabled+deleted here, new unit's `enable` skipped
+  // by reconfigure-only) — invisible until the next reboot. Reconfigure-only therefore leaves
+  // any pre-v3.4.0 legacy unit untouched; migrating away from it remains a bare
+  // `node setup.mjs` (first install / fresh_install) job, same as it always was. In practice
+  // this is very close to unreachable via scripts/upgrade.mjs's phase 4 specifically — doctor
+  // gates that cross-minor "upgrade" path (the only caller of --reconfigure-only) at
+  // >= v3.4.0, already past the v3.1.0 rename that produced these legacy names — but the
+  // gate lives here regardless, since the contract ("reconfigure-only touches only this
+  // unit's own config") should hold even where it's never exercised.
+  // Consequence, stated plainly (review round 2): on a host that DOES still have a legacy unit
+  // and DOES take the reconfigure-only path, this gate converts what used to be a successful
+  // migration into a failed upgrade — phase 5 starts the new unit against a port the legacy
+  // one may still hold, post-flight fails, and the operator rolls back. Rollback restores the
+  // git tree and admin-key/db files, not `~/.config/systemd/user/` or
+  // `~/Library/LaunchAgents/`, so the newly-written (but not migrated-away-from) unit is left
+  // as-is; since it carries `Restart=always`/`RestartSec=5`, it will keep respawning and
+  // failing after the aborted upgrade until an operator intervenes. Judged acceptable given
+  // the same near-zero reachability as above, and because loud-and-rolled-back beats silent-
+  // and-invisible-until-reboot (round 1's failure mode).
+  if (!servicePlan.reconfigureOnly) {
+    if (platform === "darwin") {
+      const legacyPlist = join(HOME, "Library", "LaunchAgents", "ai.openclaw.proxy.plist");
+      if (existsPath(legacyPlist)) {
+        try { run(`launchctl bootout gui/$(id -u) "${legacyPlist}" 2>/dev/null`); } catch { /* ignore */ }
+        try { unlinkPath(legacyPlist); } catch { /* ignore */ }
+        log(`Removed legacy plist: ai.openclaw.proxy`);
+      }
+    } else if (platform === "linux") {
+      const legacyService = join(HOME, ".config", "systemd", "user", "openclaw-proxy.service");
+      if (existsPath(legacyService)) {
+        try { run(`systemctl --user stop openclaw-proxy 2>/dev/null`); } catch { /* ignore */ }
+        try { run(`systemctl --user disable openclaw-proxy 2>/dev/null`); } catch { /* ignore */ }
+        try { unlinkPath(legacyService); } catch { /* ignore */ }
+        try { run(`systemctl --user daemon-reload`); } catch { /* ignore */ }
+        log(`Removed legacy systemd service: openclaw-proxy`);
+      }
+    }
+  }
+
+  if (platform === "darwin") {
+    // macOS: launchd
+    const plistDir = join(HOME, "Library", "LaunchAgents");
+    if (!existsPath(plistDir)) makeDir(plistDir, { recursive: true });
+
+    const plistPath = join(plistDir, "dev.ocp.proxy.plist");
+    const logPath = join(ocpLogsDir, "proxy.log");
+
+    const plistXml = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>dev.ocp.proxy</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${nodeBin}</string>
+    <string>${serverPath}</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>CLAUDE_PROXY_PORT</key>
+    <string>${xmlEscape(PORT)}</string>
+    <key>CLAUDE_BIND</key>
+    <string>${xmlEscape(BIND_ADDRESS)}</string>
+    <key>CLAUDE_AUTH_MODE</key>
+    <string>${xmlEscape(AUTH_MODE_CONFIG)}</string>${CLAUDE_BIN_INJECT ? `
+    <key>CLAUDE_BIN</key>
+    <string>${xmlEscape(CLAUDE_BIN_INJECT)}</string>` : ""}${OCP_ADMIN_KEY_INJECT ? `
+    <key>OCP_ADMIN_KEY</key>
+    <string>${xmlEscape(OCP_ADMIN_KEY_INJECT)}</string>` : ""}${PROXY_ANON_KEY_INJECT ? `
+    <key>PROXY_ANONYMOUS_KEY</key>
+    <string>${xmlEscape(PROXY_ANON_KEY_INJECT)}</string>` : ""}
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>${logPath}</string>
+  <key>StandardErrorPath</key>
+  <string>${logPath}</string>
+</dict>
+</plist>
+`;
+
+    const existingPlist = existsPath(plistPath) ? readFile(plistPath, "utf8") : null;
+    const finalPlistXml = mergePlistEnv(existingPlist, plistXml);
+    writeFile(plistPath, finalPlistXml);
+    chmodPath(plistPath, 0o600);
+    if (existingPlist && finalPlistXml !== plistXml) {
+      log(`Plist written: ${plistPath} (mode 600, preserved user env vars)`);
+    } else {
+      log(`Plist written: ${plistPath} (mode 600)`);
+    }
+
+    if (servicePlan.bootstrap) {
+      // Bootout first (in case it was already loaded) then bootstrap
+      try { run(`launchctl bootout gui/$(id -u) "${plistPath}" 2>/dev/null`); } catch { /* ignore */ }
+      run(`launchctl bootstrap gui/$(id -u) "${plistPath}"`);
+      log(`launchctl loaded dev.ocp.proxy`);
+    } else {
+      // Does NOT touch launchd's persistent enable/disable state either way (see
+      // scripts/lib/service-mode.mjs) — only skips loading/starting the job THIS session.
+      log(`Plist written (reconfigure-only: launchctl bootstrap left to the upgrade flow's restart phase)`);
+    }
+
+  } else if (platform === "linux") {
+    // Linux: systemd user service
+    const systemdDir = join(HOME, ".config", "systemd", "user");
+    if (!existsPath(systemdDir)) makeDir(systemdDir, { recursive: true });
+
+    const servicePath = join(systemdDir, "ocp-proxy.service");
+    const logPath = join(ocpLogsDir, "proxy.log");
+
+    const serviceUnit = `[Unit]
+Description=OCP — Open Claude Proxy
+After=network.target
+
+[Service]
+ExecStart=${nodeBin} ${serverPath}
+Environment=CLAUDE_PROXY_PORT=${PORT}
+Environment=CLAUDE_BIND=${BIND_ADDRESS}
+Environment=CLAUDE_AUTH_MODE=${AUTH_MODE_CONFIG}${CLAUDE_BIN_INJECT ? `\nEnvironment=CLAUDE_BIN=${CLAUDE_BIN_INJECT}` : ""}${OCP_ADMIN_KEY_INJECT ? `\nEnvironment=OCP_ADMIN_KEY=${OCP_ADMIN_KEY_INJECT}` : ""}${PROXY_ANON_KEY_INJECT ? `\nEnvironment=PROXY_ANONYMOUS_KEY=${PROXY_ANON_KEY_INJECT}` : ""}
+Restart=always
+RestartSec=5
+StandardOutput=append:${logPath}
+StandardError=append:${logPath}
+
+[Install]
+WantedBy=default.target
+`;
+
+    const existingService = existsPath(servicePath) ? readFile(servicePath, "utf8") : null;
+    const finalServiceUnit = mergeSystemdEnv(existingService, serviceUnit);
+    writeFile(servicePath, finalServiceUnit);
+    chmodPath(servicePath, 0o600);
+    if (existingService && finalServiceUnit !== serviceUnit) {
+      log(`Service file written: ${servicePath} (mode 600, preserved user env vars)`);
+    } else {
+      log(`Service file written: ${servicePath} (mode 600)`);
+    }
+
+    if (servicePlan.daemonReload) run(`systemctl --user daemon-reload`);
+    if (servicePlan.enable) run(`systemctl --user enable ocp-proxy`);
+    if (servicePlan.start) run(`systemctl --user start ocp-proxy`);
+    if (servicePlan.enable && servicePlan.start) {
+      log(`systemd user service enabled and started`);
+    } else {
+      // Note: only `start` is "left to" the restart phase (it issues `systemctl restart`,
+      // which starts a not-yet-running unit fine). `enable` is not deferred to anything — it
+      // is simply left untouched here, preserving whatever it already was.
+      log(`Service file written + daemon-reload'd (reconfigure-only: enable left as-is; start left to the upgrade flow's restart phase)`);
+    }
+
+  } else {
+    warn(`Auto-start not supported on ${platform} — start manually with: bash ${startPath}`);
+  }
+
+  // Banner: only claim "will start automatically" when this run actually attempted to
+  // load/start it (bare install/first-run — not --reconfigure-only, which never runs
+  // `enable`/`start`/`bootstrap` on either platform). This applies uniformly to both
+  // platforms: a first-install bootstrap/enable+start failing against a disabled unit would
+  // already have thrown and killed the script before reaching this banner, so reaching it on
+  // the non-reconfigure-only path is real evidence, not an assumption — whereas
+  // reconfigure-only never attempts either action, so it never gets to claim that evidence
+  // (previously this banner over-claimed unconditionally on darwin; see #226 review M1).
+  if (!platformSupported) {
+    // warn() above already explained it; nothing further to add.
+  } else if (servicePlan.reconfigureOnly) {
+    // Leaves auto-start-on-boot/login state untouched either way (issue #226) — whatever this
+    // unit's enablement already was (first install, or an operator's manual override) is
+    // preserved, not re-asserted. The upgrade flow's restart phase runs next and starts the
+    // service; it does not call `enable` (Linux). launchd's persistent disabled state
+    // (`launchctl enable`/`disable`, distinct from the plist file itself — man 5
+    // launchd.plist) is, as far as this module's own actions go, also simply never touched
+    // either way; whether `bootstrap`/`bootout` themselves have any side effect on that state
+    // is not something `man 1 launchctl` documents either way, so this is stated as "this
+    // module doesn't touch it", not as a claim about bootstrap/bootout's own behavior.
+    print("\n✅ Service config written (--reconfigure-only) — auto-start-on-boot state left as-is; the upgrade flow's restart phase starts the service next\n");
+  } else {
+    print("\n✅ Auto-start installed — proxy will start automatically on login\n");
+  }
+}

--- a/scripts/lib/service-mode.mjs
+++ b/scripts/lib/service-mode.mjs
@@ -2,9 +2,14 @@
 // install). Extracted so the enable/start decision is unit-testable without executing
 // setup.mjs, which has top-level side effects and cannot be imported (confirmed against
 // test-features.mjs's own "setup.mjs cannot be imported (top-level side effects run the
-// installer)" comment — this is NOT documented in AGENTS.md, which only covers server.mjs's
-// testing seams; corrected here after a review caught the file citing AGENTS.md for a claim
-// it doesn't make).
+// installer)" comment — this specific claim about setup.mjs is not itself written in
+// AGENTS.md; a review caught an earlier draft of this comment wrongly attributing it there).
+// AGENTS.md DOES have a directly-relevant, general testing-discipline section — "Testing
+// discipline: what counts as a test" — but it is not the server.mjs-scoped section right
+// above it in that file; it covers ocp-connect and bash `cmd_restart` alike, and it is
+// exactly the section this module's own tests (and scripts/lib/install-autostart.mjs's) have
+// to answer to: behavioral, not textual; mutation-proven; restored from a file backup, never
+// `git checkout`.
 //
 // Issue #226: setup.mjs's Linux branch used to unconditionally run
 //   systemctl --user daemon-reload / enable ocp-proxy / start ocp-proxy

--- a/scripts/lib/service-mode.mjs
+++ b/scripts/lib/service-mode.mjs
@@ -1,7 +1,10 @@
 // scripts/lib/service-mode.mjs — pure decision layer for setup.mjs's "Step 7" (auto-start
 // install). Extracted so the enable/start decision is unit-testable without executing
-// setup.mjs, which has top-level side effects and cannot be imported (see AGENTS.md's
-// testing note, and test-features.mjs's existing "setup.mjs cannot be imported" comment).
+// setup.mjs, which has top-level side effects and cannot be imported (confirmed against
+// test-features.mjs's own "setup.mjs cannot be imported (top-level side effects run the
+// installer)" comment — this is NOT documented in AGENTS.md, which only covers server.mjs's
+// testing seams; corrected here after a review caught the file citing AGENTS.md for a claim
+// it doesn't make).
 //
 // Issue #226: setup.mjs's Linux branch used to unconditionally run
 //   systemctl --user daemon-reload / enable ocp-proxy / start ocp-proxy
@@ -9,15 +12,29 @@
 // it as part of an upgrade. On a host where a competing unit (e.g. a system-scope
 // ocp.service) already owns the listening port, that unconditional `start` produces exactly
 // the orphan #215 describes, and `enable` re-arms the boot race #215 calls "the part that
-// makes it more than cosmetic" — both BEFORE phase 5 (whose job is restarting, and which by
-// #221 resolves unit ownership properly) ever runs. The macOS branch has the same shape:
-// `launchctl bootstrap` both loads AND starts the job (RunAtLoad=true in the plist), so it is
-// phase-4-starts-what-phase-5-should-start on macOS too, independent of which OS/unit family.
+// makes it more than cosmetic" — both BEFORE phase 5 (whose job is restarting) ever runs.
+// NOTE (review correction): phase 5, as it exists on `main` at the time of this PR, is still
+// the pre-#221 hard-coded `systemctl --user restart ocp-proxy.service` — #221 (the
+// restart-target-ownership resolution) is a separate, still-open/unmerged PR. This PR's fix
+// removes phase 4's `enable` re-arm and its `start`, but on the #215 host specifically, phase
+// 5 STILL unconditionally starts the (possibly wrong) `ocp-proxy` unit a few lines later. This
+// module does not, by itself, stop that orphan — it removes half of the #215/#226 defect
+// family (the premature enable + the premature start-before-resolution), not all of it.
+// The macOS branch has the same phase-4-does-phase-5's-job shape: `launchctl bootstrap` both
+// loads AND starts the job (RunAtLoad=true in the plist).
 //
 // planServiceActions() is that decision, made pure: given a platform and whether the caller
 // only wants to reconfigure (write the unit/plist, nothing else), it returns which of the
 // individual systemctl/launchctl actions setup.mjs should take. setup.mjs performs the
 // actions; this module only decides which ones apply.
+//
+// resolveServicePlan() wraps planServiceActions() together with the actual --reconfigure-only
+// argv parse, so the parse-to-decision path setup.mjs relies on is ONE tested function rather
+// than a setup.mjs-local const feeding an imported pure function — closing the gap a review
+// found where the argv parse itself (`flag("reconfigure-only")`, a plain assignment inside the
+// un-importable top-level script) carried none of the actual behavior-changing logic and could
+// be silently hardcoded to `false` (turning the flag into a dead no-op, or worse, reintroducing
+// the #226 defect verbatim) without any test noticing.
 
 /**
  * @param {"linux"|"darwin"|string} platform - process.platform value
@@ -26,8 +43,11 @@
  *   linux:  { daemonReload, enable, start }
  *   darwin: { bootstrap }
  */
-export function planServiceActions(platform, opts = {}) {
-  const reconfigureOnly = !!opts.reconfigureOnly;
+export function planServiceActions(platform, opts) {
+  // Defensive: default parameters only cover `undefined`, not an explicit `null` — a caller
+  // passing `null` (e.g. a mistyped opts threading) must not throw reading `.reconfigureOnly`
+  // off it. Review-flagged robustness gap.
+  const reconfigureOnly = !!(opts && opts.reconfigureOnly);
 
   if (platform === "linux") {
     return {
@@ -44,18 +64,30 @@ export function planServiceActions(platform, opts = {}) {
       // enable-and-start install action should.
       enable: !reconfigureOnly,
       // starting now is phase 5's job (restart), not phase 4's (reconfigure) — see #226.
+      // (See the module-level note above: phase 5 today is still the pre-#221 hard-coded
+      // restart, so removing this `start` does not by itself resolve unit ownership — it only
+      // stops phase 4 from racing ahead of whatever phase 5 does.)
       start: !reconfigureOnly,
     };
   }
 
   if (platform === "darwin") {
     return {
-      // launchd has no separate "enable" step distinct from loading: bootstrap loads AND
-      // starts the job in one call (the plist sets RunAtLoad=true), and a plist's mere
-      // presence under ~/Library/LaunchAgents is what makes launchd auto-load it at the next
-      // login — that "enabled for next boot" state is inherent to writing the file, not to
-      // calling bootstrap. So reconfigure-only still writes the plist; it just skips the
-      // bootstrap call that would start the job immediately in this session.
+      // CORRECTED (review M1 — the previous comment here was wrong and has been removed):
+      // launchd DOES have a persistent enable/disable state, set via `launchctl enable` /
+      // `launchctl disable service-target` and inspectable with `launchctl print-disabled`.
+      // `man 5 launchd.plist` documents the migration explicitly: "Previous Darwin operating
+      // systems would modify the configuration file's value for [the Disabled] key, but now
+      // this state is kept externally" — i.e. NOT in the plist file, in a separate persistent
+      // store, exactly analogous to systemd's enablement symlink. `bootstrap`/`bootout` do not
+      // set or clear that disabled state either way.
+      // So the correct parallel to Linux's `enable` is: --reconfigure-only preserves launchd's
+      // disabled/enabled state THE SAME WAY it preserves systemd's — by not touching it either
+      // way, regardless of this flag. What --reconfigure-only actually controls here is only
+      // whether the job is LOADED AND STARTED in this session: `bootstrap` does both in one
+      // call (RunAtLoad=true in the plist), so gating it is the direct analogue of Linux's
+      // `start` — not of Linux's `enable`, which has no gate here because nothing here touches
+      // enable/disable state on either platform.
       bootstrap: !reconfigureOnly,
     };
   }
@@ -63,4 +95,35 @@ export function planServiceActions(platform, opts = {}) {
   // Unsupported platform: setup.mjs's own auto-start step already warns and no-ops here:
   // nothing for a caller to conditionally skip.
   return {};
+}
+
+// Recognized forms: bare `--reconfigure-only` (enables it) or its absence (disables it). Any
+// `--reconfigure-only=<value>` form is refused rather than silently parsed — a boolean-ish
+// `=true`/`=false` suffix is a natural typo for a flag defined as presence-only, and
+// `args.includes("--reconfigure-only")` treats EITHER suffixed form as "absent", so a typo'd
+// `--reconfigure-only=true` (intending to enable the safety mode) would otherwise silently
+// fall through to full enable+start — the more dangerous of the two behaviors defaulting to
+// "on" for a malformed safety flag is exactly backwards. Review-flagged ("fails open").
+const RECONFIGURE_ONLY_FLAG = "--reconfigure-only";
+
+/**
+ * Parses --reconfigure-only out of argv and folds it into planServiceActions() for the given
+ * platform — the single tested seam setup.mjs calls, so the argv-parse-to-decision path is not
+ * split between an untestable top-level const in setup.mjs and a separately-tested pure
+ * function that never sees real argv.
+ * @param {string[]} argv - e.g. process.argv.slice(2)
+ * @param {"linux"|"darwin"|string} platform
+ * @returns {{ reconfigureOnly: boolean } & object}
+ */
+export function resolveServicePlan(argv, platform) {
+  const list = Array.isArray(argv) ? argv : [];
+  const malformed = list.find(a => a !== RECONFIGURE_ONLY_FLAG && a.startsWith(`${RECONFIGURE_ONLY_FLAG}=`));
+  if (malformed) {
+    throw new Error(
+      `${RECONFIGURE_ONLY_FLAG} takes no value (got "${malformed}") — pass it bare to enable, ` +
+      `omit it to disable. Refusing rather than silently defaulting to full enable+start.`
+    );
+  }
+  const reconfigureOnly = list.includes(RECONFIGURE_ONLY_FLAG);
+  return { reconfigureOnly, ...planServiceActions(platform, { reconfigureOnly }) };
 }

--- a/scripts/lib/service-mode.mjs
+++ b/scripts/lib/service-mode.mjs
@@ -1,0 +1,66 @@
+// scripts/lib/service-mode.mjs — pure decision layer for setup.mjs's "Step 7" (auto-start
+// install). Extracted so the enable/start decision is unit-testable without executing
+// setup.mjs, which has top-level side effects and cannot be imported (see AGENTS.md's
+// testing note, and test-features.mjs's existing "setup.mjs cannot be imported" comment).
+//
+// Issue #226: setup.mjs's Linux branch used to unconditionally run
+//   systemctl --user daemon-reload / enable ocp-proxy / start ocp-proxy
+// every time it ran — including when scripts/upgrade.mjs's phase 4 ("reconfigure") invokes
+// it as part of an upgrade. On a host where a competing unit (e.g. a system-scope
+// ocp.service) already owns the listening port, that unconditional `start` produces exactly
+// the orphan #215 describes, and `enable` re-arms the boot race #215 calls "the part that
+// makes it more than cosmetic" — both BEFORE phase 5 (whose job is restarting, and which by
+// #221 resolves unit ownership properly) ever runs. The macOS branch has the same shape:
+// `launchctl bootstrap` both loads AND starts the job (RunAtLoad=true in the plist), so it is
+// phase-4-starts-what-phase-5-should-start on macOS too, independent of which OS/unit family.
+//
+// planServiceActions() is that decision, made pure: given a platform and whether the caller
+// only wants to reconfigure (write the unit/plist, nothing else), it returns which of the
+// individual systemctl/launchctl actions setup.mjs should take. setup.mjs performs the
+// actions; this module only decides which ones apply.
+
+/**
+ * @param {"linux"|"darwin"|string} platform - process.platform value
+ * @param {{ reconfigureOnly?: boolean }} [opts]
+ * @returns {object} platform-specific action flags; unsupported platforms get {}
+ *   linux:  { daemonReload, enable, start }
+ *   darwin: { bootstrap }
+ */
+export function planServiceActions(platform, opts = {}) {
+  const reconfigureOnly = !!opts.reconfigureOnly;
+
+  if (platform === "linux") {
+    return {
+      // daemon-reload only refreshes systemd's in-memory cache of unit files from disk — it
+      // does not start or enable anything, so it carries none of #226's risk. It DOES need to
+      // stay unconditional: skipping it after writing an updated unit file means a later
+      // `systemctl restart` (whichever phase/tool issues it) would restart against the STALE
+      // cached definition, not the one just written — the same failure mode PR #221's MED-8
+      // finding fixed on the rollback path, and this repo's own
+      // docs/runbooks/tui-flip-rollback.md documents as required after any unit-file rewrite.
+      daemonReload: true,
+      // enabling arms/re-arms "start this unit on next boot" — exactly the boot race #215
+      // describes. A reconfigure step must not touch that; only an explicit
+      // enable-and-start install action should.
+      enable: !reconfigureOnly,
+      // starting now is phase 5's job (restart), not phase 4's (reconfigure) — see #226.
+      start: !reconfigureOnly,
+    };
+  }
+
+  if (platform === "darwin") {
+    return {
+      // launchd has no separate "enable" step distinct from loading: bootstrap loads AND
+      // starts the job in one call (the plist sets RunAtLoad=true), and a plist's mere
+      // presence under ~/Library/LaunchAgents is what makes launchd auto-load it at the next
+      // login — that "enabled for next boot" state is inherent to writing the file, not to
+      // calling bootstrap. So reconfigure-only still writes the plist; it just skips the
+      // bootstrap call that would start the job immediately in this session.
+      bootstrap: !reconfigureOnly,
+    };
+  }
+
+  // Unsupported platform: setup.mjs's own auto-start step already warns and no-ops here:
+  // nothing for a caller to conditionally skip.
+  return {};
+}

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -98,7 +98,7 @@ export async function runUpgrade(opts = {}) {
     if (kind === "upgrade") {
       plan.push(`[plan] phase 1: snapshot to ~/.ocp/upgrade-snapshot-<ts>/`);
       plan.push(`[plan] phase 2: git checkout ${doctor.latest_version} && npm install`);
-      plan.push(`[plan] phase 3: node setup.mjs`);
+      plan.push(`[plan] phase 3: node setup.mjs --reconfigure-only`);
       plan.push(`[plan] phase 4: launchctl bootout/bootstrap`);
       plan.push(`[plan] phase 5: post-flight /health + /v1/models`);
     } else if (kind === "update") {
@@ -178,8 +178,13 @@ async function runFullUpgrade({ doctor, opts }) {
     exec(`git -C ${ocpDir} checkout ${doctor.latest_version}`, "fetch+install");
     exec(`npm --prefix ${ocpDir} install --no-audit --no-fund`, "fetch+install");
 
-    // phase 4: reconfigure
-    exec(`node ${ocpDir}/setup.mjs`, "reconfigure");
+    // phase 4: reconfigure — writes the service unit/plist ONLY; must not enable-at-boot or
+    // start (issue #226). Enabling/starting here bypasses phase 5's restart-target resolution
+    // (#221) and can re-arm the boot race #215 describes on a host with a competing unit for
+    // the same port. --reconfigure-only is setup.mjs's opt-in mode for exactly this call site
+    // (see scripts/lib/service-mode.mjs); a bare first install still calls setup.mjs without
+    // it (scripts/doctor.mjs's fresh_install path), so it keeps enabling + starting.
+    exec(`node ${ocpDir}/setup.mjs --reconfigure-only`, "reconfigure");
 
     // phase 5: restart (heads-up note printed before invoking)
     if (!opts.mockExec) {

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -178,12 +178,20 @@ async function runFullUpgrade({ doctor, opts }) {
     exec(`git -C ${ocpDir} checkout ${doctor.latest_version}`, "fetch+install");
     exec(`npm --prefix ${ocpDir} install --no-audit --no-fund`, "fetch+install");
 
-    // phase 4: reconfigure — writes the service unit/plist ONLY; must not enable-at-boot or
-    // start (issue #226). Enabling/starting here bypasses phase 5's restart-target resolution
-    // (#221) and can re-arm the boot race #215 describes on a host with a competing unit for
-    // the same port. --reconfigure-only is setup.mjs's opt-in mode for exactly this call site
-    // (see scripts/lib/service-mode.mjs); a bare first install still calls setup.mjs without
-    // it (scripts/doctor.mjs's fresh_install path), so it keeps enabling + starting.
+    // phase 4: reconfigure — writes the service unit/plist ONLY (config + legacy-unit
+    // migration are both gated on --reconfigure-only inside setup.mjs; see
+    // scripts/lib/service-mode.mjs); must not enable-at-boot or start (issue #226). Enabling
+    // re-arms the boot race #215 describes on a host with a competing unit for the same port.
+    // CORRECTION (review finding M2): this does NOT by itself stop #215's orphan. Phase 5
+    // below is still the pre-#221 hard-coded `systemctl --user restart ocp-proxy.service` —
+    // #221 (restart-target-ownership resolution) is a separate PR, open/unmerged as of this
+    // change. On the #215 host, phase 5 still unconditionally starts `ocp-proxy` a few lines
+    // down, regardless of what phase 4 does. What this fix removes is phase 4's premature
+    // `enable` (the boot-race re-arm) and its premature `start` (racing ahead of whatever
+    // phase 5 does) — half of the #215/#226 defect family, not all of it. --reconfigure-only
+    // is setup.mjs's opt-in mode for exactly this call site; a bare first install still calls
+    // setup.mjs without it (scripts/doctor.mjs's fresh_install path), so it keeps enabling +
+    // starting, which is that path's actual job.
     exec(`node ${ocpDir}/setup.mjs --reconfigure-only`, "reconfigure");
 
     // phase 5: restart (heads-up note printed before invoking)

--- a/setup.mjs
+++ b/setup.mjs
@@ -17,7 +17,7 @@
  */
 import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync, readdirSync, chmodSync } from "node:fs";
 import { mergePlistEnv, mergeSystemdEnv } from "./scripts/lib/plist-merge.mjs";
-import { planServiceActions } from "./scripts/lib/service-mode.mjs";
+import { resolveServicePlan } from "./scripts/lib/service-mode.mjs";
 import { execSync } from "node:child_process";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
@@ -47,7 +47,10 @@ const SKIP_START = flag("no-start");
 // scripts/lib/service-mode.mjs for the full reasoning. Not used on a first install: that path
 // (scripts/doctor.mjs's fresh_install ai_executable) invokes `node setup.mjs` bare, and must
 // keep enabling + starting — that IS a first install's job.
-const RECONFIGURE_ONLY = flag("reconfigure-only");
+// NOT parsed as a bare `flag()` const here like the others above: the parse itself is folded
+// into scripts/lib/service-mode.mjs's resolveServicePlan(args, platform) (called below, once
+// `platform` is known), so the argv-to-behavior path is one tested function rather than a
+// setup.mjs-local assignment that no test can reach.
 const PROVIDER_NAME = opt("provider-name", "claude-local");
 const BIND_ADDRESS = opt("bind", "127.0.0.1");
 const AUTH_MODE_CONFIG = opt("auth-mode", "none");
@@ -379,14 +382,11 @@ if (!DRY_RUN) {
   console.log("\n🔄 Installing auto-start on login...\n");
 
   const platform = process.platform;
-  // Tracks whether THIS run actually arms "start automatically on login/boot" — used to keep
-  // the banner below honest under --reconfigure-only. Defaults true: on macOS, writing the
-  // plist into ~/Library/LaunchAgents is itself what arms next-login auto-start (launchd scans
-  // that directory at every login regardless of whether `bootstrap` ran this session), so
-  // reconfigure-only doesn't change that half. On Linux, auto-start-on-boot is the systemd
-  // `enable` step specifically — writing the unit file alone does not arm it — so the Linux
-  // branch below flips this to false when --reconfigure-only skips `enable`.
-  let autoStartArmed = true;
+  const platformSupported = platform === "darwin" || platform === "linux";
+  // Single tested seam bridging argv → behavior (see scripts/lib/service-mode.mjs). Computed
+  // once here (platform is now known) and used for every reconfigure-only-sensitive decision
+  // below — the action gates, the post-install banner, and Step 8's verification gate.
+  const servicePlan = resolveServicePlan(args, platform);
   // Use stable symlink path instead of versioned Cellar path (e.g. /opt/homebrew/opt/node/bin/node
   // instead of /opt/homebrew/Cellar/node/25.8.0/bin/node) so the plist survives node upgrades.
   let nodeBin = process.execPath;
@@ -412,22 +412,37 @@ if (!DRY_RUN) {
   // without an explicit mode that parent lands at the umask default (world-listable 0755).
   if (!existsSync(ocpLogsDir)) mkdirSync(ocpLogsDir, { recursive: true, mode: 0o700 });
 
-  // Uninstall legacy service names if present (upgrade path)
-  if (platform === "darwin") {
-    const legacyPlist = join(HOME, "Library", "LaunchAgents", "ai.openclaw.proxy.plist");
-    if (existsSync(legacyPlist)) {
-      try { execSync(`launchctl bootout gui/$(id -u) "${legacyPlist}" 2>/dev/null`); } catch { /* ignore */ }
-      try { unlinkSync(legacyPlist); } catch { /* ignore */ }
-      log(`Removed legacy plist: ai.openclaw.proxy`);
-    }
-  } else if (platform === "linux") {
-    const legacyService = join(HOME, ".config", "systemd", "user", "openclaw-proxy.service");
-    if (existsSync(legacyService)) {
-      try { execSync(`systemctl --user stop openclaw-proxy 2>/dev/null`); } catch { /* ignore */ }
-      try { execSync(`systemctl --user disable openclaw-proxy 2>/dev/null`); } catch { /* ignore */ }
-      try { unlinkSync(legacyService); } catch { /* ignore */ }
-      try { execSync(`systemctl --user daemon-reload`); } catch { /* ignore */ }
-      log(`Removed legacy systemd service: openclaw-proxy`);
+  // Uninstall legacy service names if present (upgrade path). Gated on !reconfigureOnly
+  // (issue #226 review, finding H1): stopping, disabling, and deleting a service is exactly
+  // the phase-5-shaped action this PR exists to keep out of phase 4 — regardless of WHICH
+  // unit it targets, "only write config" cannot also mean "and stop/disable/delete a
+  // different one". Left ungated, a host that auto-started via the legacy unit would end this
+  // run with NO enabled unit at all (legacy disabled+deleted here, new unit's `enable` skipped
+  // by reconfigure-only) — invisible until the next reboot. Reconfigure-only therefore leaves
+  // any pre-v3.4.0 legacy unit untouched; migrating away from it remains a bare
+  // `node setup.mjs` (first install / fresh_install) job, same as it always was. In practice
+  // this is very close to unreachable via scripts/upgrade.mjs's phase 4 specifically — doctor
+  // gates that cross-minor "upgrade" path (the only caller of --reconfigure-only) at
+  // >= v3.4.0, already past the v3.1.0 rename that produced these legacy names — but the
+  // gate lives here regardless, since the contract ("reconfigure-only touches only this
+  // unit's own config") should hold even where it's never exercised.
+  if (!servicePlan.reconfigureOnly) {
+    if (platform === "darwin") {
+      const legacyPlist = join(HOME, "Library", "LaunchAgents", "ai.openclaw.proxy.plist");
+      if (existsSync(legacyPlist)) {
+        try { execSync(`launchctl bootout gui/$(id -u) "${legacyPlist}" 2>/dev/null`); } catch { /* ignore */ }
+        try { unlinkSync(legacyPlist); } catch { /* ignore */ }
+        log(`Removed legacy plist: ai.openclaw.proxy`);
+      }
+    } else if (platform === "linux") {
+      const legacyService = join(HOME, ".config", "systemd", "user", "openclaw-proxy.service");
+      if (existsSync(legacyService)) {
+        try { execSync(`systemctl --user stop openclaw-proxy 2>/dev/null`); } catch { /* ignore */ }
+        try { execSync(`systemctl --user disable openclaw-proxy 2>/dev/null`); } catch { /* ignore */ }
+        try { unlinkSync(legacyService); } catch { /* ignore */ }
+        try { execSync(`systemctl --user daemon-reload`); } catch { /* ignore */ }
+        log(`Removed legacy systemd service: openclaw-proxy`);
+      }
     }
   }
 
@@ -487,13 +502,14 @@ if (!DRY_RUN) {
       log(`Plist written: ${plistPath} (mode 600)`);
     }
 
-    const darwinActions = planServiceActions(platform, { reconfigureOnly: RECONFIGURE_ONLY });
-    if (darwinActions.bootstrap) {
+    if (servicePlan.bootstrap) {
       // Bootout first (in case it was already loaded) then bootstrap
       try { execSync(`launchctl bootout gui/$(id -u) "${plistPath}" 2>/dev/null`); } catch { /* ignore */ }
       execSync(`launchctl bootstrap gui/$(id -u) "${plistPath}"`);
       log(`launchctl loaded dev.ocp.proxy`);
     } else {
+      // Does NOT touch launchd's persistent enable/disable state either way (see
+      // scripts/lib/service-mode.mjs) — only skips loading/starting the job THIS session.
       log(`Plist written (reconfigure-only: launchctl bootstrap left to the upgrade flow's restart phase)`);
     }
 
@@ -533,11 +549,10 @@ WantedBy=default.target
       log(`Service file written: ${servicePath} (mode 600)`);
     }
 
-    const linuxActions = planServiceActions(platform, { reconfigureOnly: RECONFIGURE_ONLY });
-    if (linuxActions.daemonReload) execSync(`systemctl --user daemon-reload`);
-    if (linuxActions.enable) execSync(`systemctl --user enable ocp-proxy`);
-    if (linuxActions.start) execSync(`systemctl --user start ocp-proxy`);
-    if (linuxActions.enable && linuxActions.start) {
+    if (servicePlan.daemonReload) execSync(`systemctl --user daemon-reload`);
+    if (servicePlan.enable) execSync(`systemctl --user enable ocp-proxy`);
+    if (servicePlan.start) execSync(`systemctl --user start ocp-proxy`);
+    if (servicePlan.enable && servicePlan.start) {
       log(`systemd user service enabled and started`);
     } else {
       // Note: only `start` is "left to" the restart phase (it issues `systemctl restart`,
@@ -545,31 +560,36 @@ WantedBy=default.target
       // is simply left untouched here, preserving whatever it already was.
       log(`Service file written + daemon-reload'd (reconfigure-only: enable left as-is; start left to the upgrade flow's restart phase)`);
     }
-    // Unlike the darwin branch, Linux auto-start-on-boot IS the `enable` step — a written but
-    // un-enabled unit file will not start at next boot on its own.
-    autoStartArmed = linuxActions.enable;
 
   } else {
     warn(`Auto-start not supported on ${platform} — start manually with: bash ${startPath}`);
-    autoStartArmed = false; // nothing was written or loaded on this platform
   }
 
-  if (autoStartArmed) {
-    console.log("\n✅ Auto-start installed — proxy will start automatically on login\n");
-  } else if (RECONFIGURE_ONLY) {
-    // --reconfigure-only intentionally leaves auto-start-on-boot state untouched (issue #226)
-    // — it neither arms nor disarms it, so whatever this unit's enablement already was (set by
-    // the original first install, or by an operator's manual override) is preserved. The
-    // upgrade flow's restart phase runs next and starts the service; it does not call `enable`.
+  // Banner: only claim "will start automatically" when this run actually attempted to
+  // load/start it (bare install/first-run — not --reconfigure-only, which never runs
+  // `enable`/`start`/`bootstrap` on either platform). This applies uniformly to both
+  // platforms: a first-install bootstrap/enable+start failing against a disabled unit would
+  // already have thrown and killed the script before reaching this banner, so reaching it on
+  // the non-reconfigure-only path is real evidence, not an assumption — whereas
+  // reconfigure-only never attempts either action, so it never gets to claim that evidence
+  // (previously this banner over-claimed unconditionally on darwin; see #226 review M1).
+  if (!platformSupported) {
+    // warn() above already explained it; nothing further to add.
+  } else if (servicePlan.reconfigureOnly) {
+    // Leaves auto-start-on-boot/login state untouched either way (issue #226) — whatever this
+    // unit's enablement already was (first install, or an operator's manual override) is
+    // preserved, not re-asserted. The upgrade flow's restart phase runs next and starts the
+    // service; it does not call `enable` (Linux) or touch launchd's disabled state (macOS).
     console.log("\n✅ Service config written (--reconfigure-only) — auto-start-on-boot state left as-is; the upgrade flow's restart phase starts the service next\n");
+  } else {
+    console.log("\n✅ Auto-start installed — proxy will start automatically on login\n");
   }
-  // else: unsupported platform — the warn() above already explained it; nothing further to add.
 
   // ── Step 8: Post-install health verification ───────────────────────────
   // Skipped under --reconfigure-only too: nothing was started above, so there is nothing
   // yet to verify — the upgrade flow's own post-flight phase (phase 6) checks the real
   // post-restart state after phase 5 actually restarts the service.
-  if (!SKIP_START && !RECONFIGURE_ONLY) {
+  if (!SKIP_START && !servicePlan.reconfigureOnly) {
     console.log("⏳ Waiting for server to bind...\n");
     await new Promise(r => setTimeout(r, 3000));
 

--- a/setup.mjs
+++ b/setup.mjs
@@ -3,8 +3,10 @@
  * OCP (Open Claude Proxy) setup
  *
  * Automatically configures OpenClaw to use Claude CLI as a model provider.
- * Run: node setup.mjs [--port N] [--default-model opus|sonnet|haiku] [--dry-run]
+ * Run: node setup.mjs [--port N] [--default-model opus|sonnet|haiku] [--dry-run] [--reconfigure-only]
  *      (default port = DEFAULT_PORT from lib/constants.mjs)
+ *      --reconfigure-only: write the service unit/plist but do not enable-at-boot or start it
+ *        now (used by `ocp update`'s reconfigure phase; see scripts/lib/service-mode.mjs)
  *
  * What it does:
  *   1. Verifies claude CLI is installed and authenticated
@@ -15,6 +17,7 @@
  */
 import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync, readdirSync, chmodSync } from "node:fs";
 import { mergePlistEnv, mergeSystemdEnv } from "./scripts/lib/plist-merge.mjs";
+import { planServiceActions } from "./scripts/lib/service-mode.mjs";
 import { execSync } from "node:child_process";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
@@ -38,6 +41,13 @@ const PORT = parseInt(opt("port", String(DEFAULT_PORT)), 10);
 const DEFAULT_MODEL = opt("default-model", "opus"); // opus | sonnet | haiku
 const DRY_RUN = flag("dry-run");
 const SKIP_START = flag("no-start");
+// --reconfigure-only (issue #226): write the service unit / plist, but never enable-at-boot
+// or start-now. For use by scripts/upgrade.mjs's phase 4 ("reconfigure"), so an upgrade's
+// installer step stops performing phase 5's job (starting the service) — see
+// scripts/lib/service-mode.mjs for the full reasoning. Not used on a first install: that path
+// (scripts/doctor.mjs's fresh_install ai_executable) invokes `node setup.mjs` bare, and must
+// keep enabling + starting — that IS a first install's job.
+const RECONFIGURE_ONLY = flag("reconfigure-only");
 const PROVIDER_NAME = opt("provider-name", "claude-local");
 const BIND_ADDRESS = opt("bind", "127.0.0.1");
 const AUTH_MODE_CONFIG = opt("auth-mode", "none");
@@ -369,6 +379,14 @@ if (!DRY_RUN) {
   console.log("\n🔄 Installing auto-start on login...\n");
 
   const platform = process.platform;
+  // Tracks whether THIS run actually arms "start automatically on login/boot" — used to keep
+  // the banner below honest under --reconfigure-only. Defaults true: on macOS, writing the
+  // plist into ~/Library/LaunchAgents is itself what arms next-login auto-start (launchd scans
+  // that directory at every login regardless of whether `bootstrap` ran this session), so
+  // reconfigure-only doesn't change that half. On Linux, auto-start-on-boot is the systemd
+  // `enable` step specifically — writing the unit file alone does not arm it — so the Linux
+  // branch below flips this to false when --reconfigure-only skips `enable`.
+  let autoStartArmed = true;
   // Use stable symlink path instead of versioned Cellar path (e.g. /opt/homebrew/opt/node/bin/node
   // instead of /opt/homebrew/Cellar/node/25.8.0/bin/node) so the plist survives node upgrades.
   let nodeBin = process.execPath;
@@ -469,10 +487,15 @@ if (!DRY_RUN) {
       log(`Plist written: ${plistPath} (mode 600)`);
     }
 
-    // Bootout first (in case it was already loaded) then bootstrap
-    try { execSync(`launchctl bootout gui/$(id -u) "${plistPath}" 2>/dev/null`); } catch { /* ignore */ }
-    execSync(`launchctl bootstrap gui/$(id -u) "${plistPath}"`);
-    log(`launchctl loaded dev.ocp.proxy`);
+    const darwinActions = planServiceActions(platform, { reconfigureOnly: RECONFIGURE_ONLY });
+    if (darwinActions.bootstrap) {
+      // Bootout first (in case it was already loaded) then bootstrap
+      try { execSync(`launchctl bootout gui/$(id -u) "${plistPath}" 2>/dev/null`); } catch { /* ignore */ }
+      execSync(`launchctl bootstrap gui/$(id -u) "${plistPath}"`);
+      log(`launchctl loaded dev.ocp.proxy`);
+    } else {
+      log(`Plist written (reconfigure-only: launchctl bootstrap left to the upgrade flow's restart phase)`);
+    }
 
   } else if (platform === "linux") {
     // Linux: systemd user service
@@ -510,19 +533,43 @@ WantedBy=default.target
       log(`Service file written: ${servicePath} (mode 600)`);
     }
 
-    execSync(`systemctl --user daemon-reload`);
-    execSync(`systemctl --user enable ocp-proxy`);
-    execSync(`systemctl --user start ocp-proxy`);
-    log(`systemd user service enabled and started`);
+    const linuxActions = planServiceActions(platform, { reconfigureOnly: RECONFIGURE_ONLY });
+    if (linuxActions.daemonReload) execSync(`systemctl --user daemon-reload`);
+    if (linuxActions.enable) execSync(`systemctl --user enable ocp-proxy`);
+    if (linuxActions.start) execSync(`systemctl --user start ocp-proxy`);
+    if (linuxActions.enable && linuxActions.start) {
+      log(`systemd user service enabled and started`);
+    } else {
+      // Note: only `start` is "left to" the restart phase (it issues `systemctl restart`,
+      // which starts a not-yet-running unit fine). `enable` is not deferred to anything — it
+      // is simply left untouched here, preserving whatever it already was.
+      log(`Service file written + daemon-reload'd (reconfigure-only: enable left as-is; start left to the upgrade flow's restart phase)`);
+    }
+    // Unlike the darwin branch, Linux auto-start-on-boot IS the `enable` step — a written but
+    // un-enabled unit file will not start at next boot on its own.
+    autoStartArmed = linuxActions.enable;
 
   } else {
     warn(`Auto-start not supported on ${platform} — start manually with: bash ${startPath}`);
+    autoStartArmed = false; // nothing was written or loaded on this platform
   }
 
-  console.log("\n✅ Auto-start installed — proxy will start automatically on login\n");
+  if (autoStartArmed) {
+    console.log("\n✅ Auto-start installed — proxy will start automatically on login\n");
+  } else if (RECONFIGURE_ONLY) {
+    // --reconfigure-only intentionally leaves auto-start-on-boot state untouched (issue #226)
+    // — it neither arms nor disarms it, so whatever this unit's enablement already was (set by
+    // the original first install, or by an operator's manual override) is preserved. The
+    // upgrade flow's restart phase runs next and starts the service; it does not call `enable`.
+    console.log("\n✅ Service config written (--reconfigure-only) — auto-start-on-boot state left as-is; the upgrade flow's restart phase starts the service next\n");
+  }
+  // else: unsupported platform — the warn() above already explained it; nothing further to add.
 
   // ── Step 8: Post-install health verification ───────────────────────────
-  if (!SKIP_START) {
+  // Skipped under --reconfigure-only too: nothing was started above, so there is nothing
+  // yet to verify — the upgrade flow's own post-flight phase (phase 6) checks the real
+  // post-restart state after phase 5 actually restarts the service.
+  if (!SKIP_START && !RECONFIGURE_ONLY) {
     console.log("⏳ Waiting for server to bind...\n");
     await new Promise(r => setTimeout(r, 3000));
 

--- a/setup.mjs
+++ b/setup.mjs
@@ -15,9 +15,9 @@
  *   4. Creates start.sh for easy launch
  *   5. Optionally starts the proxy
  */
-import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync, readdirSync, chmodSync } from "node:fs";
-import { mergePlistEnv, mergeSystemdEnv } from "./scripts/lib/plist-merge.mjs";
+import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
 import { resolveServicePlan } from "./scripts/lib/service-mode.mjs";
+import { installAutoStart } from "./scripts/lib/install-autostart.mjs";
 import { execSync } from "node:child_process";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
@@ -79,10 +79,6 @@ const OCP_ADMIN_KEY_INJECT = process.env.OCP_ADMIN_KEY || null;
 const PROXY_ANON_KEY_INJECT = process.env.PROXY_ANONYMOUS_KEY || null;
 
 // ── Inject-value helpers ─────────────────────────────────────────────────
-// Escape a value for safe inclusion in a plist <string>…</string> body.
-function xmlEscape(v) {
-  return String(v).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
-}
 // Validate an injected service value: no control chars (a newline would inject a
 // rogue systemd Environment= directive; other control chars corrupt the unit/plist).
 // Spaces are allowed — filesystem paths (CLAUDE_BIN) may legitimately contain them.
@@ -379,211 +375,27 @@ if (DRY_RUN) {
 }
 
 if (!DRY_RUN) {
-  console.log("\n🔄 Installing auto-start on login...\n");
-
   const platform = process.platform;
-  const platformSupported = platform === "darwin" || platform === "linux";
   // Single tested seam bridging argv → behavior (see scripts/lib/service-mode.mjs). Computed
-  // once here (platform is now known) and used for every reconfigure-only-sensitive decision
-  // below — the action gates, the post-install banner, and Step 8's verification gate.
+  // once here (platform is now known) and used both by installAutoStart() below and by Step
+  // 8's verification gate.
   const servicePlan = resolveServicePlan(args, platform);
-  // Use stable symlink path instead of versioned Cellar path (e.g. /opt/homebrew/opt/node/bin/node
-  // instead of /opt/homebrew/Cellar/node/25.8.0/bin/node) so the plist survives node upgrades.
-  let nodeBin = process.execPath;
-  if (platform === "darwin" && nodeBin.includes("/Cellar/")) {
-    const stable = nodeBin.replace(/\/Cellar\/[^/]+\/[^/]+\//, "/opt/");
-    if (existsSync(stable)) {
-      nodeBin = stable;
-      log(`Using stable node path: ${nodeBin}`);
-    }
-  }
 
-  // Ensure logs dir exists
-  const logsDir = join(OPENCLAW_DIR, "logs");
-  if (!existsSync(logsDir)) mkdirSync(logsDir, { recursive: true });
-
-  // Use neutral service names to avoid OpenClaw gateway's extra-service detection.
-  // OpenClaw scans LaunchAgent plists and systemd units for "openclaw" / "clawdbot"
-  // markers and flags them as conflicting gateway-like services. Using "dev.ocp.*"
-  // and "ocp-proxy" keeps the proxy invisible to that heuristic.
-  const OCP_HOME = join(HOME, ".ocp");
-  const ocpLogsDir = join(OCP_HOME, "logs");
-  // mode 0700: with `recursive`, this call can create ~/.ocp ITSELF on a fresh install, and
-  // without an explicit mode that parent lands at the umask default (world-listable 0755).
-  if (!existsSync(ocpLogsDir)) mkdirSync(ocpLogsDir, { recursive: true, mode: 0o700 });
-
-  // Uninstall legacy service names if present (upgrade path). Gated on !reconfigureOnly
-  // (issue #226 review, finding H1): stopping, disabling, and deleting a service is exactly
-  // the phase-5-shaped action this PR exists to keep out of phase 4 — regardless of WHICH
-  // unit it targets, "only write config" cannot also mean "and stop/disable/delete a
-  // different one". Left ungated, a host that auto-started via the legacy unit would end this
-  // run with NO enabled unit at all (legacy disabled+deleted here, new unit's `enable` skipped
-  // by reconfigure-only) — invisible until the next reboot. Reconfigure-only therefore leaves
-  // any pre-v3.4.0 legacy unit untouched; migrating away from it remains a bare
-  // `node setup.mjs` (first install / fresh_install) job, same as it always was. In practice
-  // this is very close to unreachable via scripts/upgrade.mjs's phase 4 specifically — doctor
-  // gates that cross-minor "upgrade" path (the only caller of --reconfigure-only) at
-  // >= v3.4.0, already past the v3.1.0 rename that produced these legacy names — but the
-  // gate lives here regardless, since the contract ("reconfigure-only touches only this
-  // unit's own config") should hold even where it's never exercised.
-  if (!servicePlan.reconfigureOnly) {
-    if (platform === "darwin") {
-      const legacyPlist = join(HOME, "Library", "LaunchAgents", "ai.openclaw.proxy.plist");
-      if (existsSync(legacyPlist)) {
-        try { execSync(`launchctl bootout gui/$(id -u) "${legacyPlist}" 2>/dev/null`); } catch { /* ignore */ }
-        try { unlinkSync(legacyPlist); } catch { /* ignore */ }
-        log(`Removed legacy plist: ai.openclaw.proxy`);
-      }
-    } else if (platform === "linux") {
-      const legacyService = join(HOME, ".config", "systemd", "user", "openclaw-proxy.service");
-      if (existsSync(legacyService)) {
-        try { execSync(`systemctl --user stop openclaw-proxy 2>/dev/null`); } catch { /* ignore */ }
-        try { execSync(`systemctl --user disable openclaw-proxy 2>/dev/null`); } catch { /* ignore */ }
-        try { unlinkSync(legacyService); } catch { /* ignore */ }
-        try { execSync(`systemctl --user daemon-reload`); } catch { /* ignore */ }
-        log(`Removed legacy systemd service: openclaw-proxy`);
-      }
-    }
-  }
-
-  if (platform === "darwin") {
-    // macOS: launchd
-    const plistDir = join(HOME, "Library", "LaunchAgents");
-    if (!existsSync(plistDir)) mkdirSync(plistDir, { recursive: true });
-
-    const plistPath = join(plistDir, "dev.ocp.proxy.plist");
-    const logPath = join(ocpLogsDir, "proxy.log");
-
-    const plistXml = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key>
-  <string>dev.ocp.proxy</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>${nodeBin}</string>
-    <string>${serverPath}</string>
-  </array>
-  <key>EnvironmentVariables</key>
-  <dict>
-    <key>CLAUDE_PROXY_PORT</key>
-    <string>${xmlEscape(PORT)}</string>
-    <key>CLAUDE_BIND</key>
-    <string>${xmlEscape(BIND_ADDRESS)}</string>
-    <key>CLAUDE_AUTH_MODE</key>
-    <string>${xmlEscape(AUTH_MODE_CONFIG)}</string>${CLAUDE_BIN_INJECT ? `
-    <key>CLAUDE_BIN</key>
-    <string>${xmlEscape(CLAUDE_BIN_INJECT)}</string>` : ""}${OCP_ADMIN_KEY_INJECT ? `
-    <key>OCP_ADMIN_KEY</key>
-    <string>${xmlEscape(OCP_ADMIN_KEY_INJECT)}</string>` : ""}${PROXY_ANON_KEY_INJECT ? `
-    <key>PROXY_ANONYMOUS_KEY</key>
-    <string>${xmlEscape(PROXY_ANON_KEY_INJECT)}</string>` : ""}
-  </dict>
-  <key>RunAtLoad</key>
-  <true/>
-  <key>KeepAlive</key>
-  <true/>
-  <key>StandardOutPath</key>
-  <string>${logPath}</string>
-  <key>StandardErrorPath</key>
-  <string>${logPath}</string>
-</dict>
-</plist>
-`;
-
-    const existingPlist = existsSync(plistPath) ? readFileSync(plistPath, "utf8") : null;
-    const finalPlistXml = mergePlistEnv(existingPlist, plistXml);
-    writeFileSync(plistPath, finalPlistXml);
-    chmodSync(plistPath, 0o600);
-    if (existingPlist && finalPlistXml !== plistXml) {
-      log(`Plist written: ${plistPath} (mode 600, preserved user env vars)`);
-    } else {
-      log(`Plist written: ${plistPath} (mode 600)`);
-    }
-
-    if (servicePlan.bootstrap) {
-      // Bootout first (in case it was already loaded) then bootstrap
-      try { execSync(`launchctl bootout gui/$(id -u) "${plistPath}" 2>/dev/null`); } catch { /* ignore */ }
-      execSync(`launchctl bootstrap gui/$(id -u) "${plistPath}"`);
-      log(`launchctl loaded dev.ocp.proxy`);
-    } else {
-      // Does NOT touch launchd's persistent enable/disable state either way (see
-      // scripts/lib/service-mode.mjs) — only skips loading/starting the job THIS session.
-      log(`Plist written (reconfigure-only: launchctl bootstrap left to the upgrade flow's restart phase)`);
-    }
-
-  } else if (platform === "linux") {
-    // Linux: systemd user service
-    const systemdDir = join(HOME, ".config", "systemd", "user");
-    if (!existsSync(systemdDir)) mkdirSync(systemdDir, { recursive: true });
-
-    const servicePath = join(systemdDir, "ocp-proxy.service");
-    const logPath = join(ocpLogsDir, "proxy.log");
-
-    const serviceUnit = `[Unit]
-Description=OCP — Open Claude Proxy
-After=network.target
-
-[Service]
-ExecStart=${nodeBin} ${serverPath}
-Environment=CLAUDE_PROXY_PORT=${PORT}
-Environment=CLAUDE_BIND=${BIND_ADDRESS}
-Environment=CLAUDE_AUTH_MODE=${AUTH_MODE_CONFIG}${CLAUDE_BIN_INJECT ? `\nEnvironment=CLAUDE_BIN=${CLAUDE_BIN_INJECT}` : ""}${OCP_ADMIN_KEY_INJECT ? `\nEnvironment=OCP_ADMIN_KEY=${OCP_ADMIN_KEY_INJECT}` : ""}${PROXY_ANON_KEY_INJECT ? `\nEnvironment=PROXY_ANONYMOUS_KEY=${PROXY_ANON_KEY_INJECT}` : ""}
-Restart=always
-RestartSec=5
-StandardOutput=append:${logPath}
-StandardError=append:${logPath}
-
-[Install]
-WantedBy=default.target
-`;
-
-    const existingService = existsSync(servicePath) ? readFileSync(servicePath, "utf8") : null;
-    const finalServiceUnit = mergeSystemdEnv(existingService, serviceUnit);
-    writeFileSync(servicePath, finalServiceUnit);
-    chmodSync(servicePath, 0o600);
-    if (existingService && finalServiceUnit !== serviceUnit) {
-      log(`Service file written: ${servicePath} (mode 600, preserved user env vars)`);
-    } else {
-      log(`Service file written: ${servicePath} (mode 600)`);
-    }
-
-    if (servicePlan.daemonReload) execSync(`systemctl --user daemon-reload`);
-    if (servicePlan.enable) execSync(`systemctl --user enable ocp-proxy`);
-    if (servicePlan.start) execSync(`systemctl --user start ocp-proxy`);
-    if (servicePlan.enable && servicePlan.start) {
-      log(`systemd user service enabled and started`);
-    } else {
-      // Note: only `start` is "left to" the restart phase (it issues `systemctl restart`,
-      // which starts a not-yet-running unit fine). `enable` is not deferred to anything — it
-      // is simply left untouched here, preserving whatever it already was.
-      log(`Service file written + daemon-reload'd (reconfigure-only: enable left as-is; start left to the upgrade flow's restart phase)`);
-    }
-
-  } else {
-    warn(`Auto-start not supported on ${platform} — start manually with: bash ${startPath}`);
-  }
-
-  // Banner: only claim "will start automatically" when this run actually attempted to
-  // load/start it (bare install/first-run — not --reconfigure-only, which never runs
-  // `enable`/`start`/`bootstrap` on either platform). This applies uniformly to both
-  // platforms: a first-install bootstrap/enable+start failing against a disabled unit would
-  // already have thrown and killed the script before reaching this banner, so reaching it on
-  // the non-reconfigure-only path is real evidence, not an assumption — whereas
-  // reconfigure-only never attempts either action, so it never gets to claim that evidence
-  // (previously this banner over-claimed unconditionally on darwin; see #226 review M1).
-  if (!platformSupported) {
-    // warn() above already explained it; nothing further to add.
-  } else if (servicePlan.reconfigureOnly) {
-    // Leaves auto-start-on-boot/login state untouched either way (issue #226) — whatever this
-    // unit's enablement already was (first install, or an operator's manual override) is
-    // preserved, not re-asserted. The upgrade flow's restart phase runs next and starts the
-    // service; it does not call `enable` (Linux) or touch launchd's disabled state (macOS).
-    console.log("\n✅ Service config written (--reconfigure-only) — auto-start-on-boot state left as-is; the upgrade flow's restart phase starts the service next\n");
-  } else {
-    console.log("\n✅ Auto-start installed — proxy will start automatically on login\n");
-  }
+  // Step 7 (auto-start install: legacy-unit migration, plist/unit write, enable/start/
+  // bootstrap per servicePlan) lives in scripts/lib/install-autostart.mjs — extracted so it
+  // can be called with injected run/fs functions in tests. See that module's header comment
+  // for why (issue #226 review: a prior source-text-assertion approach here tested
+  // co-location, not containment, and a review mutation proved it — AGENTS.md's "Testing
+  // discipline: what counts as a test" section, not its server.mjs-specific section, is the
+  // one this had to answer to).
+  installAutoStart({
+    platform,
+    servicePlan,
+    paths: { HOME, OPENCLAW_DIR, serverPath, startPath },
+    config: { PORT, BIND_ADDRESS, AUTH_MODE_CONFIG, CLAUDE_BIN_INJECT, OCP_ADMIN_KEY_INJECT, PROXY_ANON_KEY_INJECT },
+    log,
+    warn,
+  });
 
   // ── Step 8: Post-install health verification ───────────────────────────
   // Skipped under --reconfigure-only too: nothing was started above, so there is nothing

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -1677,7 +1677,6 @@ test("upgrade full path executes 5 phases", async () => {
 // (including the --reconfigure-only argv parse itself, per resolveServicePlan) was
 // deliberately extracted out of it into something that can be.
 import { planServiceActions, resolveServicePlan } from "./scripts/lib/service-mode.mjs";
-import { readFileSync as setupSrcRead } from "node:fs";
 
 console.log("\nReconfigure-only service mode (#226):");
 
@@ -1748,56 +1747,182 @@ test("resolveServicePlan tolerates other unrelated argv alongside the bare flag"
   assert.equal(plan.reconfigureOnly, true);
 });
 
-// ── setup.mjs wiring: source-shape assertions (review finding H2 / MX2, MX3, and H1) ──────
-// setup.mjs has top-level side effects and cannot be imported or executed in this suite (see
-// module comment above). These read its actual source text and assert the SPECIFIC guard ↔
-// call pairing is present — not merely that a token like "execSync" appears somewhere, which
-// a source-level assertion the task's own conventions rightly call "not a test". Each regex
-// requires the guard condition and the gated call to be adjacent/bound in source, so a
-// mutation that strips the `if (...)` (making the call unconditional, i.e. literally
-// reintroducing #226) breaks the match. This is a deliberate, narrow exception to
-// "behavioral, not textual" made specifically because setup.mjs itself is not executable
-// here — the DECISION these guards consume (servicePlan) is fully behaviorally tested above;
-// this only confirms setup.mjs's imperative body actually consults it.
-const setupSrc = setupSrcRead(new URL("./setup.mjs", import.meta.url), "utf8");
+// ── installAutoStart: behavioral tests (review round 2 — replaces source-shape assertions) ──
+// Round 1 of this review response added source-text regex assertions here, on the premise
+// that setup.mjs's top-level side effects make it unimportable/unexecutable. The premise was
+// real; the fix was wrong. AGENTS.md's "Testing discipline: what counts as a test" section
+// (general — it covers ocp-connect and bash `cmd_restart`, NOT scoped to server.mjs the way
+// the OTHER testing section is) says exactly why: a source-text assertion "passes when the
+// code is deleted and re-added wrong, and breaks on reformatting." Both failure modes were
+// demonstrated against the actual PR: a reviewer mutation emptied the H1 gate
+// (`if (!servicePlan.reconfigureOnly) { }`) while leaving the migration code in an adjacent,
+// now-unguarded block — the landmark-bounded regex found every string it searched for
+// (co-location, not containment) and the suite stayed green. Fix: the imperative Step 7 body
+// moved into scripts/lib/install-autostart.mjs's installAutoStart(), an injectable function —
+// the same seam scripts/upgrade.mjs already uses (opts.mockExec) and doctor.mjs uses
+// (opts.mockHealth). These tests call the REAL function with fake run/fs primitives and
+// assert on which commands/files were actually touched, not on source shape.
+import { installAutoStart } from "./scripts/lib/install-autostart.mjs";
 
-test("setup.mjs actually calls resolveServicePlan(args, platform) — not a disconnected/hardcoded value", () => {
-  // Anchored to the actual assignment statement, not a bare call expression — a prose comment
-  // elsewhere in the file legitimately contains the substring "resolveServicePlan(args,
-  // platform)" too, and matching only the call expression would pass vacuously against that
-  // comment even if the REAL call were mutated to e.g. resolveServicePlan([], platform).
-  assert.ok(/const\s+servicePlan\s*=\s*resolveServicePlan\(args,\s*platform\);/.test(setupSrc),
-    "setup.mjs must assign `const servicePlan = resolveServicePlan(args, platform);` to wire the flag to behavior");
+function baseInstallOpts(overrides = {}) {
+  return {
+    platform: "linux",
+    servicePlan: resolveServicePlan([], "linux"),
+    paths: {
+      HOME: "/fake/home",
+      OPENCLAW_DIR: "/fake/home/.openclaw",
+      serverPath: "/fake/repo/server.mjs",
+      startPath: "/fake/repo/start.sh",
+    },
+    config: {
+      PORT: 3456, BIND_ADDRESS: "127.0.0.1", AUTH_MODE_CONFIG: "none",
+      CLAUDE_BIN_INJECT: null, OCP_ADMIN_KEY_INJECT: null, PROXY_ANON_KEY_INJECT: null,
+    },
+    run: () => "",
+    writeFile: () => {},
+    readFile: () => "",
+    existsPath: () => false,
+    makeDir: () => {},
+    chmodPath: () => {},
+    unlinkPath: () => {},
+    log: () => {},
+    warn: () => {},
+    print: () => {},
+    ...overrides,
+  };
+}
+
+console.log("\ninstallAutoStart (behavioral, review round 2):");
+
+test("installAutoStart(linux, reconfigureOnly): run gets daemon-reload but never enable or start", () => {
+  const calls = [];
+  installAutoStart(baseInstallOpts({
+    servicePlan: resolveServicePlan(["--reconfigure-only"], "linux"),
+    run: (cmd) => { calls.push(cmd); return ""; },
+  }));
+  assert.ok(calls.some(c => c.includes("daemon-reload")), `expected a daemon-reload call; got ${JSON.stringify(calls)}`);
+  assert.ok(!calls.some(c => c.includes("enable ocp-proxy")), `enable must never run under --reconfigure-only; calls=${JSON.stringify(calls)}`);
+  assert.ok(!calls.some(c => c.includes("start ocp-proxy")), `start must never run under --reconfigure-only; calls=${JSON.stringify(calls)}`);
 });
 
-test("setup.mjs's systemd `enable` call is guarded by servicePlan.enable", () => {
-  assert.ok(/if\s*\(servicePlan\.enable\)\s*execSync\(`systemctl --user enable ocp-proxy`\);/.test(setupSrc),
-    "the `systemctl --user enable ocp-proxy` call must be gated on servicePlan.enable");
+test("installAutoStart(linux, first install): run gets daemon-reload, enable, AND start (positive-path control)", () => {
+  const calls = [];
+  installAutoStart(baseInstallOpts({
+    servicePlan: resolveServicePlan([], "linux"),
+    run: (cmd) => { calls.push(cmd); return ""; },
+  }));
+  assert.ok(calls.some(c => c.includes("daemon-reload")));
+  assert.ok(calls.some(c => c.includes("enable ocp-proxy")), `expected enable on a first install; calls=${JSON.stringify(calls)}`);
+  assert.ok(calls.some(c => c.includes("start ocp-proxy")), `expected start on a first install; calls=${JSON.stringify(calls)}`);
 });
 
-test("setup.mjs's systemd `start` call is guarded by servicePlan.start", () => {
-  assert.ok(/if\s*\(servicePlan\.start\)\s*execSync\(`systemctl --user start ocp-proxy`\);/.test(setupSrc),
-    "the `systemctl --user start ocp-proxy` call must be gated on servicePlan.start");
+test("installAutoStart(darwin, reconfigureOnly): run never receives bootstrap or bootout for the new plist", () => {
+  const calls = [];
+  installAutoStart(baseInstallOpts({
+    platform: "darwin",
+    servicePlan: resolveServicePlan(["--reconfigure-only"], "darwin"),
+    run: (cmd) => { calls.push(cmd); return ""; },
+  }));
+  assert.ok(!calls.some(c => c.includes("bootstrap")), `bootstrap must never run under --reconfigure-only; calls=${JSON.stringify(calls)}`);
+  assert.ok(!calls.some(c => c.includes("bootout")), `bootout for the new plist must never run under --reconfigure-only; calls=${JSON.stringify(calls)}`);
 });
 
-test("setup.mjs's launchctl bootstrap block is guarded by servicePlan.bootstrap", () => {
-  const m = setupSrc.match(/if\s*\(servicePlan\.bootstrap\)\s*\{([\s\S]*?)\}\s*else\s*\{/);
-  assert.ok(m, "expected an `if (servicePlan.bootstrap) { ... } else {` block");
-  assert.ok(m[1].includes("launchctl bootstrap gui"),
-    "the launchctl bootstrap call must be inside the servicePlan.bootstrap-guarded block");
+test("installAutoStart(darwin, first install): run gets bootout then bootstrap (positive-path control)", () => {
+  const calls = [];
+  installAutoStart(baseInstallOpts({
+    platform: "darwin",
+    servicePlan: resolveServicePlan([], "darwin"),
+    run: (cmd) => { calls.push(cmd); return ""; },
+  }));
+  assert.ok(calls.some(c => c.includes("bootout")), `expected bootout on a first install; calls=${JSON.stringify(calls)}`);
+  assert.ok(calls.some(c => c.includes("bootstrap")), `expected bootstrap on a first install; calls=${JSON.stringify(calls)}`);
 });
 
-test("setup.mjs's legacy-unit migration is gated on !servicePlan.reconfigureOnly (review finding H1)", () => {
-  // Landmark-bounded slice: from the "Uninstall legacy service names" comment up to the start
-  // of the main plist-write block ("// macOS: launchd") — the region that must be entirely
-  // inside the !reconfigureOnly gate.
-  const region = setupSrc.match(/Uninstall legacy service names[\s\S]*?\/\/ macOS: launchd/);
-  assert.ok(region, "legacy-migration region landmark not found in setup.mjs");
-  const block = region[0];
-  assert.ok(/if\s*\(!servicePlan\.reconfigureOnly\)\s*\{/.test(block),
-    "legacy-unit migration must be wrapped in `if (!servicePlan.reconfigureOnly) { ... }`");
-  assert.ok(block.includes("ai.openclaw.proxy.plist"), "darwin legacy-plist removal must be inside the gated region");
-  assert.ok(block.includes("openclaw-proxy.service"), "linux legacy-service removal must be inside the gated region");
+// ── H1, proven behaviorally: legacy-unit migration must not run under --reconfigure-only ──
+// This is the exact scenario the review's "empty gate" mutation targeted: a host with a
+// legacy plist/service present, running --reconfigure-only. Unlike the deleted source
+// assertion, this calls the real installAutoStart() and observes real (faked) run/unlink
+// calls — a mutation that empties the gate, or moves the migration code outside it, makes
+// these calls actually happen, which these tests actually catch.
+test("installAutoStart(darwin, reconfigureOnly, legacy plist present): legacy bootout/unlink never happen (H1)", () => {
+  const legacyPath = "/fake/home/Library/LaunchAgents/ai.openclaw.proxy.plist";
+  const calls = [];
+  const unlinked = [];
+  installAutoStart(baseInstallOpts({
+    platform: "darwin",
+    servicePlan: resolveServicePlan(["--reconfigure-only"], "darwin"),
+    existsPath: (p) => p === legacyPath, // only the legacy plist "exists"; the new one is a fresh write
+    run: (cmd) => { calls.push(cmd); return ""; },
+    unlinkPath: (p) => { unlinked.push(p); },
+  }));
+  assert.ok(!calls.some(c => c.includes("ai.openclaw.proxy")), `legacy bootout must never run under --reconfigure-only; calls=${JSON.stringify(calls)}`);
+  assert.ok(!unlinked.includes(legacyPath), `legacy plist must never be unlinked under --reconfigure-only; unlinked=${JSON.stringify(unlinked)}`);
+});
+
+test("installAutoStart(darwin, first install, legacy plist present): legacy IS migrated away (positive-path control)", () => {
+  const legacyPath = "/fake/home/Library/LaunchAgents/ai.openclaw.proxy.plist";
+  const calls = [];
+  const unlinked = [];
+  installAutoStart(baseInstallOpts({
+    platform: "darwin",
+    servicePlan: resolveServicePlan([], "darwin"),
+    existsPath: (p) => p === legacyPath,
+    run: (cmd) => { calls.push(cmd); return ""; },
+    unlinkPath: (p) => { unlinked.push(p); },
+  }));
+  assert.ok(calls.some(c => c.includes("ai.openclaw.proxy")), "legacy bootout must run on a bare install with a legacy plist present");
+  assert.ok(unlinked.includes(legacyPath), "legacy plist must be unlinked on a bare install");
+});
+
+test("installAutoStart(linux, reconfigureOnly, legacy service present): stop/disable/unlink never happen; daemon-reload runs exactly once (H1)", () => {
+  const legacyPath = "/fake/home/.config/systemd/user/openclaw-proxy.service";
+  const calls = [];
+  const unlinked = [];
+  installAutoStart(baseInstallOpts({
+    platform: "linux",
+    servicePlan: resolveServicePlan(["--reconfigure-only"], "linux"),
+    existsPath: (p) => p === legacyPath,
+    run: (cmd) => { calls.push(cmd); return ""; },
+    unlinkPath: (p) => { unlinked.push(p); },
+  }));
+  assert.ok(!calls.some(c => c.includes("stop openclaw-proxy")), `legacy stop must never run under --reconfigure-only; calls=${JSON.stringify(calls)}`);
+  assert.ok(!calls.some(c => c.includes("disable openclaw-proxy")), `legacy disable must never run under --reconfigure-only; calls=${JSON.stringify(calls)}`);
+  assert.ok(!unlinked.includes(legacyPath), `legacy service file must never be unlinked under --reconfigure-only; unlinked=${JSON.stringify(unlinked)}`);
+  const daemonReloadCount = calls.filter(c => c.includes("daemon-reload")).length;
+  assert.equal(daemonReloadCount, 1,
+    `expected exactly one daemon-reload (main write path only, not a second one from legacy migration) — got ${daemonReloadCount}: ${JSON.stringify(calls)}`);
+});
+
+test("installAutoStart(linux, first install, legacy service present): stop/disable/unlink DO happen (positive-path control)", () => {
+  const legacyPath = "/fake/home/.config/systemd/user/openclaw-proxy.service";
+  const calls = [];
+  const unlinked = [];
+  installAutoStart(baseInstallOpts({
+    platform: "linux",
+    servicePlan: resolveServicePlan([], "linux"),
+    existsPath: (p) => p === legacyPath,
+    run: (cmd) => { calls.push(cmd); return ""; },
+    unlinkPath: (p) => { unlinked.push(p); },
+  }));
+  assert.ok(calls.some(c => c.includes("stop openclaw-proxy")), "legacy stop must run on a bare install with a legacy service present");
+  assert.ok(calls.some(c => c.includes("disable openclaw-proxy")), "legacy disable must run on a bare install with a legacy service present");
+  assert.ok(unlinked.includes(legacyPath), "legacy service file must be unlinked on a bare install");
+});
+
+test("installAutoStart(unsupported platform): no run/write/unlink calls at all, regardless of reconfigureOnly", () => {
+  const calls = [];
+  const unlinked = [];
+  const written = [];
+  installAutoStart(baseInstallOpts({
+    platform: "win32",
+    servicePlan: resolveServicePlan(["--reconfigure-only"], "win32"),
+    run: (cmd) => { calls.push(cmd); return ""; },
+    unlinkPath: (p) => { unlinked.push(p); },
+    writeFile: (p) => { written.push(p); },
+  }));
+  assert.equal(calls.length, 0);
+  assert.equal(unlinked.length, 0);
+  assert.equal(written.length, 0);
 });
 
 test("upgrade full path's reconfigure phase invokes setup.mjs with --reconfigure-only", async () => {

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -773,6 +773,18 @@ test("doctor next_action.kind enum is one of allowed values", async () => {
   assert.ok(ALLOWED.includes(result.next_action.kind), `kind=${result.next_action.kind} not in enum`);
 });
 
+// #226 premise-check: a first install genuinely must enable + start the service (that IS its
+// job) — only scripts/upgrade.mjs's reconfigure phase should opt into --reconfigure-only.
+// This guards against the flag's use accidentally spreading to fresh_install's real command.
+test("doctor fresh_install's setup.mjs step does NOT carry --reconfigure-only (first install must enable+start)", async () => {
+  const result = await runDoctor({ skipNetwork: true, mockVersion: "v3.2.0", mockLatest: "v3.14.0" });
+  assert.equal(result.next_action.kind, "fresh_install");
+  const setupStep = result.next_action.ai_executable.find(c => c.includes("setup.mjs"));
+  assert.ok(setupStep, "fresh_install ai_executable must include a setup.mjs step");
+  assert.ok(!setupStep.includes("--reconfigure-only"),
+    `fresh_install must call setup.mjs bare (enable+start) — got: ${setupStep}`);
+});
+
 test("doctor noop when current==latest", async () => {
   const result = await runDoctor({ skipNetwork: true, mockVersion: "v3.14.0", mockLatest: "v3.14.0" });
   assert.equal(result.next_action.kind, "noop");
@@ -1646,6 +1658,71 @@ test("upgrade full path executes 5 phases", async () => {
   for (const expected of ["pre-flight", "snapshot", "fetch+install", "reconfigure", "restart", "post-flight"]) {
     assert.ok(phaseNames.includes(expected), `missing phase: ${expected}; got ${phaseNames.join(",")}`);
   }
+});
+
+// ── Reconfigure-only service mode (#226) ──────────────────────────────────
+// #215: on a host where a competing systemd/launchd unit already owns the OCP port, an
+// upgrade's reconfigure step (setup.mjs) must not enable-at-boot or start the service it
+// writes config for — that races/duplicates whatever phase 5 (restart) resolves to run, and
+// re-arms the boot race #215 describes. #221 fixes phase 5's target resolution; this section
+// covers the layering fix so phase 4 stops performing phase 5's job in the first place.
+//
+// planServiceActions() is imported directly (not replicated, unlike the setup.mjs inject
+// helpers above) because scripts/lib/service-mode.mjs is a real side-effect-free module —
+// setup.mjs itself still cannot be imported, but the decision was deliberately extracted out
+// of it into something that can be.
+import { planServiceActions } from "./scripts/lib/service-mode.mjs";
+
+console.log("\nReconfigure-only service mode (#226):");
+
+test("planServiceActions(linux) default: daemon-reload + enable + start (first-install behavior)", () => {
+  const actions = planServiceActions("linux");
+  assert.deepEqual(actions, { daemonReload: true, enable: true, start: true });
+});
+
+test("planServiceActions(linux, reconfigureOnly): daemon-reload stays true, enable+start become false", () => {
+  const actions = planServiceActions("linux", { reconfigureOnly: true });
+  assert.deepEqual(actions, { daemonReload: true, enable: false, start: false });
+});
+
+test("planServiceActions(darwin) default: bootstrap true (first-install behavior)", () => {
+  const actions = planServiceActions("darwin");
+  assert.deepEqual(actions, { bootstrap: true });
+});
+
+test("planServiceActions(darwin, reconfigureOnly): bootstrap false (plist written, not loaded)", () => {
+  const actions = planServiceActions("darwin", { reconfigureOnly: true });
+  assert.deepEqual(actions, { bootstrap: false });
+});
+
+test("planServiceActions on an unsupported platform returns {} regardless of reconfigureOnly", () => {
+  assert.deepEqual(planServiceActions("win32"), {});
+  assert.deepEqual(planServiceActions("win32", { reconfigureOnly: true }), {});
+});
+
+test("upgrade full path's reconfigure phase invokes setup.mjs with --reconfigure-only", async () => {
+  const result = await runUpgrade({
+    yes: true,
+    dryRun: false,
+    mockExec: true,
+    mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" },
+                  current_version: "v3.10.0", latest_version: "v3.14.0" }
+  });
+  const reconfigurePhase = result.phases.find(p => p.name === "reconfigure");
+  assert.ok(reconfigurePhase, "reconfigure phase must be present");
+  assert.ok(reconfigurePhase.cmd.includes("setup.mjs"), `expected a setup.mjs invocation, got: ${reconfigurePhase.cmd}`);
+  assert.ok(reconfigurePhase.cmd.includes("--reconfigure-only"),
+    `reconfigure phase must pass --reconfigure-only so it does not enable/start — got: ${reconfigurePhase.cmd}`);
+});
+
+test("upgrade --dry-run plan text for the 'upgrade' kind names --reconfigure-only", async () => {
+  const result = await runUpgrade({
+    dryRun: true,
+    mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" },
+                  current_version: "v3.10.0", latest_version: "v3.14.0" }
+  });
+  assert.ok(result.plan.some(line => line.includes("--reconfigure-only")),
+    `dry-run plan should mention --reconfigure-only; got: ${result.plan.join(" | ")}`);
 });
 
 // ── Snapshot Tests ──

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -1664,14 +1664,20 @@ test("upgrade full path executes 5 phases", async () => {
 // #215: on a host where a competing systemd/launchd unit already owns the OCP port, an
 // upgrade's reconfigure step (setup.mjs) must not enable-at-boot or start the service it
 // writes config for — that races/duplicates whatever phase 5 (restart) resolves to run, and
-// re-arms the boot race #215 describes. #221 fixes phase 5's target resolution; this section
-// covers the layering fix so phase 4 stops performing phase 5's job in the first place.
+// re-arms the boot race #215 describes. #221 fixes phase 5's target resolution (still open,
+// unmerged as of this section); this covers the layering fix so phase 4 stops performing
+// phase 5's job in the first place. NOTE: phase 5, as it exists on `main` right now, is still
+// the pre-#221 hard-coded restart — so on the actual #215 host, this fix alone does not stop
+// the orphan (phase 5 still unconditionally starts `ocp-proxy.service` a few lines later); it
+// removes the `enable` re-arm and phase 4's premature `start`, which is half the defect family.
 //
-// planServiceActions() is imported directly (not replicated, unlike the setup.mjs inject
-// helpers above) because scripts/lib/service-mode.mjs is a real side-effect-free module —
-// setup.mjs itself still cannot be imported, but the decision was deliberately extracted out
-// of it into something that can be.
-import { planServiceActions } from "./scripts/lib/service-mode.mjs";
+// planServiceActions() / resolveServicePlan() are imported directly (not replicated, unlike
+// the setup.mjs inject helpers above) because scripts/lib/service-mode.mjs is a real
+// side-effect-free module — setup.mjs itself still cannot be imported, but the decision
+// (including the --reconfigure-only argv parse itself, per resolveServicePlan) was
+// deliberately extracted out of it into something that can be.
+import { planServiceActions, resolveServicePlan } from "./scripts/lib/service-mode.mjs";
+import { readFileSync as setupSrcRead } from "node:fs";
 
 console.log("\nReconfigure-only service mode (#226):");
 
@@ -1698,6 +1704,100 @@ test("planServiceActions(darwin, reconfigureOnly): bootstrap false (plist writte
 test("planServiceActions on an unsupported platform returns {} regardless of reconfigureOnly", () => {
   assert.deepEqual(planServiceActions("win32"), {});
   assert.deepEqual(planServiceActions("win32", { reconfigureOnly: true }), {});
+});
+
+test("planServiceActions(platform, null) does not throw (review-flagged robustness gap)", () => {
+  assert.doesNotThrow(() => planServiceActions("linux", null));
+  assert.deepEqual(planServiceActions("linux", null), { daemonReload: true, enable: true, start: true });
+});
+
+// ── resolveServicePlan: the argv-parse-to-decision seam (review finding H2 / MX1) ──────────
+// Closes the gap where the --reconfigure-only argv parse lived as an untestable setup.mjs
+// top-level const, separate from the tested planServiceActions() decision — a mutation to
+// that const (e.g. hardcoding it to `false`) previously left the full suite green.
+test("resolveServicePlan([], 'linux'): reconfigureOnly false, full enable+start plan", () => {
+  const plan = resolveServicePlan([], "linux");
+  assert.deepEqual(plan, { reconfigureOnly: false, daemonReload: true, enable: true, start: true });
+});
+
+test("resolveServicePlan(['--reconfigure-only'], 'linux'): reconfigureOnly true, enable+start false", () => {
+  const plan = resolveServicePlan(["--reconfigure-only"], "linux");
+  assert.deepEqual(plan, { reconfigureOnly: true, daemonReload: true, enable: false, start: false });
+});
+
+test("resolveServicePlan([], 'darwin'): reconfigureOnly false, bootstrap true", () => {
+  const plan = resolveServicePlan([], "darwin");
+  assert.deepEqual(plan, { reconfigureOnly: false, bootstrap: true });
+});
+
+test("resolveServicePlan(['--reconfigure-only'], 'darwin'): reconfigureOnly true, bootstrap false", () => {
+  const plan = resolveServicePlan(["--reconfigure-only"], "darwin");
+  assert.deepEqual(plan, { reconfigureOnly: true, bootstrap: false });
+});
+
+test("resolveServicePlan refuses --reconfigure-only=true rather than silently parsing as false (fails-open guard)", () => {
+  assert.throws(() => resolveServicePlan(["--reconfigure-only=true"], "linux"), /takes no value/);
+});
+
+test("resolveServicePlan refuses --reconfigure-only=false rather than silently parsing as false", () => {
+  assert.throws(() => resolveServicePlan(["--reconfigure-only=false"], "linux"), /takes no value/);
+});
+
+test("resolveServicePlan tolerates other unrelated argv alongside the bare flag", () => {
+  const plan = resolveServicePlan(["--port", "3456", "--reconfigure-only", "--bind", "0.0.0.0"], "linux");
+  assert.equal(plan.reconfigureOnly, true);
+});
+
+// ── setup.mjs wiring: source-shape assertions (review finding H2 / MX2, MX3, and H1) ──────
+// setup.mjs has top-level side effects and cannot be imported or executed in this suite (see
+// module comment above). These read its actual source text and assert the SPECIFIC guard ↔
+// call pairing is present — not merely that a token like "execSync" appears somewhere, which
+// a source-level assertion the task's own conventions rightly call "not a test". Each regex
+// requires the guard condition and the gated call to be adjacent/bound in source, so a
+// mutation that strips the `if (...)` (making the call unconditional, i.e. literally
+// reintroducing #226) breaks the match. This is a deliberate, narrow exception to
+// "behavioral, not textual" made specifically because setup.mjs itself is not executable
+// here — the DECISION these guards consume (servicePlan) is fully behaviorally tested above;
+// this only confirms setup.mjs's imperative body actually consults it.
+const setupSrc = setupSrcRead(new URL("./setup.mjs", import.meta.url), "utf8");
+
+test("setup.mjs actually calls resolveServicePlan(args, platform) — not a disconnected/hardcoded value", () => {
+  // Anchored to the actual assignment statement, not a bare call expression — a prose comment
+  // elsewhere in the file legitimately contains the substring "resolveServicePlan(args,
+  // platform)" too, and matching only the call expression would pass vacuously against that
+  // comment even if the REAL call were mutated to e.g. resolveServicePlan([], platform).
+  assert.ok(/const\s+servicePlan\s*=\s*resolveServicePlan\(args,\s*platform\);/.test(setupSrc),
+    "setup.mjs must assign `const servicePlan = resolveServicePlan(args, platform);` to wire the flag to behavior");
+});
+
+test("setup.mjs's systemd `enable` call is guarded by servicePlan.enable", () => {
+  assert.ok(/if\s*\(servicePlan\.enable\)\s*execSync\(`systemctl --user enable ocp-proxy`\);/.test(setupSrc),
+    "the `systemctl --user enable ocp-proxy` call must be gated on servicePlan.enable");
+});
+
+test("setup.mjs's systemd `start` call is guarded by servicePlan.start", () => {
+  assert.ok(/if\s*\(servicePlan\.start\)\s*execSync\(`systemctl --user start ocp-proxy`\);/.test(setupSrc),
+    "the `systemctl --user start ocp-proxy` call must be gated on servicePlan.start");
+});
+
+test("setup.mjs's launchctl bootstrap block is guarded by servicePlan.bootstrap", () => {
+  const m = setupSrc.match(/if\s*\(servicePlan\.bootstrap\)\s*\{([\s\S]*?)\}\s*else\s*\{/);
+  assert.ok(m, "expected an `if (servicePlan.bootstrap) { ... } else {` block");
+  assert.ok(m[1].includes("launchctl bootstrap gui"),
+    "the launchctl bootstrap call must be inside the servicePlan.bootstrap-guarded block");
+});
+
+test("setup.mjs's legacy-unit migration is gated on !servicePlan.reconfigureOnly (review finding H1)", () => {
+  // Landmark-bounded slice: from the "Uninstall legacy service names" comment up to the start
+  // of the main plist-write block ("// macOS: launchd") — the region that must be entirely
+  // inside the !reconfigureOnly gate.
+  const region = setupSrc.match(/Uninstall legacy service names[\s\S]*?\/\/ macOS: launchd/);
+  assert.ok(region, "legacy-migration region landmark not found in setup.mjs");
+  const block = region[0];
+  assert.ok(/if\s*\(!servicePlan\.reconfigureOnly\)\s*\{/.test(block),
+    "legacy-unit migration must be wrapped in `if (!servicePlan.reconfigureOnly) { ... }`");
+  assert.ok(block.includes("ai.openclaw.proxy.plist"), "darwin legacy-plist removal must be inside the gated region");
+  assert.ok(block.includes("openclaw-proxy.service"), "linux legacy-service removal must be inside the gated region");
 });
 
 test("upgrade full path's reconfigure phase invokes setup.mjs with --reconfigure-only", async () => {


### PR DESCRIPTION
## Review response (round 3)

Round 2 review was REQUEST CHANGES with one blocker. Credit first: the H1 gate itself was correct on both platforms, `resolveServicePlan` closed MX1 behaviorally (a real win — hardcoding the parse to `false` broke three real `deepEqual` assertions, not a grep), M1's launchd correction was accurate, M2's correction was honest, all LOWs were addressed, and R1–R8 all reproduced exactly as tabled. The blocker was entirely about **how H1/H2 were tested**, not the fix itself.

**The ruling: replace the source-shape assertions, don't keep them as a supplement.** Three reasons:

1. `AGENTS.md`'s own testing sections were written to refuse exactly this argument. Its general "Testing discipline: what counts as a test" section (distinct from its server.mjs-specific section) states: *"a test asserting on the source text of the thing it tests is not a test — it passes when the code is deleted and re-added wrong, and breaks on reformatting."*
2. The two things I called "sanctioned exceptions" in that same document have a structure the source assertions didn't: they protect a harness that *then runs the code*, so behavior is still exercised and the textual check only guards slice validity. Here nothing ran — the textual assertion **was** the coverage, not a premise check on top of it.
3. **The empirical argument, which settles it: the technique failed at its one job.** The reviewer reverted H1 completely — legacy migration ungated again — while leaving an empty `if (!servicePlan.reconfigureOnly) { }` token in the region. The landmark-bounded regex tests **co-location** ("do these strings appear somewhere in this slice"), not **containment** ("are they inside the braces"). It found everything it searched for; the suite stayed at 506/0. Its own failure message said the migration "must be **wrapped in**" the gate — containment is precisely what it never tested. Second-order: a semantically-inert Prettier-style brace addition around the `enable` guard broke that assertion outright too — the doc's "breaks on reformatting" failure mode, reproduced on demand.

**The fix — extraction, not more regex.** `scripts/lib/install-autostart.mjs`'s `installAutoStart({ platform, servicePlan, paths, config, run, writeFile, readFile, existsPath, makeDir, chmodPath, unlinkPath, log, warn, print })` — `setup.mjs`'s entire Step 7 imperative body (legacy-unit migration, plist/systemd-unit write with existing-file env-merge, platform-specific enable/start/bootstrap), moved essentially verbatim (~200 lines relocated, no logic change) behind an injectable interface. Every side-effecting primitive defaults to the real Node function `setup.mjs` already called, so its actual behavior is unchanged; tests pass recording fakes and assert on which commands/files were **actually touched**. This is the same seam `scripts/upgrade.mjs` already uses (`opts.mockExec`) and `doctor.mjs` uses (`opts.mockHealth`) — **not** `scripts/lib/restart-unit.mjs`, which an earlier draft of this module's own comment wrongly cited as precedent (that file ships only in the separate, still-unmerged #221; it does not exist on `main`, as the round-2 review caught).

The five source-shape tests are **deleted**. Nine behavioral tests replace them, calling the real `installAutoStart()` with recording fakes:
- linux/darwin × {reconfigureOnly, first-install}: `run()` receives exactly the expected command set.
- **H1, the exact scenario the reviewer's mutation targeted**: legacy plist/service present + `--reconfigure-only` → `bootout`/`stop`/`disable` never run, `unlink` never called, `daemon-reload` runs **exactly once** (not twice — the tell for "the gate leaked and the legacy path ran too"). Paired positive-path controls (legacy present + first-install) prove the fixture genuinely exercises the migration when the gate is open, so the negative assertions aren't vacuously true regardless of gate state.
- unsupported platform: zero `run`/`write`/`unlink` calls, regardless of the flag.

**Reproduced the reviewer's exact attack against the new code**: emptying the H1 gate the same way (`if (!servicePlan.reconfigureOnly) { }` followed by the migration code in an unguarded block) now fails 2 tests with real `run()` calls appearing in the failure message — see the mutation table. **Reproduced the reformat too**: wrapping the `enable` guard's body in braces (semantically inert) leaves the suite green — proving the reformatting immunity the deleted approach lacked.

**Three non-blocking items, all fixed:**
1. **A new false claim, same sentence as round 1's.** I wrote "this is NOT documented in AGENTS.md, which only covers server.mjs's testing seams" — false. `AGENTS.md` has two testing sections; the second, "Testing discipline: what counts as a test," mentions `ocp-connect` and bash `cmd_restart`, never `server.mjs`. It is not server.mjs-scoped, and it is precisely the section this module's tests have to answer to. Corrected in `service-mode.mjs`'s header and here.
2. **The H1 gate comment now states the consequence, not just the reachability argument.** On a legacy-unit host that does take the reconfigure-only path, the gate converts a *successful* migration into a *failed* upgrade — phase 5 starts the new unit against a port the legacy one may still hold, post-flight fails, operator rolls back. Rollback restores the git tree and admin-key/db files, not `~/.config/systemd/user/` or `~/Library/LaunchAgents/`, so the new (but not-migrated-into) unit is left in place; carrying `Restart=always`/`RestartSec=5`, it respawn-loops and fails after the aborted upgrade until an operator intervenes. Judged acceptable — same near-zero reachability, and loud-and-rolled-back beats round 1's silent-until-reboot failure — but now stated in `install-autostart.mjs`'s comment, not left implicit.
3. **Softened an unsourceable claim.** "`bootstrap`/`bootout` do not set or clear that disabled state either way" is not something `man 1 launchctl` documents either way. Reworded to: this module doesn't touch launchd's persistent disabled state, not a claim about what `bootstrap`/`bootout` themselves do.

Suite after this round: **510 passed, 0 failed**, up from 506 (net +4: −5 deleted source-assertion tests, +9 new behavioral tests).

---

## The defect

```js
// setup.mjs:513-515 (pre-fix) — hard-coded, no ownership resolution
execSync(`systemctl --user daemon-reload`);
execSync(`systemctl --user enable ocp-proxy`);
execSync(`systemctl --user start ocp-proxy`);
```

`scripts/upgrade.mjs`'s phase 4 (`"reconfigure"`) called `node ${ocpDir}/setup.mjs` with no flags, every time an upgrade takes the full (cross-minor) path — **before** phase 5 (restart) runs. On the host that motivated #215 (a system-scope `ocp.service` already owns the port, alongside a user-scope `ocp-proxy.service`), phase 4's unconditional `start` starts the second, port-losing process #215 describes, and `enable` re-arms the boot race #215 calls "the part that makes it more than cosmetic" — even if an operator had manually disabled the user unit.

**Correction (from round 2's M2, still true here): this PR does not by itself stop the #215 orphan.** #221 (restart-target-ownership resolution) is a separate PR, still open/unmerged. Phase 5 in this PR remains the pre-#221 hard-coded restart, which still unconditionally starts `ocp-proxy` regardless of what phase 4 does. This PR removes the `enable` re-arm and phase 4's premature `start` — half of the defect family.

## Design chosen, and the premise-checks that justify it

Took **option 1** from #226: `setup.mjs` gains an opt-in `--reconfigure-only` mode that writes the unit/plist but does not `enable`/`start`; `scripts/upgrade.mjs`'s phase 4 now passes it.

1. **Does anything depend on phase 4 having started the service?** No — phase 5's restart/bootstrap sequence is unconditional and self-sufficient regardless of phase 4's prior state.
2. **First install must still enable + start, and the legacy-unit migration must not run under reconfigure-only either (H1).** `scripts/doctor.mjs`'s `fresh_install` calls `node setup.mjs` bare. Every other invocation is also bare: `package.json`'s `"setup"` npm script, and prose across README/`docs/lan-mode.md`/`docs/troubleshooting.md`/`setup.mjs`'s own `warn()`. The legacy-unit migration is explicitly gated on `!servicePlan.reconfigureOnly` (H1) — now proven behaviorally (see mutation table).
3. **`daemon-reload` stays unconditional** — load-bearing, not incidental: it only refreshes systemd's on-disk unit-file cache; skipping it would leave a later restart applying a stale definition.
4. **`enable` is skipped under `--reconfigure-only`, not deferred** — neither the current hard-coded phase 5 nor a future #221 ever calls `enable`; reconfigure-only leaves whatever boot-enablement already existed untouched.
5. **macOS has the same shape** (`bootstrap` both loads and starts), so `--reconfigure-only` gates it the same way. Its persistent enable/disable state (`launchctl enable`/`disable`, distinct from the plist file — corrected per round 2's M1) is, like Linux's, simply never touched by this module either way.

## What happens in each mode

| Mode | writes unit/plist | legacy-unit migration | `daemon-reload` (Linux) | `enable` (Linux) / disabled-state (darwin) | `start`/`bootstrap` | Step 8 verify |
|---|---|---|---|---|---|---|
| First install (`node setup.mjs`) | yes | yes | yes | yes / untouched | yes | yes |
| Reconfigure (`node setup.mjs --reconfigure-only`) | yes | **no** (H1: gated) | yes | **no** (left as-is) / untouched | **no** (left to phase 5) | **no** (phase 6 covers it) |

## Extraction for testability

`setup.mjs` cannot be imported or executed in tests (top-level side effects). The argv-parse-to-decision path lives in `scripts/lib/service-mode.mjs`'s `resolveServicePlan(argv, platform)`, directly imported by tests. **Round 3 correction**: the imperative Step 7 body that *consumes* that decision is no longer covered by source-shape assertions (round 2's approach, deleted — see "Review response" above for why). It now lives in `scripts/lib/install-autostart.mjs`'s injectable `installAutoStart()`, called from `setup.mjs` with real Node functions as defaults, and from tests with recording fakes. `setup.mjs` itself is reduced to: compute `platform`/`servicePlan`, call `installAutoStart({...})`, then Step 8 (unchanged, gated on `servicePlan.reconfigureOnly`).

## Mutation table — round 1 (original submission, `scripts/lib/service-mode.mjs`)

| # | Target | Mutation | Test(s) caught | Failure message |
|---|---|---|---|---|
| M1 | `service-mode.mjs` | `enable: !reconfigureOnly` → inverted | 2 | `Expected values to be strictly deep-equal` |
| M2 | `service-mode.mjs` | `start: !reconfigureOnly` → inverted | 2 | `Expected values to be strictly deep-equal` |
| M3 | `service-mode.mjs` | `daemonReload: true` → wrongly conditional | 1 | `Expected values to be strictly deep-equal` |
| M4 | `service-mode.mjs` | `bootstrap: !reconfigureOnly` → inverted | 2 | `Expected values to be strictly deep-equal` |
| M5 | `service-mode.mjs` | unsupported-platform `return {}` → actionable object | 1 | `Expected values to be strictly deep-equal` |
| M6 | `upgrade.mjs` | phase 4: removed `--reconfigure-only` | 1 | `reconfigure phase must pass --reconfigure-only ...` |
| M7 | `upgrade.mjs` | dry-run plan: removed `--reconfigure-only` | 1 | `dry-run plan should mention --reconfigure-only ...` |
| M8 | `doctor.mjs` | fresh_install: added `--reconfigure-only` | 1 | `fresh_install must call setup.mjs bare ...` |

## Mutation table — round 2 (`resolveServicePlan` + robustness; R3–R6/R8 superseded, see below)

| # | Target | Mutation | Result |
|---|---|---|---|
| R1 | `service-mode.mjs` | `resolveServicePlan`'s parse hardcoded to `false` | Caught (3 tests) — still valid, untouched this round |
| R2 | `service-mode.mjs` | malformed-value check disabled | Caught (2 tests) — still valid, untouched this round |
| R7 | `service-mode.mjs` | `planServiceActions` null-safety removed | Caught (4 tests) — still valid, untouched this round |
| R3, R4, R5, R6, R8 | `setup.mjs` (source-shape assertions) | enable/start/bootstrap/H1-gate/wiring-call mutations | **Superseded** — the tests these mutations targeted are deleted this round (see "Review response"). Round 3's T1–T4 below re-prove the same invariants behaviorally. |

## Mutation table — round 3 (`scripts/lib/install-autostart.mjs`, behavioral)

Protocol unchanged: real source edited (backed up via `cp`, never `git checkout`), mutation confirmed to produce an actionable failure, restored from the file backup, `diff -u`-verified byte-identical, suite reconfirmed green (510/0) before the next mutation.

| # | Mutation | Test(s) caught | Failure message |
|---|---|---|---|
| T1 | **Reviewer's exact demonstrated attack**: `if (!servicePlan.reconfigureOnly) { }` emptied, migration code left in an adjacent unguarded block | 2 (darwin legacy-H1, linux legacy-H1) | darwin: `legacy bootout must never run under --reconfigure-only; calls=["launchctl bootout ... ai.openclaw.proxy.plist ..."]` / linux: `legacy stop must never run ...; calls=["...stop openclaw-proxy...","...disable openclaw-proxy...","...daemon-reload","...daemon-reload"]` (note the duplicated daemon-reload — exactly the "ran twice" tell) |
| T2 | `if (servicePlan.enable)` guard removed (unconditional `run`) | 1 | `enable must never run under --reconfigure-only; calls=["...daemon-reload","...enable ocp-proxy"]` |
| T3 | `if (servicePlan.start)` guard removed | 1 | `start must never run under --reconfigure-only; calls=["...daemon-reload","...start ocp-proxy"]` |
| T4 | `if (servicePlan.bootstrap)` → `if (true)` | 1 | `bootstrap must never run under --reconfigure-only; calls=["...bootout...","...bootstrap..."]` |

**Reformat-immunity check** (not a mutation expected to fail — a demonstration that a non-mutation doesn't): wrapped the `enable` guard's single-statement body in braces (`if (servicePlan.enable) { run(...); }`), a Prettier-style change with identical semantics. Suite stayed at **510/0** — unlike round 2's regex assertion, which the review demonstrated breaks on exactly this change.

All mutations across all three rounds (M1–M8, R1/R2/R7, T1–T4 = 15 total live checks): confirmed actionable failure or, for the reformat check, confirmed no false failure; restored from file backup; `diff` clean; suite green before proceeding.

## Suite count

**510 passed, 0 failed** (`node test-features.mjs`), up from 485 on `main` before this PR.

## Release-kit items walked (`CLAUDE.md`'s `release_kit.new_feature_doc_expectations`)

- **new CLI subcommand → README § "All Commands" + usage example** — closest match for a new flag on `setup.mjs`. Updated README's "Upgrading" § to name `--reconfigure-only`; `setup.mjs`'s own header comment documents it. Not added to the "All Commands" table (that table enumerates `ocp` CLI subcommands, not `setup.mjs` flags — none of `setup.mjs`'s flags are, including `--port`, `--default-model`, `--bind`, `--auth-mode`, `--dry-run`, `--no-start`, `--provider-name`).
- **new file / SPOT / schema → Architecture or contributor § with link** — applies twice now: `scripts/lib/service-mode.mjs` and `scripts/lib/install-autostart.mjs` are both new. Both have rows in README's "Repository Layout" table.
- **new env var / auto-sync / endpoint / bootstrap quirk** — all N/A (no new env var, no new endpoint, `server.mjs` untouched, no one-time migration quirk).
- **CHANGELOG.md** — left untouched, matching this repo's convention (populated at release-cut time). No version bump for the same reason.

`docs/upgrading.md`'s cross-minor "full path" bullet carries the same corrected explanation from round 2 (config-only; Linux enable-state left untouched; macOS auto-start-on-login unaffected via file-presence; and the M2 correction that this alone doesn't stop the #215 orphan without #221).

## `server.mjs` — untouched

No `cli.js` citation applies.

## Deferred / out of scope

- **#221** (restart-target resolution) — still open/unmerged; this PR does not depend on it or supersede the need for it. `refs #221`, not `closes`.
- **#224** (bash `cmd_restart`) — untouched, different layer.
- **#220** (pre-flight refusal on two enabled units) — untouched, different remediation option.

refs #215, #220, #221, #224
Closes #226
