### PR TITLE
test: add reverse-direction check to _spotRegistryMaxTokens

### DIFF
--- a/test-features.mjs
+++ b/test-features.mjs
@@ -4955,7 +4955,7 @@ test("models.json: contextWindow equals the registry, or is the deliberate 20000
   // the same commit that adds the model.
   for (const id of Object.keys(_spotRegistryContextWindow)) {
     assert.ok(_spotModelIds.has(id),
-      `${id} is recorded in the registry table but missing from models[] — removing a model must be ` +
+      `'${id}' is recorded in the registry table but missing from models[] — removing a model must be ` +
       `deliberate: drop its row here in the same commit and say why in the message.`);
   }
 });
@@ -4985,9 +4985,13 @@ test("models.json: every aliases value resolves to a real models[].id (referenti
 // alias, measured under FOUR keys (first_party, anthropic_aws, anthropic_google_cloud, gateway)
 // and never as an `id:`. Anchor the haiku row on the SHORT id; anchoring on the dated one returns
 // nothing, which is what tempts the next reader back into a bare-string search.
-// NOTE this table has NO reverse check, unlike _spotRegistryContextWindow above: a row left here
-// for a model that no longer exists in models.json passes green (measured: rename a model, update
-// both tables, leave the stale row here -> 463 passed, 0 failed). Tracked separately.
+// UPDATE (#222): this table now has a reverse check too, mirroring _spotRegistryContextWindow
+// above (see the reverse-direction loop inside the test below). Before this fix, a row left here
+// for a model that no longer exists in models.json passed green — both loops walked models.json,
+// so the mapping was one-way and an orphaned row was never visited. Measured on this suite pre-fix:
+// rename a model, update BOTH tables for the new id, and leave the OLD id's row behind here only
+// -> 633 passed, 0 failed (the wrong-repro trap — renaming without adding the new id anywhere
+// fails the FORWARD check instead and masks this gap entirely; see #222 for both repros).
 const _spotRegistryMaxTokens = {
   "claude-opus-5": 64000, "claude-opus-4-8": 64000, "claude-opus-4-7": 64000, "claude-opus-4-6": 64000,
   "claude-sonnet-5": 64000, "claude-sonnet-4-6": 32000,
@@ -4999,6 +5003,22 @@ test("models.json: every maxTokens equals the CLI registry's max_output_tokens.d
     assert.ok(want !== undefined,
       `${m.id} has no recorded registry value — extract it id-anchored from the CLI binary and add a row`);
     assert.equal(m.maxTokens, want, `${m.id}: models.json says ${m.maxTokens}, CLI registry says ${want}`);
+  }
+  // Reverse direction (#222), mirroring _spotRegistryContextWindow's reverse check above. Both
+  // loops here and above walk models.json, so without this the mapping is ONE-WAY and a
+  // renamed/removed model's row is simply never visited: a rename that updates this table for
+  // the new id but leaves the OLD id's row behind passed green with no reverse check (measured
+  // pre-fix: 633 passed, 0 failed on this suite). The stale row isn't just untidy — this table
+  // is the record of what the CLI registry said at 2.1.220, and an orphaned row is a claim about
+  // a model nobody can check. Same consequence as the contextWindow table: forward gives
+  // models[] subset-of table and this gives table subset-of models[], so the two id sets are now
+  // exactly EQUAL — pre-recording a row for a model not yet exposed (claude-fable-5,
+  // claude-mythos-5 — both present in the 2.1.220 registry) is a test failure, not prep. Add
+  // the row in the same commit that adds the model.
+  for (const id of Object.keys(_spotRegistryMaxTokens)) {
+    assert.ok(_spotModelIds.has(id),
+      `'${id}' is recorded in the registry table but missing from models[] — removing/renaming a ` +
+      `model must be deliberate: drop its row here in the same commit and say why in the message.`);
   }
 });
 


### PR DESCRIPTION
## Defect

`_spotRegistryMaxTokens` (`test-features.mjs`, backing the "models.json: every
maxTokens equals the CLI registry's `max_output_tokens.default`" test, #195)
only checked the **forward** direction: every `models.json` entry has a row
in the table. Nothing checked the **reverse** direction: every row in the
table corresponds to a live model id. A row left behind for a
renamed/removed model would survive silently, green. #216 closed the
identical gap on the sibling table (`_spotRegistryContextWindow`, two tests
above) already — this table never got the same fix. Per #222.

**Framing note (important, added after review): the repo has no stale row
today, and never did.** This PR is a guard against *future* drift, not a
cleanup of present rot. Every "stale row" in the repro below is a synthetic
one, injected into a local working copy purely to demonstrate the gap and
prove the fix, then reverted — never a change to real repo content.
`models.json` and the table on this branch's head are byte-identical to
`origin/main` (confirmed via `shasum` throughout this work).

## Repro (both isolated with real `npm test` runs, `origin/main` @ `7d32bbb`)

Baseline: `642 passed, 0 failed`.

**WRONG repro — the trap #222 explicitly warns about.** Rename
`claude-sonnet-4-6` → `claude-sonnet-4-9` in `models.json`, update
`_spotRegistryContextWindow`'s key (forced by #216's own reverse check),
but leave `_spotRegistryMaxTokens` completely untouched:

```
=== Results: 631 passed, 2 failed ===
✗ models.json: every maxTokens equals the CLI registry's max_output_tokens.default (#195):
  claude-sonnet-4-9 has no recorded registry value — ...
✗ ocp-connect: every models.json id classifies at or below its CLI-registry maxTokens ...:
  claude-sonnet-4-9 has no recorded registry value — ...
```

