### PR TITLE
test(setup): guard install-autostart.mjs template content/order (#231)

### DIFF
--- a/test-features.mjs
+++ b/test-features.mjs
@@ -1762,7 +1762,7 @@ test("resolveServicePlan tolerates other unrelated argv alongside the bare flag"
 // the same seam scripts/upgrade.mjs already uses (opts.mockExec) and doctor.mjs uses
 // (opts.mockHealth). These tests call the REAL function with fake run/fs primitives and
 // assert on which commands/files were actually touched, not on source shape.
-import { installAutoStart } from "./scripts/lib/install-autostart.mjs";
+import { installAutoStart, xmlEscape } from "./scripts/lib/install-autostart.mjs";
 
 function baseInstallOpts(overrides = {}) {
   return {
@@ -1923,6 +1923,160 @@ test("installAutoStart(unsupported platform): no run/write/unlink calls at all, 
   assert.equal(calls.length, 0);
   assert.equal(unlinked.length, 0);
   assert.equal(written.length, 0);
+});
+
+// ── #231: content/order guards on the generated template (not run()-call membership) ──
+// Everything above this point asserts which run()/unlink calls happened, or that a path was
+// touched — never the CONTENT of what installAutoStart actually writes, nor the ORDER commands
+// run in. Issue #231 (found in review of #229) demonstrated six template properties that are
+// load-bearing on a real host but pass this whole file's suite unchanged when mutated: a
+// WantedBy= target swap, RunAtLoad flipped to false, a dropped chmod 0600, daemon-reload moved
+// after enable/start, Restart=always flipped to Restart=no, and the env-merge branch bypassed —
+// all six survived at 510 passed/0 failed in the issue's own mutation table, because
+// baseInstallOpts()'s `existsPath: () => false` default means the env-merge branch is never even
+// exercised, and no prior test reads a captured writeFile/chmodPath argument. These tests do.
+console.log("\ninstallAutoStart template guards (#231 — assert on generated content/order):");
+
+test("G1: linux systemd unit's [Install] section targets default.target, not graphical-session.target", () => {
+  let unitContent = null;
+  installAutoStart(baseInstallOpts({
+    platform: "linux",
+    writeFile: (path, content) => { if (path.endsWith("ocp-proxy.service")) unitContent = content; },
+  }));
+  assert.ok(unitContent, "expected the systemd unit file to be written");
+  assert.match(unitContent, /^WantedBy=default\.target$/m,
+    `expected an exact "WantedBy=default.target" line; got:\n${unitContent}`);
+});
+
+test("G2: darwin plist's RunAtLoad is literally <true/> (job must actually start at login)", () => {
+  let plistContent = null;
+  installAutoStart(baseInstallOpts({
+    platform: "darwin",
+    servicePlan: resolveServicePlan([], "darwin"),
+    writeFile: (path, content) => { if (path.endsWith("dev.ocp.proxy.plist")) plistContent = content; },
+  }));
+  assert.ok(plistContent, "expected the plist to be written");
+  const m = plistContent.match(/<key>RunAtLoad<\/key>\s*<(true|false)\/>/);
+  assert.ok(m, `expected a RunAtLoad key/value pair; got:\n${plistContent}`);
+  assert.equal(m[1], "true", `RunAtLoad must be <true/>; got <${m[1]}/>`);
+});
+
+test("G3a: darwin plist file is chmod'd 0600 (carries OCP_ADMIN_KEY/PROXY_ANONYMOUS_KEY — CHANGELOG:457)", () => {
+  const chmods = [];
+  installAutoStart(baseInstallOpts({
+    platform: "darwin",
+    servicePlan: resolveServicePlan([], "darwin"),
+    chmodPath: (path, mode) => { chmods.push({ path, mode }); },
+  }));
+  const plistChmod = chmods.find(c => c.path.endsWith("dev.ocp.proxy.plist"));
+  assert.ok(plistChmod, `expected a chmodPath call on the plist; got=${JSON.stringify(chmods)}`);
+  assert.equal(plistChmod.mode, 0o600, `plist must be chmod 0600; got ${String(plistChmod.mode)}`);
+});
+
+test("G3b: linux systemd unit file is chmod'd 0600 (carries OCP_ADMIN_KEY/PROXY_ANONYMOUS_KEY — CHANGELOG:457)", () => {
+  const chmods = [];
+  installAutoStart(baseInstallOpts({
+    platform: "linux",
+    chmodPath: (path, mode) => { chmods.push({ path, mode }); },
+  }));
+  const unitChmod = chmods.find(c => c.path.endsWith("ocp-proxy.service"));
+  assert.ok(unitChmod, `expected a chmodPath call on the unit file; got=${JSON.stringify(chmods)}`);
+  assert.equal(unitChmod.mode, 0o600, `unit file must be chmod 0600; got ${String(unitChmod.mode)}`);
+});
+
+test("G4: linux first-install run() order is daemon-reload BEFORE enable BEFORE start (#221 MED-8: stale-cache restart)", () => {
+  const calls = [];
+  installAutoStart(baseInstallOpts({
+    platform: "linux",
+    servicePlan: resolveServicePlan([], "linux"),
+    run: (cmd) => { calls.push(cmd); return ""; },
+  }));
+  const relevant = calls.filter(c => /daemon-reload|enable ocp-proxy|start ocp-proxy/.test(c));
+  assert.deepEqual(relevant, [
+    "systemctl --user daemon-reload",
+    "systemctl --user enable ocp-proxy",
+    "systemctl --user start ocp-proxy",
+  ], `expected exactly this order (membership alone does not prove ordering); got ${JSON.stringify(relevant)}`);
+});
+
+test("G5: linux systemd unit has Restart=always, not Restart=no", () => {
+  let unitContent = null;
+  installAutoStart(baseInstallOpts({
+    platform: "linux",
+    writeFile: (path, content) => { if (path.endsWith("ocp-proxy.service")) unitContent = content; },
+  }));
+  assert.ok(unitContent, "expected the systemd unit file to be written");
+  assert.match(unitContent, /^Restart=always$/m, `expected "Restart=always"; got:\n${unitContent}`);
+});
+
+test("G6: linux mergeSystemdEnv actually runs — a pre-existing operator env var survives the rewrite", () => {
+  // baseInstallOpts()'s existsPath: () => false means this branch (existsPath(path) ?
+  // readFile(...) : null) is never exercised by any test above — closing G6 means exercising
+  // it, not just asserting on mergeSystemdEnv in isolation (already covered at the unit level
+  // around test-features.mjs:649-653; this is the WIRING, which was never proven).
+  const servicePath = "/fake/home/.config/systemd/user/ocp-proxy.service";
+  const existingUnit = `[Unit]
+Description=OCP — Open Claude Proxy
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/node /fake/repo/server.mjs
+Environment=CLAUDE_PROXY_PORT=3456
+Environment=CLAUDE_BIND=127.0.0.1
+Environment=CLAUDE_AUTH_MODE=none
+Environment=CUSTOM_OPERATOR_VAR=keep-me
+Restart=always
+RestartSec=5
+`;
+  let finalContent = null;
+  installAutoStart(baseInstallOpts({
+    platform: "linux",
+    existsPath: (p) => p === servicePath,
+    readFile: (p) => (p === servicePath ? existingUnit : ""),
+    writeFile: (path, content) => { if (path === servicePath) finalContent = content; },
+  }));
+  assert.ok(finalContent, "expected the systemd unit file to be (re)written");
+  assert.match(finalContent, /Environment=CUSTOM_OPERATOR_VAR=keep-me/,
+    `expected the pre-existing operator env var to survive the rewrite; got:\n${finalContent}`);
+});
+
+// ── G7 (added — not in the issue's list; same defect class as G6, other platform) ──
+// The exact same existsPath: () => false blind spot leaves darwin's mergePlistEnv branch
+// (installAutoStart's plist counterpart to G6's mergeSystemdEnv) equally unexercised. It's the
+// identical wiring gap on the platform this dev host actually runs under, so it's covered here
+// too rather than left as a known gap.
+test("G7: darwin mergePlistEnv actually runs — a pre-existing operator env var survives the rewrite", () => {
+  const plistPath = "/fake/home/Library/LaunchAgents/dev.ocp.proxy.plist";
+  const existingPlist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>dev.ocp.proxy</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>CLAUDE_PROXY_PORT</key>
+    <string>3456</string>
+    <key>CLAUDE_BIND</key>
+    <string>127.0.0.1</string>
+    <key>CLAUDE_AUTH_MODE</key>
+    <string>none</string>
+    <key>CUSTOM_OPERATOR_VAR</key>
+    <string>keep-me</string>
+  </dict>
+</dict>
+</plist>`;
+  let finalContent = null;
+  installAutoStart(baseInstallOpts({
+    platform: "darwin",
+    servicePlan: resolveServicePlan([], "darwin"),
+    existsPath: (p) => p === plistPath,
+    readFile: (p) => (p === plistPath ? existingPlist : ""),
+    writeFile: (path, content) => { if (path === plistPath) finalContent = content; },
+  }));
+  assert.ok(finalContent, "expected the plist to be (re)written");
+  assert.match(finalContent, /<key>CUSTOM_OPERATOR_VAR<\/key>\s*<string>keep-me<\/string>/,
+    `expected the pre-existing operator env var to survive the rewrite; got:\n${finalContent}`);
 });
 
 test("upgrade full path's reconfigure phase invokes setup.mjs with --reconfigure-only", async () => {
@@ -2138,14 +2292,17 @@ test("gcSnapshots keeps last N regardless of age", () => {
   rmSync(root, { recursive: true, force: true });
 });
 
-// ── setup.mjs helpers: xmlEscape + assertSafeInjectValue ──
-// setup.mjs cannot be imported (top-level side effects run the installer).
-// Replicated verbatim from setup.mjs for unit-testing — keep in sync with source.
+// ── setup.mjs inject helpers: xmlEscape (real import) + assertSafeInjectValue (replica) ──
+// xmlEscape used to be a verbatim replica here too, on the same "setup.mjs cannot be imported"
+// premise — but #229 moved xmlEscape OUT of setup.mjs's unimportable top level and into
+// scripts/lib/install-autostart.mjs, which exports it (see the import above). The premise the
+// replica relied on is gone, so it's imported for real now (issue #231's stale-replica finding:
+// the old comment's three justifying clauses — "setup.mjs helper", "cannot be imported",
+// "keep in sync with source" — were all false once #229 landed). assertSafeInjectValue has NOT
+// moved (still setup.mjs-local, still unexported, still genuinely unimportable), so its replica
+// below remains legitimate.
 console.log("\nsetup.mjs inject helpers:");
 
-function xmlEscape(v) {
-  return String(v).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
-}
 function assertSafeInjectValueTest(name, v) {
   if (v == null) return v;
   // eslint-disable-next-line no-control-regex

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -2079,6 +2079,79 @@ test("G7: darwin mergePlistEnv actually runs — a pre-existing operator env var
     `expected the pre-existing operator env var to survive the rewrite; got:\n${finalContent}`);
 });
 
+// ── G8-G10 (added — independent review of this PR found these while verifying G1-G7) ──
+// A fresh-context reviewer applied the same "is this actually load-bearing and actually
+// unguarded" test G1-G7 used to every other property in the template and found two more real
+// survivors before approving. Both close the same class of gap #231 described, just on
+// properties #231's own list happened not to name.
+test("G8: darwin plist's KeepAlive is literally <true/> (job must respawn after a crash, not die permanently)", () => {
+  // Same defect class as G5 (Restart=always) — G5's own linux property, mapped onto darwin's
+  // launchd equivalent. A mutation flipping this to <false/> survived the full suite (650/0)
+  // until this test was added: nothing previously read KeepAlive out of the written plist.
+  let plistContent = null;
+  installAutoStart(baseInstallOpts({
+    platform: "darwin",
+    servicePlan: resolveServicePlan([], "darwin"),
+    writeFile: (path, content) => { if (path.endsWith("dev.ocp.proxy.plist")) plistContent = content; },
+  }));
+  assert.ok(plistContent, "expected the plist to be written");
+  const m = plistContent.match(/<key>KeepAlive<\/key>\s*<(true|false)\/>/);
+  assert.ok(m, `expected a KeepAlive key/value pair; got:\n${plistContent}`);
+  assert.equal(m[1], "true", `KeepAlive must be <true/> (launchd must respawn the proxy after a crash); got <${m[1]}/>`);
+});
+
+test("G9: darwin plist writes injected secrets under their real key names (OCP_ADMIN_KEY/PROXY_ANONYMOUS_KEY/CLAUDE_BIN)", () => {
+  // baseInstallOpts()'s default config leaves all three *_INJECT fields null, so every G1-G7
+  // test above writes a plist with NO secrets in it — the conditional inject branches
+  // (install-autostart.mjs's CLAUDE_BIN_INJECT/OCP_ADMIN_KEY_INJECT/PROXY_ANON_KEY_INJECT
+  // ternaries) were dead code as far as this suite could tell. This matters because G3's own
+  // justification for chmod 0600 is that these files "carry OCP_ADMIN_KEY/PROXY_ANONYMOUS_KEY"
+  // — chmod without content is a lock on an empty box. Renaming the plist key (independently
+  // reproduced during review) survives every G1-G8 test above; only this one catches it.
+  let plistContent = null;
+  installAutoStart(baseInstallOpts({
+    platform: "darwin",
+    servicePlan: resolveServicePlan([], "darwin"),
+    config: {
+      PORT: 3456, BIND_ADDRESS: "127.0.0.1", AUTH_MODE_CONFIG: "multi",
+      CLAUDE_BIN_INJECT: "/custom/claude/bin",
+      OCP_ADMIN_KEY_INJECT: "ocp_admin_test_token",
+      PROXY_ANON_KEY_INJECT: "ocp_anon_test_token",
+    },
+    writeFile: (path, content) => { if (path.endsWith("dev.ocp.proxy.plist")) plistContent = content; },
+  }));
+  assert.ok(plistContent, "expected the plist to be written");
+  assert.match(plistContent, /<key>CLAUDE_BIN<\/key>\s*<string>\/custom\/claude\/bin<\/string>/,
+    `expected CLAUDE_BIN under its real key name; got:\n${plistContent}`);
+  assert.match(plistContent, /<key>OCP_ADMIN_KEY<\/key>\s*<string>ocp_admin_test_token<\/string>/,
+    `expected OCP_ADMIN_KEY under its real key name; got:\n${plistContent}`);
+  assert.match(plistContent, /<key>PROXY_ANONYMOUS_KEY<\/key>\s*<string>ocp_anon_test_token<\/string>/,
+    `expected PROXY_ANONYMOUS_KEY under its real key name; got:\n${plistContent}`);
+});
+
+test("G10: linux systemd unit writes injected secrets under their real Environment= names (OCP_ADMIN_KEY/PROXY_ANONYMOUS_KEY/CLAUDE_BIN)", () => {
+  // Same gap as G9, other platform: baseInstallOpts()'s default config means the systemd
+  // template's inject ternaries are equally dead code across every prior test.
+  let unitContent = null;
+  installAutoStart(baseInstallOpts({
+    platform: "linux",
+    config: {
+      PORT: 3456, BIND_ADDRESS: "127.0.0.1", AUTH_MODE_CONFIG: "multi",
+      CLAUDE_BIN_INJECT: "/custom/claude/bin",
+      OCP_ADMIN_KEY_INJECT: "ocp_admin_test_token",
+      PROXY_ANON_KEY_INJECT: "ocp_anon_test_token",
+    },
+    writeFile: (path, content) => { if (path.endsWith("ocp-proxy.service")) unitContent = content; },
+  }));
+  assert.ok(unitContent, "expected the systemd unit file to be written");
+  assert.match(unitContent, /^Environment=CLAUDE_BIN=\/custom\/claude\/bin$/m,
+    `expected CLAUDE_BIN under its real Environment= name; got:\n${unitContent}`);
+  assert.match(unitContent, /^Environment=OCP_ADMIN_KEY=ocp_admin_test_token$/m,
+    `expected OCP_ADMIN_KEY under its real Environment= name; got:\n${unitContent}`);
+  assert.match(unitContent, /^Environment=PROXY_ANONYMOUS_KEY=ocp_anon_test_token$/m,
+    `expected PROXY_ANONYMOUS_KEY under its real Environment= name; got:\n${unitContent}`);
+});
+
 test("upgrade full path's reconfigure phase invokes setup.mjs with --reconfigure-only", async () => {
   const result = await runUpgrade({
     yes: true,


### PR DESCRIPTION
## Summary

Issue #231 (found in review of #229): `scripts/lib/install-autostart.mjs` generates the systemd unit / launchd plist that actually boots OCP on a real host, and six properties of that template were load-bearing but unguarded — the issue's own mutation table left all six passing at **510 passed / 0 failed**. The existing tests in `test-features.mjs` assert **membership** in captured `run()` calls (`calls.some(c => c.includes(...))`); none read a captured `writeFile`/`chmodPath` argument, and none assert call **order**.

This PR adds behavioral tests that do — calling the real `installAutoStart()` with the injected `run`/`writeFile`/`readFile`/`existsPath`/`makeDir`/`chmodPath`/`unlinkPath` fakes it was written for, asserting on the captured output/order, never on `install-autostart.mjs`'s own source text. No real filesystem, `launchctl`, or `systemctl` is touched by any test.

**`server.mjs` is not touched by this PR.** No `cli.js` citation is included because none is required (ALIGNMENT.md Rules 1–5 govern `server.mjs`'s `cli.js`-mirror surface; this PR is test-only, scoped to `scripts/lib/install-autostart.mjs`'s already-injected fs/run seam from #229).

## The six properties, verified against the file (not just trusted from the issue)

Read `scripts/lib/install-autostart.mjs` directly rather than taking the issue's list on faith. All six check out against current `main`:

| | property | file:line |
|---|---|---|
| G1 | linux `[Install]` section: `WantedBy=default.target` | `install-autostart.mjs:248` |
| G2 | darwin plist: `RunAtLoad` is `<true/>` | `install-autostart.mjs:192-193` |
| G3 | both unit files `chmodPath(..., 0o600)` | `install-autostart.mjs:207` (plist), `:254` (systemd) |
| G4 | linux: `daemon-reload` runs before `enable` before `start` | `install-autostart.mjs:261-263` |
| G5 | linux: `Restart=always` | `install-autostart.mjs:242` |
| G6 | linux: `mergeSystemdEnv(existingService, serviceUnit)` actually wired up (not bypassed) | `install-autostart.mjs:251-252` |

## Three more properties, added

**G7 (added while verifying G6):** `baseInstallOpts()`'s `existsPath: () => false` default means **darwin's** `mergePlistEnv` env-merge branch (`install-autostart.mjs:204-205`) was equally unexercised by every existing test, for the same reason as G6. Same defect class, other platform.

**G8, G9, G10 (added by independent review of this PR):** a fresh-context reviewer (Iron Rule 10) ran the same "is this actually load-bearing and actually unguarded" check against every other property in the template and found three more real survivors before approving:

- **G8** — darwin plist's `KeepAlive` must be `<true/>` (`install-autostart.mjs:194-195`) — the launchd equivalent of G5's `Restart=always`. Nothing previously read `KeepAlive` out of the written plist; flipping it to `<false/>` (proxy dies permanently on first crash instead of respawning) survived the full suite.
- **G9 / G10** — neither platform's secret-inject wiring was exercised. `baseInstallOpts()`'s default config leaves `CLAUDE_BIN_INJECT`/`OCP_ADMIN_KEY_INJECT`/`PROXY_ANON_KEY_INJECT` all `null`, so every G1–G8 test writes a plist/unit with **no secrets in it at all** — directly undercutting G3's own justification (chmod 0600 because these files "carry `OCP_ADMIN_KEY`/`PROXY_ANONYMOUS_KEY`"): a lock on an empty box proves nothing about the box's contents. G9 (darwin, `install-autostart.mjs:184-190`) / G10 (linux, `install-autostart.mjs:241`) set real inject values and assert they land under their real key/`Environment=` names.

## Also fixed: the issue's "stale replica" finding

`test-features.mjs` still locally re-declared `xmlEscape` under a comment claiming (a) it's a `setup.mjs` helper, (b) `setup.mjs` can't be imported so the copy must exist, and (c) it must be kept in sync with source. All three were false: #229 moved `xmlEscape` out of `setup.mjs`'s unimportable top level and into `install-autostart.mjs`, which **exports** it. Now imported for real (the import at `test-features.mjs:1765` already pulled in `installAutoStart` from that module; `xmlEscape` is added to the same import). `assertSafeInjectValue`'s replica is untouched — it genuinely has not moved out of `setup.mjs` and is still unexported, so its replica remains legitimate.

## Mutation table

Protocol used for every row: `cp` the pre-mutation file aside → apply mutation → `npm test` → record pass/fail → restore from the file-backup copy (**never `git checkout --`**, which would have discarded the uncommitted tests along with the mutation) → `shasum -a 256` the restored file against the backup to confirm byte-identical → re-run `npm test` to confirm green again. Baseline before any mutation: **653 passed, 0 failed** (642 pre-existing + 11 new tests: G1, G2, G3a, G3b, G4, G5, G6, G7, G8, G9, G10).

| # | mutation | before | after | result |
|---|---|---|---|---|
| G1 | `WantedBy=default.target` → `graphical-session.target` | 650/0 | 649/1 (G1 fails) | **CAUGHT** |
| G2 | plist `RunAtLoad` `<true/>` → `<false/>` | 650/0 | 649/1 (G2 fails) | **CAUGHT** |
| G3 | drop `chmodPath(…, 0o600)` on both unit files | 650/0 | 648/2 (G3a + G3b fail) | **CAUGHT** |
| G4 | move `daemon-reload` after `enable`+`start` | 650/0 | 649/1 (G4 fails) | **CAUGHT** |
| G5 | `Restart=always` → `Restart=no` | 650/0 | 649/1 (G5 fails) | **CAUGHT** |
| G6 | bypass `mergeSystemdEnv` (`finalServiceUnit = serviceUnit`) | 650/0 | 649/1 (G6 fails) | **CAUGHT** |
| G7 | bypass `mergePlistEnv` (`finalPlistXml = plistXml`) | 650/0 | 649/1 (G7 fails) | **CAUGHT** |
| G8 | plist `KeepAlive` `<true/>` → `<false/>` | 653/0 | 652/1 (G8 fails) | **CAUGHT** |
| G9 | darwin plist key `OCP_ADMIN_KEY` → `WRONG_KEY_NAME` | 653/0 | 652/1 (G9 fails) | **CAUGHT** |
| G10 | linux `Environment=OCP_ADMIN_KEY=` → `Environment=WRONG_KEY_NAME=` | 653/0 | 652/1 (G10 fails) | **CAUGHT** |

(G1–G7 were run before G8–G10 existed, hence the 650-baseline for those rows and 653 for G8–G10 — both are "everything green before this mutation.")

Every restore was verified `shasum -a 256` byte-identical to the pre-mutation backup, and a full `npm test` after each restore returned to green. Several unrelated flakes were observed mid-session in this repo's `ltBoot`-based live-server integration tests (the `OCP_LOCAL_TOOLS`/`-p`-wrapper spawn tests, e.g. 8–9 failures in one run) — always in that pre-existing, documented-flaky area (per `AGENTS.md`), never in G1–G10, and always cleared on an immediate re-run with no code change.

## Independent review (Iron Rule 10)

A fresh-context reviewer independently re-ran the full mutation-and-restore protocol for all seven originally-claimed properties (not just read the table), confirmed `install-autostart.mjs`'s zero-diff-from-main claim by sha256, opened the file at all cited line ranges, and ran `npm test` in an isolated clone. Verdict: **APPROVE WITH NITS** — the "nits" were G8/G9/G10 above, since folded in. Full findings on request; summary: all G1–G7 citations accurate, all mutations independently reproduced with matching results, tests confirmed behavioral (read captured output/order, never source text), closing-keyword usage clean, `cli.js`-citation omission correctly justified.

## Test evidence

- Baseline on `main` at fetch time (`7d32bbb`): **642 passed, 0 failed**.
- Rebased onto `main` after PR #245 merged (`87b7feb`) mid-session: still **642 passed, 0 failed** on `main` (PR #245 added assertions to existing tests, not new `test()` entries).
- With this PR's 11 tests added, unmutated: **653 passed, 0 failed** (confirmed stable across multiple consecutive runs post-rebase).
- Full mutation-and-restore cycle above: all 10 properties CAUGHT, all restores byte-identical, suite green after each restore.

## Scope notes

- `server.mjs`: **not touched**. No `cli.js` citation included — none applies.
- `scripts/lib/install-autostart.mjs`: **not touched** (all 10 mutations were applied only transiently during testing and restored from file backup before commit; `git diff` against `main` on this file is empty).
- Only `test-features.mjs` is changed.
- PR #244 (in-flight comment edit to `scripts/lib/install-autostart.mjs`) does not conflict — this PR does not modify that file at all.

Refs #229, refs #221, refs #87, refs #244.
Closes #231.
