### PR TITLE
docs: sweep post-#221 staleness across 8 locations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ Allocate ports with `ltFreePort()`. Fixed ports have caused at least one flake h
 
 ## Testing discipline: what counts as a test
 
-Enforced as a review condition on recent test PRs (#204, #205, #208, #216, #218; #221 still in review), never written down. Its only written form was inside #210: "This is behavioral, so a mutation to the table or the fallback fails it. A source-grep test would not — and per this repo's standing rule, a test that greps source is not a test." Written down now (#223). Line numbers below are `test-features.mjs` unless noted.
+Enforced as a review condition on recent test PRs (#204, #205, #208, #216, #218, #221), never written down. Its only written form was inside #210: "This is behavioral, so a mutation to the table or the fallback fails it. A source-grep test would not — and per this repo's standing rule, a test that greps source is not a test." Written down now (#223). Line numbers below are `test-features.mjs` unless noted.
 
 - **Behavioral, not textual.** A test asserting on the *source text* of the thing it tests is not a test — it passes when the code is deleted and re-added wrong, and breaks on reformatting. Assert on behavior: call the function, run the process, read the output. The ocp-connect section (#210, #218, ~5690) `exec()`s the real `model_meta`/`get_model_meta()` sliced from `ocp-connect`'s source instead of grepping for a number. Exception this suite relies on: a textual assertion is fine for a *premise of the harness or a slice boundary*, never the behavior under test — see the heredoc-quoting check (`:5992`) and the kept `os.makedirs`/`open(config_path` anchor-drift guards (`:5792-5793`).
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -30,16 +30,26 @@ What `ocp update` does:
   unit (because a different unit already owns the port) stays disabled across an upgrade.
   Running the installer's reconfigure step with a bare `setup.mjs` (no flag) would
   start/enable the unit itself, before the restart phase gets a chance to run — on the host
-  that motivated issue #215, that reproduces the orphan process #215 describes and re-arms
-  its boot race. **This alone does not stop the #215 orphan**, though: the restart phase
-  that runs next is, as of this writing, still a hard-coded `systemctl --user restart
-  ocp-proxy.service` — it does not yet resolve which unit actually owns the port (that fix,
-  #221, is a separate PR). So on the #215 host specifically, the restart phase still starts
-  `ocp-proxy` unconditionally a few steps later; --reconfigure-only removes the boot-race
-  re-arm (`enable`) and phase 4 racing ahead of phase 5 (its premature `start`), which is
-  half of the #215/#226 defect family, not the orphan itself. A first install
-  (`node setup.mjs`, no flags) is unaffected and still enables + starts the service, which
-  is that path's actual job.
+  that motivated issue #215, that would reproduce the orphan process #215 describes and
+  re-arm its boot race. `--reconfigure-only` removes that half of the risk (phase 4 no
+  longer races ahead of phase 5 with a premature `enable`/`start`); the restart phase that
+  runs next closes most of the other half. **On Linux**, it no longer hard-codes a restart
+  target — it resolves which unit actually owns the port from live process/cgroup state
+  before restarting it (PR #221, merged). **macOS coverage is narrower** — see
+  [Restart target resolution](#restart-target-resolution) below for exactly what is and
+  isn't verified there. A first install (`node setup.mjs`, no flags) is unaffected and still
+  enables + starts the service, which is that path's actual job.
+
+  The same #215 defect shape is **not yet fully fixed**: the "tree already at latest" and
+  patch-bump paths above both delegate to bash's `cmd_restart()`, a hard-coded
+  try-these-names-in-order cascade that does not do the live-ownership resolution described
+  above — tracked separately as
+  [#224](https://github.com/dtzp555-max/ocp/issues/224). And on the cross-minor path just
+  described, a narrower gap remains on macOS even after that resolution runs (see
+  [Restart target resolution](#restart-target-resolution) below): a *confirmed* listener
+  there is still restarted over without verifying it is actually the `dev.ocp.proxy` job —
+  its own open item, tracked as
+  [#239](https://github.com/dtzp555-max/ocp/issues/239).
 - **Old version** (< v3.4.0):
   fresh-install. Pre-v3.4 lacked admin-key/usage-db, so there is nothing to
   migrate. Your OAuth token (managed by the Claude Code CLI, not OCP) is
@@ -124,7 +134,7 @@ on both paths.
 | `requires "sudo systemctl restart -- <unit>"` | The port is owned by a SYSTEM unit and non-interactive sudo isn't authorized for that specific command. | Run the printed `sudo systemctl restart -- <unit>` manually, or grant it explicitly (e.g. `deploy ALL=(root) NOPASSWD: /bin/systemctl restart -- <unit>`), then re-run. |
 | `rollback only restores the launchd plist and the USER-scope systemd unit file` | `--rollback` resolved the port to a SYSTEM unit. Rollback (see `scripts/lib/snapshot.mjs`) never captured or restores that unit's OWN config, so that part of the refusal stands — but the message also names the exact commit the working tree was already rolled back to and the exact manual restart command, since on a host where that unit runs from the same working tree (common — see issue #215), the code-level rollback is otherwise complete. | Run the printed manual restart command; separately roll back the system unit's own config by hand if that also needs it. |
 
-> **Upgrading with an existing `NOPASSWD` sudoers rule — read this if you granted one before v3.27.0.**
+> **Upgrading with an existing `NOPASSWD` sudoers rule — read this if you granted one before PR #221.**
 > The probe now sends `systemctl restart -- <unit>`; it previously sent `systemctl restart <unit>`.
 > `sudoers(5)`: *"If a Cmnd has associated command line arguments, the arguments in the Cmnd must
 > match those given by the user on the command line."* So a rule written as

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -44,16 +44,16 @@ function semverCompare(a, b) {
 // `ocp doctor` surfaced this; it was found by hand while diagnosing an unrelated
 // update failure. See issue #215 for the live evidence table.
 //
-// Relationship to scripts/lib/restart-unit.mjs: introduced on PR #221's branch
-// (issue #215's OTHER half; NOT YET on main as of this writing — #221 is still
-// in review) to resolve which unit CURRENTLY owns the port from LIVE
-// process/cgroup state (ss/lsof + /proc/<pid>/cgroup) for the upgrade restart
-// phase — a live-PID question. This check answers a different, STATIC question
-// — which units WOULD start at boot, and are any two of them configured to
-// collide on the same port — by reading unit-file config (`systemctl show`
-// ExecStart/Environment, or plist content on macOS), never a live PID. No logic
-// is shared or duplicated between the two; this module intentionally does not
-// import restart-unit.mjs and does not depend on #221 landing first.
+// Relationship to scripts/lib/restart-unit.mjs: introduced by PR #221 (merged)
+// — issue #215's OTHER half — to resolve which unit CURRENTLY owns the port
+// from LIVE process/cgroup state (ss/lsof + /proc/<pid>/cgroup) for the
+// upgrade restart phase — a live-PID question. This check answers a
+// different, STATIC question — which units WOULD start at boot, and are any
+// two of them configured to collide on the same port — by reading unit-file
+// config (`systemctl show` ExecStart/Environment, or plist content on macOS),
+// never a live PID. No logic is shared or duplicated between the two; this
+// module intentionally does not import restart-unit.mjs — the two checks are
+// independent by design, not because one was waiting on the other to land.
 //
 // WARN, never FAIL: scripts/upgrade.mjs's runUpgrade() pre-flight guard only
 // tolerates ready_to_upgrade=false for next_action.kind="fresh_install" — a

--- a/scripts/lib/install-autostart.mjs
+++ b/scripts/lib/install-autostart.mjs
@@ -14,9 +14,10 @@
 // was looking for (co-location, not containment) and passed at 506/0. The actual fix, per that
 // review, is this file: move the imperative body into something an injected `run`/fs layer can
 // observe, the same seam `scripts/upgrade.mjs` already uses (`opts.mockExec`) and `doctor.mjs`
-// uses (`opts.mockHealth`) — NOT `scripts/lib/restart-unit.mjs`, which does not exist on `main`
-// (it ships only in #221, a separate, still-unmerged PR; an earlier draft of this module
-// wrongly cited it as precedent).
+// uses (`opts.mockHealth`) — NOT `scripts/lib/restart-unit.mjs`'s shape (a pure decision layer
+// unit-tested by injecting fake command OUTPUT, rather than an injectable run/fs seam like
+// this module's): `scripts/lib/restart-unit.mjs` has since merged (#221) but was not yet on
+// `main` when an earlier draft of this module wrongly cited it as precedent.
 //
 // installAutoStart() performs every action setup.mjs's Step 7 used to perform inline: legacy-
 // unit migration (gated on !servicePlan.reconfigureOnly — issue #226 review finding H1),

--- a/scripts/lib/service-mode.mjs
+++ b/scripts/lib/service-mode.mjs
@@ -18,13 +18,18 @@
 // ocp.service) already owns the listening port, that unconditional `start` produces exactly
 // the orphan #215 describes, and `enable` re-arms the boot race #215 calls "the part that
 // makes it more than cosmetic" — both BEFORE phase 5 (whose job is restarting) ever runs.
-// NOTE (review correction): phase 5, as it exists on `main` at the time of this PR, is still
-// the pre-#221 hard-coded `systemctl --user restart ocp-proxy.service` — #221 (the
-// restart-target-ownership resolution) is a separate, still-open/unmerged PR. This PR's fix
-// removes phase 4's `enable` re-arm and its `start`, but on the #215 host specifically, phase
-// 5 STILL unconditionally starts the (possibly wrong) `ocp-proxy` unit a few lines later. This
-// module does not, by itself, stop that orphan — it removes half of the #215/#226 defect
-// family (the premature enable + the premature start-before-resolution), not all of it.
+// UPDATE (#221, merged): phase 5 no longer hard-codes `systemctl --user restart
+// ocp-proxy.service` — ON LINUX it now calls resolveRestartPlan() (scripts/lib/
+// restart-unit.mjs) to resolve which unit actually owns the port from live process/cgroup
+// state before restarting it. Together with #221, this module's fix (removing phase 4's
+// premature `enable`/`start`) closes the #215 orphan for the cross-minor upgrade path — ON
+// LINUX. ON MACOS, resolveRestartPlan()'s lsof/netstat cross-check (scripts/upgrade.mjs,
+// #240) now correctly tells a genuinely empty port apart from an ambiguous one (a listener
+// lsof can't identify the owner of) — but even a CONFIRMED listener is still restarted over
+// without verifying it's actually the `dev.ocp.proxy` job (open: #239). The same #215 defect
+// shape also persists, on both platforms, on the separate bash `cmd_restart` cascade used by
+// the patch-bump and plain-restart paths — tracked separately as #224, not touched by either
+// fix.
 // The macOS branch has the same phase-4-does-phase-5's-job shape: `launchctl bootstrap` both
 // loads AND starts the job (RunAtLoad=true in the plist).
 //
@@ -69,9 +74,9 @@ export function planServiceActions(platform, opts) {
       // enable-and-start install action should.
       enable: !reconfigureOnly,
       // starting now is phase 5's job (restart), not phase 4's (reconfigure) — see #226.
-      // (See the module-level note above: phase 5 today is still the pre-#221 hard-coded
-      // restart, so removing this `start` does not by itself resolve unit ownership — it only
-      // stops phase 4 from racing ahead of whatever phase 5 does.)
+      // (See the module-level note above: phase 5 now resolves unit ownership itself via
+      // resolveRestartPlan() (#221, merged); this `start` removal's job is only to stop
+      // phase 4 from racing ahead of phase 5's resolution, not to resolve ownership itself.)
       start: !reconfigureOnly,
     };
   }

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -441,16 +441,23 @@ async function runFullUpgrade({ doctor, opts }) {
     // migration are both gated on --reconfigure-only inside setup.mjs; see
     // scripts/lib/service-mode.mjs); must not enable-at-boot or start (issue #226). Enabling
     // re-arms the boot race #215 describes on a host with a competing unit for the same port.
-    // CORRECTION (review finding M2): this does NOT by itself stop #215's orphan. Phase 5
-    // below is still the pre-#221 hard-coded `systemctl --user restart ocp-proxy.service` —
-    // #221 (restart-target-ownership resolution) is a separate PR, open/unmerged as of this
-    // change. On the #215 host, phase 5 still unconditionally starts `ocp-proxy` a few lines
-    // down, regardless of what phase 4 does. What this fix removes is phase 4's premature
-    // `enable` (the boot-race re-arm) and its premature `start` (racing ahead of whatever
-    // phase 5 does) — half of the #215/#226 defect family, not all of it. --reconfigure-only
-    // is setup.mjs's opt-in mode for exactly this call site; a bare first install still calls
-    // setup.mjs without it (scripts/doctor.mjs's fresh_install path), so it keeps enabling +
-    // starting, which is that path's actual job.
+    // UPDATE: together with #221 (merged), this closes MOST of #215's orphan for THIS path.
+    // Phase 5 below no longer hard-codes `systemctl --user restart ocp-proxy.service` — ON
+    // LINUX it calls resolveRestartPlan() (scripts/lib/restart-unit.mjs), which resolves which
+    // unit actually owns the port from live process/cgroup state before restarting it. ON
+    // MACOS, resolveRestartPlan()'s lsof/netstat cross-check (mapLsofFailureToProbeValue /
+    // netstatHasListenerOnPort above, #240) now correctly tells a genuinely empty port apart
+    // from an ambiguous one (a listener lsof can't identify the owner of) — but even a
+    // CONFIRMED listener is still restarted over without verifying it's actually the
+    // `dev.ocp.proxy` job (open: #239). What this phase-4 fix removes is phase 4's premature
+    // `enable` (the boot-race re-arm) and its premature `start` (racing ahead of phase 5's
+    // resolution); #221 is what makes phase 5 itself restart the right unit on Linux.
+    // --reconfigure-only is setup.mjs's opt-in mode for exactly this call site; a bare first
+    // install still calls setup.mjs without it (scripts/doctor.mjs's fresh_install path), so
+    // it keeps enabling + starting, which is that path's actual job.
+    // The same #215 defect shape persists on the SEPARATE bash `cmd_restart` cascade used by
+    // the patch-bump ("update") and plain-restart ("restart") kinds — tracked as #224, not
+    // fixed by this module.
     exec(`node ${ocpDir}/setup.mjs --reconfigure-only`, "reconfigure");
 
     // phase 5: restart (heads-up note printed before invoking)

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -1664,12 +1664,17 @@ test("upgrade full path executes 5 phases", async () => {
 // #215: on a host where a competing systemd/launchd unit already owns the OCP port, an
 // upgrade's reconfigure step (setup.mjs) must not enable-at-boot or start the service it
 // writes config for — that races/duplicates whatever phase 5 (restart) resolves to run, and
-// re-arms the boot race #215 describes. #221 fixes phase 5's target resolution (still open,
-// unmerged as of this section); this covers the layering fix so phase 4 stops performing
-// phase 5's job in the first place. NOTE: phase 5, as it exists on `main` right now, is still
-// the pre-#221 hard-coded restart — so on the actual #215 host, this fix alone does not stop
-// the orphan (phase 5 still unconditionally starts `ocp-proxy.service` a few lines later); it
-// removes the `enable` re-arm and phase 4's premature `start`, which is half the defect family.
+// re-arms the boot race #215 describes. #221 (merged) fixes phase 5's target resolution ON
+// LINUX — phase 5 no longer hard-codes a restart target, it resolves the unit that actually
+// owns the port from live process/cgroup state; this section covers the layering fix so
+// phase 4 stops performing phase 5's job in the first place. Together the two close the #215
+// orphan for this (cross-minor upgrade) path — on Linux. ON MACOS, phase 5's resolution (its
+// lsof/netstat cross-check, #240) now correctly tells a genuinely empty port apart from an
+// ambiguous one — but even a CONFIRMED listener is still restarted over without verifying
+// it's actually the `dev.ocp.proxy` job (open: #239). The same #215 defect shape also
+// persists, on both platforms, on the separate bash `cmd_restart` cascade used by the
+// patch-bump ("update") and plain-restart ("restart") kinds — tracked separately as #224,
+// not touched by either fix.
 //
 // planServiceActions() / resolveServicePlan() are imported directly (not replicated, unlike
 // the setup.mjs inject helpers above) because scripts/lib/service-mode.mjs is a real
@@ -6828,9 +6833,9 @@ test("ocp-connect: the hardcoded three-id JSON-parse-failure fallback never over
 //
 // This is a STATIC config cross-reference (which units WOULD start at boot,
 // and do any two collide) — deliberately independent of scripts/lib/
-// restart-unit.mjs (PR #221, not yet on main), which resolves a DIFFERENT,
-// live-PID question for the restart phase. See the PR body for the explicit
-// dependency decision.
+// restart-unit.mjs (PR #221, merged), which resolves a DIFFERENT, live-PID
+// question for the restart phase. See the PR body for the explicit
+// independence decision.
 //
 // Every test here is BEHAVIORAL: it calls the exported classifier/gatherer (or
 // runDoctor with an injected opts.run) and asserts on return values / pushed


### PR DESCRIPTION
## Defect

PR #221 (restart-target-ownership resolution) merged as `b833b7a`, but eight
places on `main` still described it as unmerged/pending/proposed — text
written earlier in the same v3.26.0..main batch, never swept once #221
actually landed. Per #238.

## Evidence

`grep -rn "#221"` plus a grep for "not yet on main" / "still-unmerged" /
"still in review" / "open/unmerged" near restart/unit/resolution wording
across `docs/`, `AGENTS.md`, `scripts/`, `test-features.mjs`:

| Location | Said (stale) | Says now |
|---|---|---|
| `docs/upgrading.md` (Cross-minor bullet) | phase 5 "is, as of this writing, still a hard-coded `systemctl --user restart ocp-proxy.service` ... (that resolution, #221, is a separate PR)" | phase 5 calls `resolveRestartPlan()` on Linux; residual gaps named explicitly (see Round 2 below) |
| `scripts/upgrade.mjs` (phase-4 comment) | "Phase 5 below is still the pre-#221 hard-coded ... open/unmerged as of this change" | describes `resolveRestartPlan()`, notes the residual gaps |
| `scripts/lib/service-mode.mjs` (module header + inline comment) | "phase 5 ... is still the pre-#221 hard-coded ... still-open/unmerged PR" | describes `resolveRestartPlan()`, notes the residual gaps |
| `scripts/lib/install-autostart.mjs` | "`restart-unit.mjs`, which does not exist on `main` (it ships only in #221, a separate, still-unmerged PR...)" | states it merged; preserves the original design point (different seam shape) |
| `scripts/doctor.mjs` (module comment) | "introduced on PR #221's branch ... NOT YET on main ... #221 is still in review"; "does not depend on #221 landing first" | states #221 merged; reworded independence rationale |
| `AGENTS.md:74` | "(#204, #205, #208, #216, #218; #221 still in review)" | "(#204, #205, #208, #216, #218, #221)" |
| `test-features.mjs` (×2) | "#221 addresses phase 5's target resolution (still open, unmerged...)"; "restart-unit.mjs (PR #221, not yet on main)" | both corrected to "merged" |

Issue #238 named 5 of these; the other 3 (`AGENTS.md` and the two
`test-features.mjs` comments) turned up from grepping `main` directly rather
than trusting the issue's list — as instructed.

All other `#221` mentions left untouched (in `scripts/upgrade.mjs`,
`scripts/lib/restart-unit.mjs`, `scripts/doctor.mjs`, `test-features.mjs`,
`AGENTS.md:78`) are historical citations of PR #221's own review findings
(MED-5, HIGH-1, etc.) — true regardless of merge status, not claims about
merge status, and out of scope for this sweep.

The two "smaller items" #238 also raises (`doctor.mjs` `schema_version` bump;
macOS plist regex-only scan gap) are explicitly left for a separate PR per
#238's own text ("decide separately") and Iron Rule 11 — this PR is
documentation-only staleness correction.

## Scope

Documentation/comment-only. **`server.mjs` is not touched** — no `cli.js`
citation applies (`ALIGNMENT.md` / `CLAUDE.md` hard requirement #1 is N/A).

---

## Review Round 2 — fixed

Independent re-review confirmed all 8 corrections above are true and
complete (its own pattern search across `docs/`, `README.md`, `AGENTS.md`,
`CLAUDE.md`, `scripts/`, `*.mjs`, `ocp`, `docs/adr/` found zero remaining
merge-status claims about #221 or any other merged PR). One blocking finding
and three non-blocking, all fixed here:

**MED-1 (blocking) — the sweep introduced four new false claims about
platform coverage.** Four of the corrected passages (`docs/upgrading.md`,
`scripts/upgrade.mjs`, `scripts/lib/service-mode.mjs`, `test-features.mjs`)
stated "resolves which unit actually owns the port from live process/cgroup
state before restarting it" as if this held universally. It's Linux-only.
Verified directly against `scripts/lib/restart-unit.mjs`: the darwin branch
of `resolveOwningUnit` (`:264-272`) returns `mismatched: false`
unconditionally for every outcome and has no `no-unit` analogue, and
`launchdCmds` (`:302-307`) hard-codes the bootout label `dev.ocp.proxy`
regardless of what the port is actually bound by — confirmed further that
`planRestart`'s `kind === "launchd"` branch (`:412-414`) proceeds
unconditionally, no mismatch check at all. So on macOS, a stray process
(e.g. a bare `node server.mjs`) holding the port is still restarted over.
This isn't an inference: `#233` (open) is titled verbatim "#221's
restart-target resolution is Linux-only — macOS never determines ownership,
and the docs say it does," and `#240` (open, in flight) exists partly to
remove the equivalent overclaim from `README.md` / `docs/troubleshooting.md`
/ the pre-existing "Restart target resolution" section of
`docs/upgrading.md` (which this PR does not touch). All four passages here
now explicitly separate Linux (real ownership resolution) from macOS
(listening/not-listening only, via `lsof`, no ownership determination) —
made true standalone, not coordinated with #240's ordering.

**MED-2 — residual-gap pointer still incomplete.** `docs/upgrading.md`'s
replacement paragraph named only `#224` (the bash `cmd_restart` cascade). It
omitted the macOS ownership gap (`#233`, `#239` — both open), a live
#215-shape hole on the very cross-minor path that paragraph describes. Now
names all three, neutral verbs only.

**LOW-1.** `docs/upgrading.md:38` said "issue #221, merged" — #221 is a PR;
every other reference in this PR correctly says "PR #221" (corrected as
part of the MED-1 edit).

**INFO (pre-existing, confirmed not introduced by this PR, fixed anyway
since it's a one-liner).** `docs/upgrading.md`'s sudoers-migration callout
said "if you granted one before v3.27.0" — `v3.27.0` does not exist:
`package.json` is `3.26.0`, latest tag is `v3.26.0`, `CHANGELOG.md`'s
Unreleased section is empty, and the commits that added the `--` argument
(including #221) merged after the `v3.26.0` tag but before any new version
was cut (`git merge-base --is-ancestor v3.26.0 b833b7a` confirms). Reworded
to reference "before PR #221" instead of a speculative future version
number.

## Review Round 3 — rebased onto #240, reconciled (not just re-run)

`#240` (macOS `lsof` exit-1/empty-stdout fix + netstat cross-check) merged as
`f6131c3`. The rebase onto it was **clean — no git conflicts** — which is
exactly why it needed a second look rather than being trusted: `#240` added
its own, more detailed platform-coverage description to
`docs/upgrading.md`'s "Restart target resolution" section, in a **different
hunk** from Round 2's four passages above, so nothing merge-conflicted while
the document quietly became incoherent — two separate, non-identical
descriptions of macOS coverage in the same file.

Read `docs/upgrading.md` end to end post-rebase (not just the touched
hunks) and reconciled:

1. **Round 2's macOS description was now incomplete, in the opposite
   direction of the original overclaim.** `#240` added a real
   `lsof`/`netstat` cross-check (`scripts/upgrade.mjs`'s
   `mapLsofFailureToProbeValue` / `netstatHasListenerOnPort`) that
   correctly separates "genuinely empty port" from "a listener exists but
   ownership can't be confirmed" (the non-root-probing-a-root-owned-process
   case). Round 2's "only distinguishes listening/not-listening via lsof"
   undersold this and would itself have been a fresh false statement
   post-#240 — the exact failure mode this PR exists to prevent, just
   pointed the other way. Re-verified directly against
   `scripts/lib/restart-unit.mjs`'s `resolveOwningUnit` (darwin branch,
   `:341-352`, post-#240): a **confirmed** listener still maps
   unconditionally to `kind: "launchd", mismatched: false` — so what
   remains true and still needs saying is narrower than Round 2's text: not
   "no determination at all," but "a confirmed listener's ownership is
   still unverified." All four passages rewritten to say exactly that, each
   now a short, accurate **pointer** into `#240`'s own detailed explanation
   (`docs/upgrading.md`'s "Restart target resolution" section;
   `scripts/upgrade.mjs`'s file-level comment) instead of a competing
   restatement — one description, not two.
2. Checked the "could not determine ..." remediation and the residual-gap
   paragraph against `#240`'s `docs/troubleshooting.md` update (same
   macOS privilege-gap/netstat mechanism, described consistently) — no
   changes needed there since this PR never touches that file.
3. **`#233` is no longer open** (superseded by `#239` — defects 1 and 3
   landed in `#240`, defect 2 remaining). Round 2's four passages, plus the
   residual-gap paragraph, named "`#233` and `#239`" as open tracking
   issues; all five now name `#239` only, neutral verbs, describing the
   remaining gap accurately: on macOS a confirmed listener is still
   restarted over without verifying it's the `dev.ocp.proxy` job.
   (Historical "`#233` defect 1 ..." / "`#233` HIGH-1 ..." citations
   elsewhere in the file, in `scripts/upgrade.mjs`, and in
   `test-features.mjs` — all authored by `#240`, none touched by this PR —
   are unaffected: they cite what `#233` found, not its open/closed state,
   and stay true either way.)

## Test plan

- [x] `npm test` — **666 passed, 0 failed**, rebased onto `origin/main` @
      `f6131c3` (`#240` merged; baseline moved 642 → 666 via its own +14
      tests plus other merged work — doc/comment-only PR, unaffected).
      Run **serially** per `#248` (concurrent `npm test` runs on a shared
      host produce spurious `ltBoot` "server did not start" failures
      unrelated to code changes) — confirmed stable across two consecutive
      serial runs.
- [x] Re-grepped `main` post-fix for the original stale phrasing patterns —
      zero hits.
- [x] Re-verified the darwin-branch claims in `scripts/lib/restart-unit.mjs`
      directly (not taken on the reviewer's word) both in Round 2 and again
      post-rebase in Round 3, before writing the platform-qualified text
      each time.

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)