The **forward** check fires (on two consumers of the same table, not one —
this repo's suite has grown since #222's own analysis, which measured
462/1 on a smaller suite; two consumers here means 2 failures, not 1, but
the trap is identical: it masks the real gap).

**CORRECT isolating repro.** Additionally add the `"claude-sonnet-4-9"` row
to `_spotRegistryMaxTokens` (forward now satisfied for both tables), while
leaving the synthetic stale `"claude-sonnet-4-6"` row behind:

```
=== Results: 633 passed, 0 failed ===
```

**Green, with an orphaned row for a model that no longer exists anywhere in
`models.json`.** That's the bug this check closes — demonstrated with a
synthetic rename in a local working copy, not a real one. #222's own number
for its smaller suite was 463/0; the pattern (green-with-a-stale-row) is
what matters and matches exactly.

## Fix

Copied the three-line reverse loop already used by
`_spotRegistryContextWindow` (#222's "Option 1" — the shared-bijection hoist
across both tables, "Option 2", touches both test blocks and per Iron Rule
11 wants its own PR, per #222's own text).

Re-ran the correct-isolating-repro state with the new loop in place:

```
=== Results: 632 passed, 1 failed ===
✗ ...: 'claude-sonnet-4-6' is recorded in the registry table but missing from
  models[] — removing/renaming a model must be deliberate: ...
```

Reverted the synthetic rename (both `models.json` and the test tables back
to real repo content — confirmed byte-identical to `origin/main` via
`shasum`) → back to `642 passed, 0 failed`, on the actual shipped fix with
no injected data.

## Mutation-verify (control mutation)

With the real fix shipped and the suite green, injected a synthetic orphaned
row (`"claude-sonnet-3-9-MUTATION-TEST": 16000`) directly into the real
table in `test-features.mjs`:

```
✗ ...: 'claude-sonnet-3-9-MUTATION-TEST' is recorded in the registry table but
  missing from models[] — ...
```

Restored via `cp` from a file backup taken at the pre-mutation green state
(**never** `git checkout --`, which would have discarded the uncommitted fix
itself) → `shasum -a 256` byte-identical → green again.

## Consequence (documented, per #216's own note on the sibling table)

The forward+reverse pair makes the table a strict bijection with `models[]`.
Pre-recording a row for a model not yet exposed (`claude-fable-5`,
`claude-mythos-5` — both present in the 2.1.220 registry) is now a test
failure by design, not valid prep — add the row in the same commit that
adds the model.

## Scope

Test-only change (`test-features.mjs`). `models.json` is untouched.
**`server.mjs` is not touched** — no `cli.js` citation applies
(`ALIGNMENT.md` / `CLAUDE.md` hard requirement #1 is N/A).

---

## Review Round 2 — APPROVED, three non-blocking nits fixed here

Reviewer independently verified the check is non-vacuous and catches subtle
near-misses: injected orphan → failure; trailing-whitespace near-miss
`"claude-opus-5 "` → failure; case near-miss `"Claude-Opus-5"` → failure; a
control that neuters the new assert *with the orphan row still present* →
green, proving the new loop is the only thing catching it.

**Correction absorbed.** The review briefing (and this PR's own earlier
wording) described a stale row being "removed" in a way that read as a real
repo change. There was none — see the framing note at the top. Reworded
this PR body and the commit body: the check guards against **future**
drift; nothing in the repo needed cleaning up.

**LOW-1 (fixed).** `claude-fable-5, claude-mythos-5 — both in the 2.1.220
registry at 1e6` lifted "1e6" from the CONTEXT WINDOW comment above it,
where it means a 1,000,000-token context window — sitting under maxTokens
rows of 64000/32000 it misleadingly read as a claim about
`max_output_tokens.default`. Changed to "both present in the 2.1.220
registry" (dropped the unsubstantiated number).

**LOW-2 (fixed, two lines).** Both reverse-check failure messages
(`_spotRegistryContextWindow`'s existing one and `_spotRegistryMaxTokens`'
new one) interpolated the id unquoted, so a trailing-whitespace near-miss
rendered invisibly in the very output meant to diagnose it. Quoted both
(`` `'${id}'` ``), matching the alias check's existing style two tests down.
Verified live: injecting `"claude-opus-5 "` (trailing space) now renders
`'claude-opus-5 '` in the failure message; restored from a file backup,
shasum-verified, green again.

**LOW-3 (no action, by design).** The reverse loop runs after the forward
loop in the same `test()`, so a simultaneous drop+add reports only the
forward failure until fixed. Identical to the sibling table; #222's
"Option 2" bijection hoist is the correct fix and is deliberately deferred
under Iron Rule 11 (minimum reviewable unit) rather than bundled here.

## Test plan

- [x] `npm test` — 642 passed, 0 failed (rebased onto `origin/main` @
      `7d32bbb`, which merged #243 after this branch was first opened —
      baseline moved 633 → 642, unrelated to this PR's content).
- [x] Wrong repro reproduced and shown: 631 passed, 2 failed.
- [x] Correct isolating repro reproduced and shown (pre-fix): 633 passed, 0
      failed (the bug, synthetic).
- [x] New check shown to fail against that exact synthetic state: 632
      passed, 1 failed.
- [x] Mutation-verified against the shipped fix: injected orphaned row →
      failure; restored from file backup (`cp`, not `git checkout`);
      `shasum`-verified byte-identical; green again.
- [x] Quoting fix verified live against a trailing-whitespace near-miss;
      restored from file backup, `shasum`-verified, green again.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)
