### PR TITLE
test(bash): harness for ocp's dispatch wiring; fix update --dry-run mutation + absent-python3 death

### DIFF
--- a/ocp
+++ b/ocp
@@ -817,6 +817,19 @@ cmd_update() {
   # hosts. sys.stdout.reconfigure(errors="replace") makes stdout tolerant of an unencodable
   # glyph (degrades to "?" instead of raising) without changing 2>/dev/null's existing behavior
   # for any OTHER failure mode. Verified fixed under the same env -i reproduction.
+  # Issue #236: the block's own comment above states the general hazard correctly (a non-zero
+  # exit from this pipeline kills `cmd_update` immediately under `set -euo pipefail`, and
+  # `2>/dev/null` hides why) and then fixed exactly ONE instance of it — an unencodable-glyph
+  # UnicodeEncodeError under a C-locale stdout. A host with no `python3` on PATH at all hits the
+  # SAME `set -e` exposure a different way: bash's own command-not-found is exit 127, printing
+  # NOTHING (this block's stdout carries the WARN/INFO lines; nothing has been emitted yet), and
+  # `cmd_update` dies right here — before ever reaching the `case "$kind" in` dispatch below, on
+  # a perfectly healthy host (kind=noop). Verified: `env -i PATH=/nonexistent-marker bash` on the
+  # pre-fix block exits 127 with empty output. `|| true` (matching `doctor_json=... || true` a
+  # few lines above, the fix for the identical exposure on the PRECEDING python3 call) makes this
+  # block's own failure — for ANY reason: command-not-found, a stdin JSON error the inner
+  # try/except doesn't already swallow, a future exit code this comment didn't anticipate —
+  # non-fatal to `cmd_update`, same as its sibling.
   if [[ -n "$doctor_json" ]]; then
     echo "$doctor_json" | python3 -c "
 import sys, json
@@ -831,7 +844,7 @@ for c in d.get('checks', []):
         print(f\"⚠ {c.get('message', '')}\")
     elif level == 'INFO':
         print(f\"ℹ {c.get('message', '')}\")
-" 2>/dev/null
+" 2>/dev/null || true
   fi
 
   case "$kind" in
@@ -843,7 +856,7 @@ for c in d.get('checks', []):
       _cmd_update_restart "$script_dir" "$@"
       ;;
     update)
-      _cmd_update_light "$script_dir"
+      _cmd_update_light "$script_dir" "$@"
       ;;
     upgrade|fresh_install)
       exec node "$script_dir/scripts/upgrade.mjs" "$@"
@@ -862,11 +875,27 @@ for c in d.get('checks', []):
 
 # Existing light-path body extracted into a helper so cmd_update can call it conditionally.
 _cmd_update_light() {
-  local script_dir="$1"
+  local script_dir="$1"; shift
   echo "Updating OCP (light path)..."
   cd "$script_dir"
-  local old_ver new_ver
+  local old_ver new_ver arg
   old_ver=$(python3 -c "import json; print(json.load(open('package.json'))['version'])" 2>/dev/null || echo "?")
+
+  # Honor --dry-run BEFORE any mutation (issue #235). This arm used to be called with NO
+  # forwarding at all — `cmd_update`'s `update)` case did `_cmd_update_light "$script_dir"`,
+  # dropping every flag including --dry-run — so `ocp update --dry-run` on the single most
+  # common upgrade path (an ordinary same-minor patch bump) silently ran a real `git pull` and a
+  # real restart despite ocp:732's documented "Preview the plan, don't mutate" contract.
+  # _cmd_update_restart (added by #217, for the sibling "restart" kind) already got this right;
+  # mirrors its --dry-run loop verbatim rather than inventing a second shape for the same flag.
+  for arg in "$@"; do
+    if [[ "$arg" == "--dry-run" ]]; then
+      echo "[dry-run] would pull latest from origin/main, install deps, and restart the proxy."
+      echo "[dry-run] currently v$old_ver; no git/npm/restart operations performed."
+      return 0
+    fi
+  done
+
   echo "  Pulling latest from GitHub..."
   if ! git pull origin main --ff-only 2>&1 | sed 's/^/    /'; then
     echo "  ✗ Git pull failed. Resolve conflicts manually in: $script_dir"

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -8468,6 +8468,22 @@ test("MED-F: rollback's SYSTEM-unit refusal recommends a bare (no-sudo) command 
 // four function signatures every test below depends on, slice does NOT contain the dispatch
 // case statement itself (overgrown-slice guard), and the REMOVED tail DOES contain it (confirms
 // the boundary is where this comment claims, not merely "found A/B in either order").
+//
+// Scope, stated exactly (not merely implied by what's tested): this harness's `node` stub
+// recognizes `scripts/doctor.mjs --json` (drives the kind decision) and `scripts/upgrade.mjs
+// --post-flight-only` (drives _cmd_update_restart's verification step) by pattern-matching the
+// invoking ARGV and returning a canned exit code — it never actually runs `scripts/upgrade.mjs`
+// itself. This deliberately does NOT cover #225's own N6 finding: the real argv-parsing inside
+// `scripts/upgrade.mjs`'s `_isMain()` CLI entrypoint (the `postFlightOnlyIdx = args.indexOf(...)`
+// block, `scripts/upgrade.mjs` around line 598) that decides what "--post-flight-only" even
+// means before `runPostFlightCheck`/`postFlightOk` (already covered directly, by name, elsewhere
+// in this file — see the "upgrade full path" section's imports) get called. #225 explicitly
+// flagged N6 as requiring a DECISION ("either invoke the real CLI end-to-end ... or refactor
+// scripts/upgrade.mjs to accept an injectable ocpDir/homedir() override — whoever picks this up
+// should decide which") rather than assuming either path is free. This PR's decision: defer,
+// same as PR #217's own manual pass did for the same finding — invoking the real CLI end-to-end
+// risks exactly the mutation hazard this harness's `node` stub exists to prevent, and building
+// the injectable-override refactor is its own, separable unit of work. Tracked in #241.
 console.log("\nocp bash CLI wiring (#225, #235, #236):");
 
 const _bwOcpPath = spotJoin(_spotDir, "ocp");
@@ -8590,6 +8606,15 @@ function _bwHarnessRun({
     // definition of a function name is executed LAST, so plain top-to-bottom ordering in one
     // file gives the same guarantee as "define the stub after `source`" without an actual
     // `source` call.
+    //
+    // Independent-review finding (MEDIUM-1): an earlier revision of this harness ran ONLY the
+    // sliced function-definitions region and then called `cmd_update "$@"` directly, which
+    // never executes ocp's own OUTER dispatch (the `case "$subcmd" in ... update) cmd_update
+    // "$@" ;; ...` block after `# ── dispatch`). Dropping "$@" at THAT outer arm fully
+    // reintroduces #235's bug class yet left the suite green under the direct-call design,
+    // because that design skipped the exact wiring layer #225 asks this harness to cover.
+    // Fixed by appending the REAL, unmodified dispatch section after the override and driving
+    // it via its own argv, so the outer dispatch runs for real too.
     const driver = [
       _bwFnSrc,
       "",
@@ -8602,7 +8627,7 @@ function _bwHarnessRun({
       "",
       `PROXY="http://127.0.0.1:1"`,
       "",
-      `cmd_update "$@"`,
+      _bwFullSrc.slice(_bwDispatchIdx > -1 ? _bwDispatchIdx : _bwFullSrc.length),
       "",
     ].join("\n");
     const driverPath = join(root, "driver.sh");
@@ -8618,6 +8643,9 @@ function _bwHarnessRun({
       OCP_ADMIN_KEY: "",
     };
 
+    // `args[0]` is now the top-level SUBCOMMAND, since the real dispatch runs for real (see the
+    // driver-assembly comment above) — callers below pass `["update", ...flags]`, matching a
+    // real `ocp update ...` invocation's argv shape.
     let stdout = "", stderr = "", status = 0;
     try {
       stdout = execFileSync("bash", [driverPath, ...args], { cwd: root, env, encoding: "utf8" });
@@ -8638,8 +8666,11 @@ function _bwCalled(log, prefix) {
 }
 
 // ── #235: `ocp update --dry-run` must not mutate on the patch-bump ("update" kind) path ──────
+// args[0]="update" drives this through ocp's REAL top-level dispatch (`case "$subcmd" in ...
+// update) cmd_update "$@" ;;`), not a direct call to cmd_update — see the driver-assembly
+// comment in _bwHarnessRun for why that distinction is load-bearing (MEDIUM-1 finding).
 test("#235: cmd_update kind=update --dry-run does NOT pull or restart (the money test)", () => {
-  const r = _bwHarnessRun({ kind: "update", args: ["--dry-run"] });
+  const r = _bwHarnessRun({ kind: "update", args: ["update", "--dry-run"] });
   assert.equal(r.status, 0, `expected a clean exit, got status=${r.status} stderr=${r.stderr}`);
   assert.ok(!_bwCalled(r.log, "FAKE-GIT-CALL"), `git must NOT run under --dry-run; log=${JSON.stringify(r.log)}`);
   assert.ok(!_bwCalled(r.log, "FAKE-CMD-RESTART-CALLED"), `cmd_restart must NOT run under --dry-run; log=${JSON.stringify(r.log)}`);
@@ -8647,30 +8678,42 @@ test("#235: cmd_update kind=update --dry-run does NOT pull or restart (the money
 });
 
 test("#235: cmd_update kind=update --dry-run still honors dry-run when --dry-run is NOT the first flag ('\"$@\"', not just $1)", () => {
-  const r = _bwHarnessRun({ kind: "update", args: ["--yes", "--dry-run"] });
+  const r = _bwHarnessRun({ kind: "update", args: ["update", "--yes", "--dry-run"] });
   assert.ok(!_bwCalled(r.log, "FAKE-GIT-CALL"), `git must NOT run; log=${JSON.stringify(r.log)}`);
   assert.ok(!_bwCalled(r.log, "FAKE-CMD-RESTART-CALLED"), `cmd_restart must NOT run; log=${JSON.stringify(r.log)}`);
   assert.ok(r.stdout.includes("[dry-run]"), `expected a [dry-run] line, got: ${JSON.stringify(r.stdout)}`);
 });
 
 test("#235 control: cmd_update kind=update with NO --dry-run DOES pull and restart (proves the money test above can fail)", () => {
-  const r = _bwHarnessRun({ kind: "update", args: [] });
+  const r = _bwHarnessRun({ kind: "update", args: ["update"] });
   assert.equal(r.status, 0, `expected a clean exit, got status=${r.status} stderr=${r.stderr}`);
   assert.ok(_bwCalled(r.log, "FAKE-GIT-CALL pull origin main --ff-only"), `git pull must run; log=${JSON.stringify(r.log)}`);
   assert.ok(_bwCalled(r.log, "FAKE-CMD-RESTART-CALLED"), `cmd_restart must run; log=${JSON.stringify(r.log)}`);
   assert.ok(!r.stdout.includes("[dry-run]"), `must NOT print a dry-run preview when actually mutating, got: ${JSON.stringify(r.stdout)}`);
 });
 
+test("#235 acceptance (independent-review MEDIUM-1): this money test runs through ocp's REAL outer dispatch, not a direct cmd_update call", () => {
+  // A mutation dropping "$@" at the OUTER `update) cmd_update "$@" ;;` arm (as opposed to the
+  // inner kind-dispatch arm #235 itself fixed) fully reintroduces the bug's observable
+  // behavior — git+restart fire under --dry-run because no flags ever reach cmd_update at all.
+  // Demonstrated by hand (file-backup mutation, restored + shasum-verified) in the PR
+  // description; this test is the automated guard that mutation is caught by, since it drives
+  // the real dispatch end to end rather than skipping straight to the inner function.
+  const r = _bwHarnessRun({ kind: "update", args: ["update", "--dry-run"] });
+  assert.ok(!_bwCalled(r.log, "FAKE-GIT-CALL") && !_bwCalled(r.log, "FAKE-CMD-RESTART-CALLED"),
+    `--dry-run must survive ocp's real outer dispatch and prevent mutation; log=${JSON.stringify(r.log)}`);
+});
+
 // ── Sibling non-regression: the "restart" kind's pre-existing --dry-run guard (PR #217) ──────
 test("non-regression: cmd_update kind=restart --dry-run still does not restart (pre-existing #217 guard, unaffected by #235's fix)", () => {
-  const r = _bwHarnessRun({ kind: "restart", args: ["--dry-run"] });
+  const r = _bwHarnessRun({ kind: "restart", args: ["update", "--dry-run"] });
   assert.ok(!_bwCalled(r.log, "FAKE-GIT-CALL"), `git must NOT run; log=${JSON.stringify(r.log)}`);
   assert.ok(!_bwCalled(r.log, "FAKE-CMD-RESTART-CALLED"), `cmd_restart must NOT run; log=${JSON.stringify(r.log)}`);
   assert.ok(r.stdout.includes("[dry-run]"), `expected a [dry-run] line, got: ${JSON.stringify(r.stdout)}`);
 });
 
 test("non-regression control: cmd_update kind=restart with NO --dry-run DOES restart + post-flight verify", () => {
-  const r = _bwHarnessRun({ kind: "restart", args: [] });
+  const r = _bwHarnessRun({ kind: "restart", args: ["update"] });
   assert.ok(!_bwCalled(r.log, "FAKE-GIT-CALL"), `restart kind must never touch git; log=${JSON.stringify(r.log)}`);
   assert.ok(_bwCalled(r.log, "FAKE-CMD-RESTART-CALLED"), `cmd_restart must run; log=${JSON.stringify(r.log)}`);
   assert.ok(_bwCalled(r.log, "FAKE-NODE-CALL") && r.log.some((l) => l.includes("post-flight-only")),
@@ -8679,7 +8722,7 @@ test("non-regression control: cmd_update kind=restart with NO --dry-run DOES res
 
 // ── #236: the WARN/INFO block must not kill cmd_update when python3 is absent ────────────────
 test("#236: cmd_update survives an absent python3 — no silent 127 death before the kind dispatch even runs", () => {
-  const r = _bwHarnessRun({ kind: "noop", pythonAbsent: true });
+  const r = _bwHarnessRun({ kind: "noop", args: ["update"], pythonAbsent: true });
   // Before the fix: bash's own command-not-found for the WARN/INFO block's python3 is exit 127,
   // with NOTHING printed yet (the case "$kind" in dispatch below it — the ONLY place this
   // function prints anything at that point — never runs). That exact signature is the
@@ -8696,6 +8739,7 @@ test("#236: cmd_update survives an absent python3 — no silent 127 death before
 test("#236 control: cmd_update with python3 PRESENT reaches the kind dispatch and prints WARN/INFO lines", () => {
   const r = _bwHarnessRun({
     kind: "noop",
+    args: ["update"],
     checks: [{ level: "WARN", message: "control-warn-marker" }, { level: "INFO", message: "control-info-marker" }],
   });
   assert.equal(r.status, 0, `expected a clean exit, got status=${r.status} stderr=${r.stderr}`);

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -8420,6 +8420,290 @@ test("MED-F: rollback's SYSTEM-unit refusal recommends a bare (no-sudo) command 
     "already root must not be told to prefix the manual command with sudo");
 });
 
+// ═════════════════════════════════════════════════════════════════════════════
+// ── ocp bash CLI wiring harness (issue #225) ──────────────────────────────────
+// ═════════════════════════════════════════════════════════════════════════════
+// `ocp` is a bash script; everything above tests JS. Before this section, `test-features.mjs`
+// had no way to exercise `ocp`'s own dispatch/argument-forwarding wiring — the exact layer an
+// independent review of PR #217 found to be 0/2 on mutation-catching (surviving mutations: the
+// `--dry-run` guard _cmd_update_restart's review round added, and "$@" forwarding in a case
+// arm), versus 9/9 on the JS layer (doctor.mjs, restart-unit.mjs, ocp-connect, service-mode).
+// One of the two survivors was deleting the exact guard PR #217 spent three review rounds
+// adding. This harness closes that gap and is the regression test for issues #235 and #236,
+// found by the same review pass that produced #225.
+//
+// Harness shape (the "proven shape" #225 itself prescribes): slice ONLY the function
+// definitions out of `ocp` — everything before the `# ── dispatch` section header — and run
+// that slice in a real `bash` child process, with `cmd_restart` overridden as a shell function
+// (defined AFTER the sliced source, in the same generated file — bash resolves whichever
+// definition of a name appears LAST, so simple textual ordering gives the same "source, then
+// override" semantics issue #225 prescribes without a separate `source` command) and every
+// other externally-hazardous command replaced by a REAL EXECUTABLE FILE on a scratch $PATH.
+//
+// Why real files, not shell functions, for node/git/launchctl/systemctl/pkill/nohup/openclaw:
+// `ocp`'s `upgrade|fresh_install)` kind arm does exactly `exec node "$script_dir/scripts/
+// upgrade.mjs" "$@"` (also reached via `--rollback` and via `cmd_doctor`). Bash's `exec`
+// replaces the process image via a normal PATH lookup for an executable — it does NOT consult
+// the shell function table at all, so a `node() { ... }` shell-function override would be
+// silently bypassed at exactly that line, and the REAL `scripts/upgrade.mjs` would run (which,
+// under `--yes`, `execSync`s `mv ~/.ocp …` and `rm -rf <ocpDir>`). A previous attempt at this
+// harness took a reviewing host's production OCP down this exact way, in miniature, by
+// defining a `cmd_restart` shell-function stub BEFORE sourcing the real `ocp` (the real
+// definition, sourced afterward, silently won). Putting a real fake-node FILE ahead of the
+// real node on a from-scratch $PATH — never inheriting the calling shell's $PATH — makes the
+// `exec` arm unreachable BY CONSTRUCTION: whether `node` is reached via a plain call, a
+// pipeline, or `exec`, the executable that answers is this harness's own, and its default case
+// for any invocation it doesn't explicitly recognize (`scripts/doctor.mjs --json` or
+// `scripts/upgrade.mjs --post-flight-only`) refuses loudly (exit 97) rather than silently
+// succeeding or falling through to a real script that doesn't exist in the scratch tree anyway.
+// `launchctl`/`systemctl`/`pkill`/`nohup`/`openclaw` get the same scratch-$PATH treatment as
+// defense in depth, even though the tests below only ever reach them (if at all) through the
+// `cmd_restart` shell-function override, which never calls them for real.
+//
+// Anchor-drift guard (AGENTS.md "Testing discipline"): "dispatch" is a unique word among this
+// file's own repeated "# ── <section> ──" header-comment convention (usage/status/health/.../
+// restart/update/doctor/help each get one; only this one is named "dispatch"), so a plain
+// `.indexOf` is safe from the multi-header collision the ocp-connect harness above guards
+// against with paired start/end anchors. Still guarded: slice non-empty, slice contains the
+// four function signatures every test below depends on, slice does NOT contain the dispatch
+// case statement itself (overgrown-slice guard), and the REMOVED tail DOES contain it (confirms
+// the boundary is where this comment claims, not merely "found A/B in either order").
+console.log("\nocp bash CLI wiring (#225, #235, #236):");
+
+const _bwOcpPath = spotJoin(_spotDir, "ocp");
+const _bwFullSrc = _ltRead(_bwOcpPath, "utf8");
+const _BW_DISPATCH_ANCHOR = "# ── dispatch";
+const _bwDispatchIdx = _bwFullSrc.indexOf(_BW_DISPATCH_ANCHOR);
+// Guard against a negative-index slice (`.slice(0, -1)` would silently return "everything but
+// the last char" instead of throwing) BEFORE computing the slice, not after.
+const _bwFnSrc = _bwDispatchIdx === -1 ? "" : _bwFullSrc.slice(0, _bwDispatchIdx);
+
+test("ocp bash harness: '# ── dispatch' anchor slice is well-formed (premise, #225)", () => {
+  assert.notEqual(_bwDispatchIdx, -1,
+    "'# ── dispatch' anchor not found in ocp — reformatted? update the harness anchor");
+  assert.ok(_bwFnSrc.trim().length > 0, "function-definitions slice is empty — anchor drift");
+  for (const marker of ["cmd_update()", "_cmd_update_light()", "_cmd_update_restart()", "cmd_restart()"]) {
+    assert.ok(_bwFnSrc.includes(marker), `function-definitions slice missing ${marker} — anchor drift`);
+  }
+  assert.ok(!_bwFnSrc.includes('case "$subcmd" in'),
+    "function-definitions slice overgrown into the dispatch case statement — anchor drift");
+  assert.ok(_bwFullSrc.slice(_bwDispatchIdx > -1 ? _bwDispatchIdx : 0).includes('case "$subcmd" in'),
+    "the dispatch case statement was expected AFTER the anchor and is missing — anchor drift");
+});
+
+// Runs `cmd_update <args>` against a from-scratch sandbox built fresh per call (own $HOME, own
+// $PATH, own scratch `script_dir` — never the real repo, never the calling shell's $PATH/$HOME).
+// `script_dir` doubles as the directory holding the generated driver script itself: `ocp`'s
+// functions resolve `script_dir` from `${BASH_SOURCE[0]}`, which — for a directly-executed
+// script (not `source`d) — is the file the running code was READ from, i.e. the driver file
+// this harness writes. package.json therefore lives next to driver.sh, not in a subdirectory.
+function _bwHarnessRun({
+  args = [], kind = "noop", checks = [], pythonAbsent = false,
+  gitPullExit = 0, gitPullOutput = "Already up to date.", postFlightExit = 0,
+} = {}) {
+  const root = _ltMkdtemp(join(_ltTmp(), "ocp-bash-harness-"));
+  try {
+    const home = join(root, "home");
+    const bin = join(root, "bin");
+    tMkdirSync(home, { recursive: true });
+    tMkdirSync(bin, { recursive: true });
+
+    testWriteFile(join(root, "package.json"), JSON.stringify({ version: "3.26.0" }));
+    const logPath = join(root, "log.txt");
+    testWriteFile(logPath, "");
+    const doctorJsonPath = join(root, "doctor.json");
+    testWriteFile(doctorJsonPath, JSON.stringify({
+      current_version: "v3.26.0", latest_version: "v3.26.0", next_action: { kind }, checks,
+    }));
+
+    const mkStub = (name, body) => {
+      const p = join(bin, name);
+      testWriteFile(p, `#!/usr/bin/env bash\n${body}\n`);
+      _ltChmod(p, 0o755);
+    };
+
+    // Recognizes exactly the two `node` invocations these two bugs' code paths can reach
+    // (doctor.mjs --json for the kind decision, upgrade.mjs --post-flight-only for
+    // _cmd_update_restart's verification step) and refuses anything else LOUDLY — including
+    // the `upgrade|fresh_install)` exec arm and `--rollback`, which this suite never exercises
+    // on purpose (see the exec-hazard note above the harness).
+    mkStub("node", [
+      `echo "FAKE-NODE-CALL $*" >> "${logPath}"`,
+      `case "$*" in`,
+      `  *"scripts/doctor.mjs --json"*)`,
+      `    cat "${doctorJsonPath}"`,
+      `    exit 0`,
+      `    ;;`,
+      `  *"scripts/upgrade.mjs --post-flight-only"*)`,
+      `    exit ${postFlightExit}`,
+      `    ;;`,
+      `  *)`,
+      `    echo "FAKE-NODE: refusing unhandled invocation (would run a REAL doctor.mjs/` +
+        `upgrade.mjs path -- see #225 exec hazard): $*" >&2`,
+      `    exit 97`,
+      `    ;;`,
+      `esac`,
+    ].join("\n"));
+
+    mkStub("git", [
+      `echo "FAKE-GIT-CALL $*" >> "${logPath}"`,
+      `case "$*" in`,
+      `  "pull origin main --ff-only")`,
+      `    echo ${JSON.stringify(gitPullOutput)}`,
+      `    exit ${gitPullExit}`,
+      `    ;;`,
+      `  *)`,
+      `    echo "FAKE-GIT: unhandled invocation: $*" >&2`,
+      `    exit 96`,
+      `    ;;`,
+      `esac`,
+    ].join("\n"));
+
+    // Defense in depth (AGENTS.md: "any command that can mutate a running service ... should
+    // be a stub that fails loudly by default") — unreachable from the tests below (which all
+    // override `cmd_restart` wholesale, see the driver below), but must never silently succeed
+    // if a future test forgets to.
+    for (const name of ["launchctl", "systemctl", "pkill", "nohup", "openclaw"]) {
+      mkStub(name, [
+        `echo "FAKE-${name.toUpperCase()}-CALL $*" >> "${logPath}"`,
+        `echo "FAKE-${name.toUpperCase()}: refusing -- this harness must never reach a real ` +
+          `service-mutating command (AGENTS.md 'unreachable by construction')" >&2`,
+        `exit 95`,
+      ].join("\n"));
+    }
+
+    // Simulates issue #236's exact repro ("stubbed absent": a real executable file that always
+    // reports command-not-found's own exit code) rather than trying to strip PATH of every
+    // directory that might contain a real python3 — the issue's own reviewer used the identical
+    // technique. Omitted entirely (not merely present-but-broken) when pythonAbsent is false, so
+    // the real /usr/bin/python3 answers instead (present on both this repo's macOS dev hosts and
+    // its Linux CI runners).
+    if (pythonAbsent) {
+      mkStub("python3", [
+        `echo "FAKE-PYTHON3-ABSENT-CALL $*" >> "${logPath}"`,
+        `exit 127`,
+      ].join("\n"));
+    }
+
+    // `cmd_restart` override goes AFTER the sliced source in the SAME generated file — never
+    // before (the #217 incident this harness exists to never repeat). Bash resolves whichever
+    // definition of a function name is executed LAST, so plain top-to-bottom ordering in one
+    // file gives the same guarantee as "define the stub after `source`" without an actual
+    // `source` call.
+    const driver = [
+      _bwFnSrc,
+      "",
+      `cmd_restart() {`,
+      `  echo "FAKE-CMD-RESTART-CALLED $*" >> "${logPath}"`,
+      `  echo "Restarting proxy..."`,
+      `  echo "✓ Proxy restarted successfully."`,
+      `  return 0`,
+      `}`,
+      "",
+      `PROXY="http://127.0.0.1:1"`,
+      "",
+      `cmd_update "$@"`,
+      "",
+    ].join("\n");
+    const driverPath = join(root, "driver.sh");
+    testWriteFile(driverPath, driver);
+
+    const env = {
+      HOME: home,
+      // From-scratch $PATH, never the calling shell's: our stubs first, then just enough of
+      // the real system to resolve bash builtins' external helpers (cat/sed/python3 when
+      // pythonAbsent is false) and nothing that could contain a second, real node/git.
+      PATH: `${bin}:/usr/bin:/bin`,
+      OCP_TEST_LOG: logPath,
+      OCP_ADMIN_KEY: "",
+    };
+
+    let stdout = "", stderr = "", status = 0;
+    try {
+      stdout = execFileSync("bash", [driverPath, ...args], { cwd: root, env, encoding: "utf8" });
+    } catch (e) {
+      stdout = e.stdout ?? "";
+      stderr = e.stderr ?? "";
+      status = typeof e.status === "number" ? e.status : 1;
+    }
+    const log = testExistsSync(logPath) ? _ltRead(logPath, "utf8").split("\n").filter(Boolean) : [];
+    return { stdout, stderr, status, log };
+  } finally {
+    _ltRm(root, { recursive: true, force: true });
+  }
+}
+
+function _bwCalled(log, prefix) {
+  return log.some((l) => l.startsWith(prefix));
+}
+
+// ── #235: `ocp update --dry-run` must not mutate on the patch-bump ("update" kind) path ──────
+test("#235: cmd_update kind=update --dry-run does NOT pull or restart (the money test)", () => {
+  const r = _bwHarnessRun({ kind: "update", args: ["--dry-run"] });
+  assert.equal(r.status, 0, `expected a clean exit, got status=${r.status} stderr=${r.stderr}`);
+  assert.ok(!_bwCalled(r.log, "FAKE-GIT-CALL"), `git must NOT run under --dry-run; log=${JSON.stringify(r.log)}`);
+  assert.ok(!_bwCalled(r.log, "FAKE-CMD-RESTART-CALLED"), `cmd_restart must NOT run under --dry-run; log=${JSON.stringify(r.log)}`);
+  assert.ok(r.stdout.includes("[dry-run]"), `expected a [dry-run] preview line in stdout, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#235: cmd_update kind=update --dry-run still honors dry-run when --dry-run is NOT the first flag ('\"$@\"', not just $1)", () => {
+  const r = _bwHarnessRun({ kind: "update", args: ["--yes", "--dry-run"] });
+  assert.ok(!_bwCalled(r.log, "FAKE-GIT-CALL"), `git must NOT run; log=${JSON.stringify(r.log)}`);
+  assert.ok(!_bwCalled(r.log, "FAKE-CMD-RESTART-CALLED"), `cmd_restart must NOT run; log=${JSON.stringify(r.log)}`);
+  assert.ok(r.stdout.includes("[dry-run]"), `expected a [dry-run] line, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#235 control: cmd_update kind=update with NO --dry-run DOES pull and restart (proves the money test above can fail)", () => {
+  const r = _bwHarnessRun({ kind: "update", args: [] });
+  assert.equal(r.status, 0, `expected a clean exit, got status=${r.status} stderr=${r.stderr}`);
+  assert.ok(_bwCalled(r.log, "FAKE-GIT-CALL pull origin main --ff-only"), `git pull must run; log=${JSON.stringify(r.log)}`);
+  assert.ok(_bwCalled(r.log, "FAKE-CMD-RESTART-CALLED"), `cmd_restart must run; log=${JSON.stringify(r.log)}`);
+  assert.ok(!r.stdout.includes("[dry-run]"), `must NOT print a dry-run preview when actually mutating, got: ${JSON.stringify(r.stdout)}`);
+});
+
+// ── Sibling non-regression: the "restart" kind's pre-existing --dry-run guard (PR #217) ──────
+test("non-regression: cmd_update kind=restart --dry-run still does not restart (pre-existing #217 guard, unaffected by #235's fix)", () => {
+  const r = _bwHarnessRun({ kind: "restart", args: ["--dry-run"] });
+  assert.ok(!_bwCalled(r.log, "FAKE-GIT-CALL"), `git must NOT run; log=${JSON.stringify(r.log)}`);
+  assert.ok(!_bwCalled(r.log, "FAKE-CMD-RESTART-CALLED"), `cmd_restart must NOT run; log=${JSON.stringify(r.log)}`);
+  assert.ok(r.stdout.includes("[dry-run]"), `expected a [dry-run] line, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("non-regression control: cmd_update kind=restart with NO --dry-run DOES restart + post-flight verify", () => {
+  const r = _bwHarnessRun({ kind: "restart", args: [] });
+  assert.ok(!_bwCalled(r.log, "FAKE-GIT-CALL"), `restart kind must never touch git; log=${JSON.stringify(r.log)}`);
+  assert.ok(_bwCalled(r.log, "FAKE-CMD-RESTART-CALLED"), `cmd_restart must run; log=${JSON.stringify(r.log)}`);
+  assert.ok(_bwCalled(r.log, "FAKE-NODE-CALL") && r.log.some((l) => l.includes("post-flight-only")),
+    `post-flight verification must run; log=${JSON.stringify(r.log)}`);
+});
+
+// ── #236: the WARN/INFO block must not kill cmd_update when python3 is absent ────────────────
+test("#236: cmd_update survives an absent python3 — no silent 127 death before the kind dispatch even runs", () => {
+  const r = _bwHarnessRun({ kind: "noop", pythonAbsent: true });
+  // Before the fix: bash's own command-not-found for the WARN/INFO block's python3 is exit 127,
+  // with NOTHING printed yet (the case "$kind" in dispatch below it — the ONLY place this
+  // function prints anything at that point — never runs). That exact signature is the
+  // regression to detect; asserting its NEGATION is the actual behavioral check (not merely
+  // "did not throw").
+  assert.ok(
+    !(r.status === 127 && r.stdout === ""),
+    `cmd_update died silently (status=127, empty stdout) — the #236 regression is back. ` +
+    `stderr=${JSON.stringify(r.stderr)} log=${JSON.stringify(r.log)}`,
+  );
+  assert.ok(r.stdout.length > 0, `expected SOME output even in degraded mode, got empty stdout (log=${JSON.stringify(r.log)})`);
+});
+
+test("#236 control: cmd_update with python3 PRESENT reaches the kind dispatch and prints WARN/INFO lines", () => {
+  const r = _bwHarnessRun({
+    kind: "noop",
+    checks: [{ level: "WARN", message: "control-warn-marker" }, { level: "INFO", message: "control-info-marker" }],
+  });
+  assert.equal(r.status, 0, `expected a clean exit, got status=${r.status} stderr=${r.stderr}`);
+  assert.ok(r.stdout.includes("control-warn-marker"), `expected the WARN line surfaced, got: ${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stdout.includes("control-info-marker"), `expected the INFO line surfaced, got: ${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stdout.includes("Already at latest"), `expected the noop-kind message, got: ${JSON.stringify(r.stdout)}`);
+});
+
 runAsyncTests().then(() => Promise.all(pendingAsync)).then(() => {
   closeDb();
   console.log(`\n=== Results: ${passed} passed, ${failed} failed ===\n`);


### PR DESCRIPTION
## Summary

- Builds a permanent bash test harness for `ocp`'s dispatch/argument-forwarding wiring (#225), driven by `npm test`.
- Uses it to fix the two live bugs it exists to catch: `ocp update --dry-run` mutating for real on the patch-bump path (#235), and `ocp update` dying silently on a host without `python3` (#236).
- No `cli.js` citation applies — `server.mjs` is untouched by this PR. `ALIGNMENT.md` governs the `cli.js`-mirror surface in `server.mjs`; this PR touches only `ocp` (the bash CLI wrapper) and `test-features.mjs`.
- **Independently reviewed** (Iron Rule 10 — implementer does not self-approve): see the review at the bottom of this description and the two follow-up commits that address its findings.

Closes #225
Closes #235
Closes #236

Refs #214, #217, #230, #233 (context) and #241, #242 (deliberately deferred follow-ups, see below).

## Why (independent review finding that motivated #225/#235/#236)

```
JS   (doctor.mjs, restart-unit.mjs, ocp-connect, service-mode)   9 / 9 caught
bash (ocp's dispatch layer)                                      0 / 2 caught
```

One survivor was deleting the `--dry-run` guard PR #217 spent three review rounds adding; the suite stayed green at 633/0. The other was dropping `"$@"` forwarding in a case arm. `test-features.mjs` had no way to exercise `ocp`'s bash wiring at all — it's JS-only.

## Harness shape (issue #225)

`test-features.mjs`, new section "ocp bash CLI wiring harness" (end of file):

- **Slice the function definitions, then run ocp's REAL dispatch on top of them.** Everything before `ocp`'s `# ── dispatch` comment is sliced out (sourcing past it runs the real CLI dispatcher, which calls `exit`). The driver script is assembled as: sliced functions → `cmd_restart` override → `PROXY` override → **the real, unmodified dispatch section appended verbatim**, then driven via its own argv (`bash driver.sh update --dry-run`, matching a real `ocp update --dry-run` invocation). This last part was added in this PR's second commit, after independent review (MEDIUM-1, see below) showed that calling `cmd_update "$@"` directly — skipping ocp's own top-level `case "$subcmd" in ... update) cmd_update "$@" ;;` — left a real coverage gap: dropping `"$@"` at THAT outer arm reintroduces #235's bug class with the suite staying green, because the harness wasn't exercising the wiring layer #225 actually asks for.
- Anchor-drift guards: slice non-empty, contains `cmd_update()`/`_cmd_update_light()`/`_cmd_update_restart()`/`cmd_restart()`, does NOT contain `case "$subcmd" in`, and the removed tail DOES — proven to fail loudly (not silently) by mutation (see table below).
- **Real executable stubs on a from-scratch $PATH, not shell functions, for `node`/`git`/`launchctl`/`systemctl`/`pkill`/`nohup`/`openclaw`.** `ocp`'s `upgrade|fresh_install)` kind arm does `exec node "$script_dir/scripts/upgrade.mjs" "$@"`. Bash's `exec` does a normal PATH lookup for an executable — it does **not** consult the shell function table — so a `node() { ... }` function stub would be silently bypassed there and the real `upgrade.mjs` would run (which, under `--yes`, `execSync`s `mv ~/.ocp …` and `rm -rf <ocpDir>`). A real fake-`node` **file** ahead of the real binary on a $PATH this harness builds from scratch (never inheriting the calling shell's) makes that arm unreachable **by construction**, regardless of how it's reached. The fake `node`'s default case for anything it doesn't explicitly recognize refuses loudly (exit 97) rather than silently succeeding. (Independently confirmed firsthand by the reviewer with a throwaway fictitious-command test of bash's `exec` semantics — see review below.)
- **`cmd_restart` overridden as a shell function, defined AFTER the sliced source in the same generated file** — never before. This is the exact ordering mistake that took a reviewing host's production OCP down during #217's review (a `cmd_restart` stub defined before `source`-ing the real `ocp` was silently shadowed once the real definition sourced over it; bootout succeeded, bootstrap failed, the nohup fallback wrote to a scratch dir). Simple top-to-bottom text ordering in one generated file gives the same "source, then override" guarantee without a separate `source` command.
- **Own $HOME, own $PATH, own scratch `script_dir` per test call** (fresh `mkdtempSync` sandbox, cleaned up in `finally`; env is *replaced*, not merged, so the calling shell's `$PATH`/`$HOME` never reach the child). Never the real repo, never the calling shell's environment.
- **Asserts on stdout content, not just exit codes** — per #225's own reasoning: with the CLI entry point deleted, control and mutant both exit 0 and only the output differs.
- **`python3` "absent"** is simulated the same way issue #236's own reviewer did it: a real executable file named `python3` that always exits 127 (command-not-found's own code), placed first on the scratch $PATH — omitted entirely (not merely broken) when a test wants the real system `python3` to answer instead.
- **Scope, stated exactly**: this harness does NOT cover #225's own N6 finding (the real argv-parsing inside `scripts/upgrade.mjs`'s `--post-flight-only` CLI entrypoint) — deliberately, for the same reason PR #217's manual pass deferred it (invoking the real CLI risks the exact mutation hazard the `node` stub exists to prevent). Documented in the harness's own top comment and cross-tracked on #241.

9 tests total: 1 harness-premise (anchor-drift guard), 4 for #235 (money test + `"$@"`-not-just-`$1` + control + the outer-dispatch acceptance test), 2 non-regression for the sibling `restart` kind (untouched by this PR, still correct), 2 for #236 (absent-python3 + control).

## The two fixes

**#235** — `ocp`'s `cmd_update` kind-dispatch `update)` arm forwarded none of `"$@"` to `_cmd_update_light`, and `_cmd_update_light` had zero `--dry-run` checks. Fixed by mirroring `_cmd_update_restart` (added by #217) exactly: forward `"$@"`, and check for `--dry-run` before `cd`/git pull/cmd_restart, printing a `[dry-run]` preview and returning 0.

**#236** — The WARN/INFO block inside `cmd_update` (added by #230) piped `doctor_json` into a `python3 -c "..." 2>/dev/null` with no `|| true`, unlike its immediately-preceding sibling line (`doctor_json=$(node ...) || true`). Under `set -euo pipefail`, a host with no `python3` on PATH hits this pipeline's own command-not-found exit (127) as a fatal, unguarded pipeline failure — killing `cmd_update` before it ever reaches the `case "$kind" in` dispatch, printing **nothing** on an otherwise perfectly healthy (`kind=noop`) host. Fixed with `|| true`, matching the sibling line and the general hazard the block's own comment already (correctly) describes.

## Independent review (Iron Rule 10)

A fresh-context reviewer checked out this PR, read the diff, independently verified bash's `exec` semantics firsthand (fictitious-command test), reproduced 4 of the mutation-table entries themselves (own file backup, own `shasum` verification, own restore), and ran the suite themselves (confirmed green on this PR's CI too). Full review: https://github.com/dtzp555-max/ocp/pull/243#issuecomment-5144157990

**Verdict: approve with notes.** Zero CRITICAL/HIGH findings; both fixes and the harness's safety-by-construction claims were independently verified, not just asserted. Three MEDIUM findings, all addressed in this PR's second commit / this description:

- **MEDIUM-1** (real gap, see harness-shape section above): fixed by making the harness run ocp's real outer dispatch instead of calling `cmd_update` directly. Re-verified: the exact mutation the reviewer described (`update)   cmd_update "$@" ;;` → `update)   cmd_update ;;`) now fails 4 tests with actionable messages; restored from a `shasum`-verified backup; suite green again (642/0 both sides).
- **MEDIUM-2** (N6 coverage decision stated but not spelled out): now documented explicitly in the harness's own comments and cross-tracked on #241 (comment added).
- **MEDIUM-3** (this PR body's `Closes` keywords weren't all registering — `gh pr view --json closingIssuesReferences` only picked up #225): fixed in this revision — `Closes #225` / `Closes #235` / `Closes #236` are now three separate lines (the commit message already had this right; only the PR body's condensed comma-separated line didn't parse the same way).

## Mutation table

All mutations applied to a **file backup**–verified copy of `ocp` (restored via `cp` from a `shasum -a 256`–verified backup after each; never `git checkout --`, which would only restore the last **committed** state, not the pre-mutation one). Full suite re-run after each restore to confirm green.

| # | Mutation | File | Before (bug present) | After (fix applied) |
|---|---|---|---|---|
| A | Revert #235's fix: drop `"$@"` from `_cmd_update_light "$script_dir" "$@"` in `cmd_update`'s inner `update)` kind arm | `ocp` | 2 tests FAIL: `git`+`cmd_restart` both called under `--dry-run` (log shows `FAKE-GIT-CALL pull origin main --ff-only`, `FAKE-CMD-RESTART-CALLED`) | Both PASS: 642/0 |
| B (**acceptance #1**) | Delete `_cmd_update_restart`'s `--dry-run` loop entirely | `ocp` | 1 test FAILS: `cmd_restart must NOT run; log=[...,"FAKE-CMD-RESTART-CALLED ","...post-flight-only..."]` | PASSES: 642/0 |
| C (**acceptance #2**) | Drop `"$@"` from `_cmd_update_restart "$script_dir" "$@"` in `cmd_update`'s inner `restart)` kind arm | `ocp` | Same test FAILS the same way (cmd_restart called under `--dry-run`) | PASSES: 642/0 |
| D | Remove `\|\| true` from the WARN/INFO block (the exact #236 defect) | `ocp` | 1 test FAILS: `cmd_update died silently (status=127, empty stdout) — the #236 regression is back` | PASSES: 642/0 |
| E | Reformat the `# ── dispatch` anchor comment (`# ── DISPATCH (reformatted)`) | `ocp` | Harness premise test fails FIRST and loudly (`'# ── dispatch' anchor not found ... update the harness anchor`), cascading into `cmd_update: command not found` on dependent tests — not a silent wrong-slice | PASSES: 642/0 |
| F (**MEDIUM-1 finding**) | Drop `"$@"` from the OUTER top-level dispatch arm: `update)   cmd_update "$@" ;;` → `update)   cmd_update ;;` | `ocp` | 4 tests FAIL (money test, `"$@"`-not-just-`$1`, the outer-dispatch acceptance test, and the sibling `restart`-kind non-regression test — all four run through this same outer arm) | All PASS: 642/0 |

Mutations A and D are the two live bugs' own regressions. **B and C are the exact two mutations #225 reports as having survived the previous manual review rig** ("delete the `--dry-run` guard in `_cmd_update_restart`" and dropping `"$@"` forwarding in a case arm) — re-run against this harness and now caught, satisfying the acceptance criterion. **F is the coverage gap the independent reviewer found** in this PR's first revision, now closed.

Every restore was `shasum -a 256`–verified byte-identical to the pre-mutation backup before re-running the suite.

## Suite count

**642 passed, 0 failed** (633 pre-existing + 9 new from this PR).

## External-binary audit (issue #236's ask)

Audited every `python3` invocation and other external-binary call in `ocp` for the same "bare pipeline/substitution, no `set -e`/pipefail fallback" shape. Fixed the one #236 reported (WARN/INFO block, `cmd_update`). Found 9 more with the same shape, all in read-only display commands (lower urgency — not on the upgrade-safety path, and most lack `2>/dev/null` too so failures are ungraceful rather than silent): `cmd_usage --by-key`, `cmd_usage` (main), `cmd_logs`, `cmd_models`, `cmd_sessions`, `cmd_clear`, `cmd_keys add`, `cmd_keys revoke`, `cmd_settings` (GET). Also noted: `cmd_restart`'s `openclaw gateway restart` has no fallback, and `scripts/upgrade.mjs`'s bare `lsof` call (no absolute path) is better fixed alongside #233's own exit-code finding on the same line. Full detail, line numbers, and reasoning: **#242**.

## Deferred (not in this PR)

- **#241** — `_cmd_update_light` still lacks the `--post-flight-only` verification `_cmd_update_restart` got from #217, and `--target` is silently ignored on the light path now that it receives `"$@"`. Both change the light path's exit-code contract and/or its git mechanism (tag-checkout vs. fast-forward pull) — a separate design decision from the dry-run mutation fix, kept out of this PR per Iron Rule 11 (minimum reviewable unit). Now also tracks #225's N6 finding (see comment on #241).
- **#242** — the broader python3-fallback audit above, as a systematic remediation PR.

## Test plan

- [x] `bash -n ocp` — syntax clean
- [x] `node --check test-features.mjs` — syntax clean
- [x] `npm test` — 642 passed, 0 failed
- [x] Mutation table above (A–F), each restored from a `shasum`-verified file backup, suite green after each restore
- [x] Acceptance mutations (B, C) re-run and confirmed caught
- [x] Independent review completed (Iron Rule 10); all MEDIUM findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gbqUZ8HfBZpjjbzQ85oH8
