### PR TITLE
fix(ocp): cmd_restart resolves the owning unit via scripts/upgrade.mjs, no more hard-coded guess

### DIFF
--- a/ocp
+++ b/ocp
@@ -614,6 +614,21 @@ cmd_restart() {
     # actionable refusal to stderr and exits non-zero. No fallback to a guess, and no more
     # unmanaged nohup process left behind on refusal.
     #
+    # Scope narrowing (independent review of this change, corrected here rather than only in
+    # the PR): delegating fully to the JS resolver drops the legacy `ai.openclaw.proxy` plist /
+    # `openclaw-proxy` unit fallback this function used to try. That is NOT because PR #221
+    # already established this precedent for its own two callers — it didn't: scripts/
+    # upgrade.mjs's restart phases never had a legacy-name fallback to begin with (verified
+    # against PR #221's own diff), so this PR is the first to actually drop it. It's justified on
+    # its own terms instead: `dev.ocp.proxy` / `ocp-proxy.service` are the current names, any host
+    # still on the legacy label should already have been migrated by setup.mjs's install-
+    # autostart step (scripts/lib/install-autostart.mjs removes the legacy plist/unit on every
+    # `ocp update`/reconfigure), and on Linux the live cgroup walk is strictly BETTER than the old
+    # two-name hard-coded list regardless — it discovers whatever unit actually holds the port by
+    # reading its cgroup, not by checking it against a fixed name. Flagged as a residual item:
+    # confirm no fleet host is still running under the legacy macOS launchd label before relying
+    # on this for such a host.
+    #
     # `|| resolve_status=$?` (not a bare assignment) is load-bearing under `set -euo pipefail`
     # (ocp:7): a bare `var=$(cmd)` where cmd exits non-zero trips `set -e` immediately, which
     # would abort THIS function (and everything that called it) before the refusal handling

--- a/ocp
+++ b/ocp
@@ -580,19 +580,12 @@ so an env change you made (e.g. CLAUDE_BIND, CLAUDE_CODE_OAUTH_TOKEN) actually
 takes effect. `kickstart -k` only re-execs the process and reuses launchd's
 cached env, so env edits would be silently ignored. (Linux systemctl already
 re-reads its EnvironmentFile on restart.)
-EOF
-}
 
-# macOS only: reload a launchd agent via bootout + bootstrap so plist
-# EnvironmentVariables are re-read (kickstart -k would reuse the cached env).
-# Args: <uid> <label> <plist-path>. Returns 0 iff bootstrap succeeds.
-_launchd_reload() {
-  local uid="$1" label="$2" plist="$3"
-  [[ -f "$plist" ]] || return 1
-  # bootout may legitimately fail if the agent is not currently loaded — that's fine,
-  # we only require the subsequent bootstrap to succeed (the load that re-reads env).
-  launchctl bootout "gui/$uid/$label" 2>/dev/null || true
-  launchctl bootstrap "gui/$uid" "$plist" 2>/dev/null
+The restart target (which systemd unit / launchd job actually owns the OCP
+port) is resolved automatically before anything is restarted — see issue
+#215 / #224 and scripts/lib/restart-unit.mjs. If it can't be determined
+safely, this refuses loudly instead of guessing.
+EOF
 }
 
 cmd_restart() {
@@ -601,40 +594,60 @@ cmd_restart() {
     openclaw gateway restart 2>&1
   else
     echo "Restarting proxy..."
-    # Try current service name, then legacy, then manual restart.
-    # macOS: bootout+bootstrap (re-reads plist EnvironmentVariables — see cmd_restart_help).
-    # Linux: systemctl --user restart already re-reads its EnvironmentFile.
-    local uid
-    uid=$(id -u)
-    if _launchd_reload "$uid" "dev.ocp.proxy" "$HOME/Library/LaunchAgents/dev.ocp.proxy.plist"; then
-      true
-    elif _launchd_reload "$uid" "ai.openclaw.proxy" "$HOME/Library/LaunchAgents/ai.openclaw.proxy.plist"; then
-      true
-    elif systemctl --user restart ocp-proxy 2>/dev/null; then
-      true
-    elif systemctl --user restart openclaw-proxy 2>/dev/null; then
-      true
-    else
-      echo "Service restart failed, trying kill + restart..."
-      pkill -f "server.mjs.*CLAUDE_PROXY" 2>/dev/null || pkill -f "claude-proxy/server.mjs" 2>/dev/null || true
-      sleep 1
-      local self_r script_dir
-      self_r="${BASH_SOURCE[0]}"
-      while [[ -L "$self_r" ]]; do self_r="$(readlink "$self_r")"; done
-      script_dir="$(cd "$(dirname "$self_r")" && pwd)"
-      # env -u strips test-only key-store redirection vars (A4): if the invoking shell had
-      # NODE_ENV=test + OCP_DIR_OVERRIDE exported (e.g. from a debugging session), this manual
-      # fallback would otherwise inherit them and start the daemon against a scratch/empty key
-      # store — a silent auth outage in AUTH_MODE=multi. The plist/systemd paths strip these via
-      # plist-merge's NEVER_PRESERVE; this covers the one direct-launch path OCP controls.
-      DISABLE_AUTOUPDATER=1 env -u NODE_ENV -u OCP_DIR_OVERRIDE nohup node "$script_dir/server.mjs" >> "$HOME/.ocp/logs/proxy.log" 2>&1 &
+    local self_r script_dir
+    self_r="${BASH_SOURCE[0]}"
+    while [[ -L "$self_r" ]]; do self_r="$(readlink "$self_r")"; done
+    script_dir="$(cd "$(dirname "$self_r")" && pwd)"
+
+    # Issue #224: this used to hard-code a restart cascade (dev.ocp.proxy plist -> legacy
+    # ai.openclaw.proxy plist -> `systemctl --user restart ocp-proxy` -> legacy
+    # `openclaw-proxy` -> a manual pkill+nohup fallback that didn't even keep the process
+    # under a service manager afterward) with ZERO verification of which unit actually owned
+    # the port — the exact defect class issue #215 reported and PR #221 already fixed for
+    # scripts/upgrade.mjs's own restart phases, but NOT for this bash path (both `ocp update`
+    # kinds delegate here — see #224's own analysis of _cmd_update_light/_cmd_update_restart).
+    # Rather than reimplementing cgroup/ss parsing a second time in bash, shell out to the SAME
+    # resolver PR #221 already wired into scripts/upgrade.mjs
+    # (scripts/lib/restart-unit.mjs's resolveOwningUnit()/planRestart(), via
+    # resolveRestartPlan()) through a one-shot CLI mode: `--resolve-restart` prints the
+    # resolved restart command(s) to stdout (one per line) and exits 0, or prints the
+    # actionable refusal to stderr and exits non-zero. No fallback to a guess, and no more
+    # unmanaged nohup process left behind on refusal.
+    #
+    # `|| resolve_status=$?` (not a bare assignment) is load-bearing under `set -euo pipefail`
+    # (ocp:7): a bare `var=$(cmd)` where cmd exits non-zero trips `set -e` immediately, which
+    # would abort THIS function (and everything that called it) before the refusal handling
+    # below ever runs — see the identical pattern and rationale on `doctor_json=... || true`
+    # in cmd_update. stderr is deliberately NOT captured here (no `2>&1`/`2>/dev/null`): it
+    # flows straight through to the caller in real time, so the refusal message reaches the
+    # operator even though only stdout (the resolved commands) is captured into a variable.
+    local resolve_out resolve_status=0
+    resolve_out=$(node "$script_dir/scripts/upgrade.mjs" --resolve-restart) || resolve_status=$?
+
+    if [[ $resolve_status -ne 0 ]]; then
+      echo "✗ Restart aborted (see error above)."
+      return 1
     fi
+
+    local restart_failed=0 cmd_line
+    while IFS= read -r cmd_line; do
+      [[ -z "$cmd_line" ]] && continue
+      echo "  $cmd_line"
+      eval "$cmd_line" || restart_failed=1
+    done <<< "$resolve_out"
+
+    if [[ $restart_failed -ne 0 ]]; then
+      echo "✗ Restart command failed."
+      return 1
+    fi
+
     sleep 3
     if curl -sf --max-time 5 "$PROXY/health" > /dev/null 2>&1; then
       echo "✓ Proxy restarted successfully."
       cmd_usage
     else
       echo "✗ Proxy not responding after restart."
+      return 1
     fi
   fi
 }
@@ -924,7 +937,15 @@ _cmd_update_light() {
   fi
 
   echo "  Restarting proxy..."
-  cmd_restart > /dev/null 2>&1
+  # Issue #224: this used to be `cmd_restart > /dev/null 2>&1`, discarding ALL of cmd_restart's
+  # output — including its own refusal/failure messages, which are exactly what #224 asks to
+  # make loud rather than invisible on the single most common update path. cmd_restart's own
+  # `exit`-on-failure hazard inside cmd_usage's success path (calling `exit`, not `return`, if
+  # its own `/usage` probe fails) is pre-existing and unrelated to this change — `_cmd_update_
+  # restart` already works around that specific hazard with a `( cmd_restart ) || true` subshell
+  # (see below); direct `ocp restart` has never been wrapped that way either, so this matches
+  # existing, established behavior rather than introducing a new one.
+  cmd_restart
 }
 
 # Issue #214: tree is already at latest, but the RUNNING SERVICE is stale — a previous update

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -744,6 +744,36 @@ if (_isMain()) {
     }
   }
 
+  // Issue #224: bash's cmd_restart() (ocp's restart phase — used directly by `ocp restart` and,
+  // via _cmd_update_light/_cmd_update_restart, by BOTH `ocp update` paths) used to hard-code a
+  // restart cascade with ZERO unit resolution — the exact defect class issue #215 reported,
+  // still live on this path even after PR #221 fixed the two scripts/upgrade.mjs call sites
+  // above (runFullUpgrade / runRollback) that already use resolveRestartPlan(). Per #224's own
+  // recommended design, `cmd_restart` shells out to THIS one-shot mode instead of reimplementing
+  // cgroup/ss parsing a second time in bash — there is ONE resolution implementation
+  // (scripts/lib/restart-unit.mjs's resolveOwningUnit()/planRestart(), wired through
+  // resolveRestartPlan() above), not two that can drift.
+  //
+  // Contract: on success, print the resolved restart command(s) to stdout, one per line, and
+  // exit 0 — bash runs them verbatim. On failure (ambiguous owner, no-unit, nothing listening,
+  // an unauthorized system-unit restart, etc.), print the actionable refusal message to stderr
+  // and exit non-zero — bash surfaces it and refuses, never falling through to a guess. Neither
+  // --dry-run nor --yes apply here: this mode never mutates anything itself, it only resolves
+  // and reports what WOULD run.
+  const resolveRestartIdx = args.indexOf("--resolve-restart");
+  if (resolveRestartIdx !== -1) {
+    const port = process.env.CLAUDE_PROXY_PORT || String(DEFAULT_PORT);
+    try {
+      const { plan } = resolveRestartPlan({ opts: {}, port });
+      for (const w of plan.warnings) console.error(w);
+      for (const c of plan.cmds) console.log(c.cmd);
+      process.exit(0);
+    } catch (err) {
+      console.error(`✗ ${err.message}`);
+      process.exit(1);
+    }
+  }
+
   try {
     const result = await runUpgrade({ dryRun, yes, rollback, list, gc, snapshotPath, target });
     if (result.plan) for (const line of result.plan) console.log(line);

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -8757,15 +8757,41 @@ test("ocp bash harness: '# ── dispatch' anchor slice is well-formed (premise
     "the dispatch case statement was expected AFTER the anchor and is missing — anchor drift");
 });
 
-// Runs `cmd_update <args>` against a from-scratch sandbox built fresh per call (own $HOME, own
+// Runs `cmd_update <args>` (or, with overrideCmdRestart:false, any other subcommand — see
+// issue #224 tests below) against a from-scratch sandbox built fresh per call (own $HOME, own
 // $PATH, own scratch `script_dir` — never the real repo, never the calling shell's $PATH/$HOME).
 // `script_dir` doubles as the directory holding the generated driver script itself: `ocp`'s
 // functions resolve `script_dir` from `${BASH_SOURCE[0]}`, which — for a directly-executed
 // script (not `source`d) — is the file the running code was READ from, i.e. the driver file
 // this harness writes. package.json therefore lives next to driver.sh, not in a subdirectory.
+//
+// Issue #224 additions (all default to the pre-#224 behavior so every existing call site above
+// is unaffected):
+//   overrideCmdRestart   default true (unchanged): cmd_restart is replaced by the
+//                        FAKE-CMD-RESTART-CALLED stub, as before. Set false to let the REAL,
+//                        sliced cmd_restart run — the only way to exercise this issue's fix.
+//   resolveRestartExit/Stdout/Stderr   controls the fake `node`'s new
+//                        `scripts/upgrade.mjs --resolve-restart` case (Stdout/Stderr are arrays
+//                        of lines; Stdout lines are what the REAL mode prints on success — the
+//                        resolved restart command(s), one per `console.log` call).
+//   serviceStubsSucceed  default false (unchanged posture: launchctl/systemctl/pkill/nohup/
+//                        openclaw log-and-loudly-refuse, exit 95, per AGENTS.md "unreachable by
+//                        construction"). Set true only to observe a resolved restart command
+//                        actually being invoked (it still never reaches a real service — this
+//                        is still the from-scratch scratch $PATH).
+//   curlHealthExit       controls the new `curl` stub's exit for a "*/health*" URL (default 1,
+//                        i.e. "not responding" — deterministic and avoids needing to fabricate
+//                        a `/usage`-shaped JSON body for cmd_usage's own picky parser, which is
+//                        unrelated to this issue). Any curl call NOT matching "*/health*" (e.g.
+//                        cmd_usage's own `/usage` call, reached only on a successful health
+//                        check) refuses loudly (exit 94) rather than silently doing something
+//                        undefined — none of this issue's tests reach that far on purpose.
 function _bwHarnessRun({
   args = [], kind = "noop", checks = [], pythonAbsent = false,
   gitPullExit = 0, gitPullOutput = "Already up to date.", postFlightExit = 0,
+  overrideCmdRestart = true,
+  resolveRestartExit = 0, resolveRestartStdout = [], resolveRestartStderr = [],
+  serviceStubsSucceed = false, curlHealthExit = 1,
 } = {}) {
   const root = _ltMkdtemp(join(_ltTmp(), "ocp-bash-harness-"));
   try {
@@ -8803,6 +8829,16 @@ function _bwHarnessRun({
       `  *"scripts/upgrade.mjs --post-flight-only"*)`,
       `    exit ${postFlightExit}`,
       `    ;;`,
+      // Issue #224: the new one-shot resolver mode `cmd_restart` shells out to instead of
+      // reimplementing cgroup/ss parsing a second time in bash — see scripts/upgrade.mjs's
+      // `--resolve-restart` CLI entrypoint. Real behavior mirrored exactly: resolved command(s)
+      // on stdout (one per line) + exit 0 on success, refusal text on stderr + nonzero exit on
+      // failure — never both, never neither.
+      `  *"scripts/upgrade.mjs --resolve-restart"*)`,
+      ...resolveRestartStderr.map((l) => `    echo ${JSON.stringify(l)} >&2`),
+      ...resolveRestartStdout.map((l) => `    echo ${JSON.stringify(l)}`),
+      `    exit ${resolveRestartExit}`,
+      `    ;;`,
       `  *)`,
       `    echo "FAKE-NODE: refusing unhandled invocation (would run a REAL doctor.mjs/` +
         `upgrade.mjs path -- see #225 exec hazard): $*" >&2`,
@@ -8826,17 +8862,52 @@ function _bwHarnessRun({
     ].join("\n"));
 
     // Defense in depth (AGENTS.md: "any command that can mutate a running service ... should
-    // be a stub that fails loudly by default") — unreachable from the tests below (which all
-    // override `cmd_restart` wholesale, see the driver below), but must never silently succeed
-    // if a future test forgets to.
+    // be a stub that fails loudly by default") — unreachable from the pre-#224 tests below
+    // (which all override `cmd_restart` wholesale, see the driver below), but must never
+    // silently succeed if a future test forgets to. Issue #224's own tests need to observe a
+    // resolved restart command actually being run (still only ever against this harness's own
+    // fake binaries — serviceStubsSucceed never reaches a real service either), so they opt in
+    // via serviceStubsSucceed; every other call site keeps the strict refuse-and-log default.
     for (const name of ["launchctl", "systemctl", "pkill", "nohup", "openclaw"]) {
-      mkStub(name, [
+      mkStub(name, serviceStubsSucceed ? [
+        `echo "FAKE-${name.toUpperCase()}-CALL $*" >> "${logPath}"`,
+        `exit 0`,
+      ].join("\n") : [
         `echo "FAKE-${name.toUpperCase()}-CALL $*" >> "${logPath}"`,
         `echo "FAKE-${name.toUpperCase()}: refusing -- this harness must never reach a real ` +
           `service-mutating command (AGENTS.md 'unreachable by construction')" >&2`,
         `exit 95`,
       ].join("\n"));
     }
+
+    // Issue #224: `sleep` is a no-op stub purely for test speed (the real `cmd_restart` calls
+    // `sleep 3` after a successful restart command, before its own health check) — never a
+    // hazard, so always stubbed regardless of overrideCmdRestart (the pre-#224 tests never
+    // reach the real cmd_restart body at all, so this has no effect on them).
+    mkStub("sleep", [
+      `echo "FAKE-SLEEP-CALL $*" >> "${logPath}"`,
+      `exit 0`,
+    ].join("\n"));
+
+    // Issue #224: `curl` is real (unstubbed) on every pre-#224 call site above — none of them
+    // reach it, since they all override `cmd_restart` wholesale. The real `cmd_restart` DOES
+    // call curl (health check, and — on the success path — `cmd_usage`'s own `/usage` call), so
+    // it needs a deterministic stub the moment overrideCmdRestart:false is used. Only "*/health*"
+    // is recognized (controlled by curlHealthExit); anything else refuses loudly (exit 94)
+    // rather than silently doing something undefined — this issue's own tests never need
+    // cmd_usage's `/usage` call to succeed, so it's deliberately left unhandled here.
+    mkStub("curl", [
+      `echo "FAKE-CURL-CALL $*" >> "${logPath}"`,
+      `case "$*" in`,
+      `  *"/health"*)`,
+      `    exit ${curlHealthExit}`,
+      `    ;;`,
+      `  *)`,
+      `    echo "FAKE-CURL: refusing unhandled invocation: $*" >&2`,
+      `    exit 94`,
+      `    ;;`,
+      `esac`,
+    ].join("\n"));
 
     // Simulates issue #236's exact repro ("stubbed absent": a real executable file that always
     // reports command-not-found's own exit code) rather than trying to strip PATH of every
@@ -8865,15 +8936,24 @@ function _bwHarnessRun({
     // because that design skipped the exact wiring layer #225 asks this harness to cover.
     // Fixed by appending the REAL, unmodified dispatch section after the override and driving
     // it via its own argv, so the outer dispatch runs for real too.
+    //
+    // Issue #224: overrideCmdRestart:false skips this stub entirely, so the REAL cmd_restart
+    // from the sliced source (_bwFnSrc, above) is what the dispatch below actually calls — the
+    // only way to exercise this issue's fix. Still safe by construction: nothing here changes
+    // the ordering guarantee (no override is defined at all, so there's nothing to shadow), and
+    // every command the real cmd_restart can reach (node/systemctl/launchctl/pkill/nohup/sleep/
+    // curl) is one of this harness's own scratch-$PATH stubs, never a real binary.
     const driver = [
       _bwFnSrc,
       "",
-      `cmd_restart() {`,
-      `  echo "FAKE-CMD-RESTART-CALLED $*" >> "${logPath}"`,
-      `  echo "Restarting proxy..."`,
-      `  echo "✓ Proxy restarted successfully."`,
-      `  return 0`,
-      `}`,
+      overrideCmdRestart ? [
+        `cmd_restart() {`,
+        `  echo "FAKE-CMD-RESTART-CALLED $*" >> "${logPath}"`,
+        `  echo "Restarting proxy..."`,
+        `  echo "✓ Proxy restarted successfully."`,
+        `  return 0`,
+        `}`,
+      ].join("\n") : "# issue #224: overrideCmdRestart=false -- the REAL cmd_restart above is used as-is",
       "",
       `PROXY="http://127.0.0.1:1"`,
       "",
@@ -9324,6 +9404,134 @@ test("issue #233 defect 1: lsof is invoked at its absolute path (/usr/sbin/lsof)
   const restartCmds = result.phases.filter(p => p.name === "restart").map(p => p.cmd);
   assert.equal(restartCmds.length, 2);
   assert.ok(restartCmds[0].includes("launchctl bootout"));
+});
+
+// ── #224: cmd_restart itself still hard-coded a restart target, zero unit resolution ─────────
+// Everything above overrides cmd_restart wholesale (a necessary safety default — see
+// serviceStubsSucceed's own comment), so none of it exercises the REAL cmd_restart body. These
+// three tests set overrideCmdRestart:false specifically to reach it: cmd_restart must now
+// resolve its target by shelling out to `scripts/upgrade.mjs --resolve-restart` (the same
+// resolver PR #221 already wired into scripts/upgrade.mjs's own restart phases — see
+// scripts/lib/restart-unit.mjs), never falling back to a hard-coded guess, and must return a
+// real, non-zero exit code on refusal instead of always reporting success (issue #224's own
+// complaint: "cmd_restart currently has no failure exit code at all").
+console.log("\ncmd_restart resolver wiring (#224):");
+
+test("#224: cmd_restart refuses when the resolver can't determine the restart target -- no hard-coded fallback, real exit code", () => {
+  const r = _bwHarnessRun({
+    args: ["restart"],
+    overrideCmdRestart: false,
+    resolveRestartExit: 1,
+    resolveRestartStderr: ["restart aborted: MOCK-RESOLVER-REFUSAL-MARKER"],
+    // Mixed signal, deliberately: the mock ALSO leaks a would-be command on stdout even though
+    // it exits non-zero (a real `--resolve-restart` never does both, but a bug that checks the
+    // wrong thing — e.g. "did stdout have content" instead of "did the exit code say ok" — would
+    // still eval this if only the exit code were dropped). Proves the guard keys off the exit
+    // status, not stdout emptiness: this string must NEVER reach a real command.
+    resolveRestartStdout: ["systemctl restart -- SHOULD-NEVER-RUN.service"],
+  });
+  assert.notEqual(r.status, 0,
+    `cmd_restart must exit non-zero on a resolver refusal (the "no failure exit code at all" ` +
+    `bug); status=${r.status} stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok((r.stdout + r.stderr).includes("MOCK-RESOLVER-REFUSAL-MARKER"),
+    `the resolver's refusal message must reach the operator, not be swallowed; ` +
+    `stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(!_bwCalled(r.log, "FAKE-SYSTEMCTL-CALL restart -- SHOULD-NEVER-RUN.service"),
+    `a leaked stdout command must NEVER run once the resolver signaled failure via its exit ` +
+    `code; log=${JSON.stringify(r.log)}`);
+  for (const name of ["SYSTEMCTL", "LAUNCHCTL", "PKILL", "NOHUP"]) {
+    assert.ok(!_bwCalled(r.log, `FAKE-${name}-CALL`),
+      `${name} must NEVER be invoked after a resolver refusal -- that would repeat issue #215's ` +
+      `hard-coded guess; log=${JSON.stringify(r.log)}`);
+  }
+});
+
+test("#224: cmd_restart runs the resolver's actual resolved command, not the old hard-coded guess", () => {
+  const r = _bwHarnessRun({
+    args: ["restart"],
+    overrideCmdRestart: false,
+    resolveRestartExit: 0,
+    resolveRestartStdout: ["systemctl restart -- ocp.service"],
+    serviceStubsSucceed: true,
+    curlHealthExit: 1, // deterministic health-check failure; this test is only about which restart command ran
+  });
+  assert.ok(_bwCalled(r.log, "FAKE-SYSTEMCTL-CALL restart -- ocp.service"),
+    `must run the resolver's resolved command verbatim; log=${JSON.stringify(r.log)}`);
+  assert.ok(!r.log.some((l) => l.startsWith("FAKE-SYSTEMCTL-CALL") && l.includes("--user restart ocp-proxy")),
+    `must NOT fall back to the old hard-coded "systemctl --user restart ocp-proxy"; log=${JSON.stringify(r.log)}`);
+  assert.ok(r.stdout.includes("systemctl restart -- ocp.service"),
+    `the resolved command must be visible to the operator, not suppressed; stdout=${JSON.stringify(r.stdout)}`);
+  assert.notEqual(r.status, 0,
+    `the health check was made to fail on purpose; cmd_restart must still report a real, ` +
+    `non-zero exit code (not the old implicit success); status=${r.status}`);
+});
+
+test("#224: _cmd_update_light no longer swallows cmd_restart's refusal (operator sees why it failed, and the exit code is non-zero)", () => {
+  const r = _bwHarnessRun({
+    kind: "update",
+    args: ["update"],
+    overrideCmdRestart: false,
+    resolveRestartExit: 1,
+    resolveRestartStderr: ["restart aborted: MOCK-RESOLVER-REFUSAL-MARKER-LIGHT"],
+    resolveRestartStdout: ["systemctl restart -- SHOULD-NEVER-RUN.service"],
+  });
+  assert.ok(r.stdout.includes("Updating OCP (light path)"),
+    `sanity check that we actually reached _cmd_update_light; stdout=${JSON.stringify(r.stdout)}`);
+  assert.notEqual(r.status, 0,
+    `ocp update (light path) must exit non-zero when the restart phase refuses; status=${r.status}`);
+  assert.ok(!_bwCalled(r.log, "FAKE-SYSTEMCTL-CALL restart -- SHOULD-NEVER-RUN.service"),
+    `a leaked stdout command must NEVER run once the resolver signaled failure via its exit ` +
+    `code; log=${JSON.stringify(r.log)}`);
+  assert.ok((r.stdout + r.stderr).includes("MOCK-RESOLVER-REFUSAL-MARKER-LIGHT"),
+    `_cmd_update_light must surface cmd_restart's refusal message instead of discarding it via ` +
+    `its old "> /dev/null 2>&1"; stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+});
+
+// The three tests above drive `--resolve-restart` entirely through the bash harness's FAKE
+// `node` stub (by design — see the harness's own "exec hazard" comment: a real fake-node file
+// on the scratch $PATH is what makes ocp's `exec node ...` arms unreachable BY CONSTRUCTION).
+// That means none of them exercise the actual NEW code this issue adds inside
+// scripts/upgrade.mjs's own CLI entrypoint (the `--resolve-restart` argv branch) — the same
+// class of gap PR #243 named explicitly (its "N6" scope note) and deferred to #241 for
+// `--post-flight-only`. Unlike that flag, this one needs no live server and no polling loop —
+// resolveRestartPlan's real gathering layer (ss/lsof, both read-only) against a port nothing is
+// listening on is a safe, deterministic, real end-to-end exercise of the new CLI code as an
+// actual child process. `ltFreePort()` (not a literal port number) guarantees a genuinely free
+// port, so the real resolver refuses rather than resolving a command — true on every platform
+// this suite runs on, and nowhere near the real, separately-running production instance.
+//
+// Deliberately NOT pinned to a specific refusal message ("not listening" vs. "could not
+// determine..."): a genuinely free port's EXACT classification is platform/lsof-behavior
+// dependent (macOS's `lsof -iTCP:<port> -sTCP:LISTEN` exits 1 — not 0 — on a clean no-match,
+// which an unrelated, already in-review fix, PR #240, is what correctly maps to "not listening"
+// instead of "unknown"; without it this same free port reads as "could not determine"). Either
+// way is a REFUSAL, which is all this test is about: does the new `--resolve-restart` CLI
+// branch correctly turn a thrown Error into stderr+exit-1 rather than a silent success. The
+// specific listening/not-listening/unknown classification is covered exhaustively elsewhere
+// (the "Restart-unit resolution" section above) and is explicitly out of scope for #224 either
+// way.
+test("#224: scripts/upgrade.mjs --resolve-restart (real subprocess, not mocked) refuses on a genuinely free port", async () => {
+  const freePort = await ltFreePort();
+  const upgradeMjsPath = spotJoin(_spotDir, "scripts", "upgrade.mjs");
+  let stdout = "", stderr = "", status = 0;
+  try {
+    stdout = execFileSync(process.execPath, [upgradeMjsPath, "--resolve-restart"], {
+      env: { ...process.env, CLAUDE_PROXY_PORT: String(freePort) },
+      encoding: "utf8",
+    });
+  } catch (e) {
+    stdout = e.stdout ?? "";
+    stderr = e.stderr ?? "";
+    status = typeof e.status === "number" ? e.status : 1;
+  }
+  assert.notEqual(status, 0,
+    `a genuinely free port must refuse (nothing listening), not exit 0; ` +
+    `stdout=${JSON.stringify(stdout)} stderr=${JSON.stringify(stderr)}`);
+  assert.equal(stdout.trim(), "",
+    `on refusal, stdout must carry NO resolved restart command at all; stdout=${JSON.stringify(stdout)}`);
+  assert.ok(/^✗ restart aborted:/.test(stderr),
+    `expected planRestart's refusal shape on stderr (message text itself is platform-dependent ` +
+    `-- see comment above); stderr=${JSON.stringify(stderr)}`);
 });
 
 runAsyncTests().then(() => Promise.all(pendingAsync)).then(() => {


### PR DESCRIPTION
## Status: responding to independent review (Iron Rule 10 record)

**Verdict from the independent review: APPROVE**, with one finding requiring a correction (not a code defect) — full review: see the PR comment thread.

### Correction: the "PR #221 already dropped this" claim was wrong

The original PR body (below) justified narrowing `cmd_restart`'s macOS coverage (dropping the legacy `ai.openclaw.proxy`/`openclaw-proxy` fallback) by claiming PR #221 had "already dropped the identical legacy fallback for its own two callers without objection." **Checked against PR #221's actual diff — this is false.** `scripts/upgrade.mjs`'s `runFullUpgrade`/`runRollback` never had a legacy-name fallback to begin with (PR #221's own "before" snippet only ever references `dev.ocp.proxy`/`ocp-proxy.service`); there was nothing there for it to drop. **This PR is the first to remove that fallback**, not the second.

The underlying decision (delegate fully to the JS resolver, which doesn't support the legacy names) still stands on its own merits, restated without the false precedent: `dev.ocp.proxy`/`ocp-proxy.service` are the current unit names; any host still on the legacy label should already have been migrated by `setup.mjs`'s auto-start step (`scripts/lib/install-autostart.mjs` removes the legacy plist/unit on every `ocp update`/reconfigure); and on Linux the live cgroup walk is strictly *better* than the old two-name hard-coded list regardless, since it discovers whatever unit actually holds the port by reading its cgroup rather than checking a fixed name list.

**Flagged for the maintainer**: please confirm no fleet host is still running under the legacy macOS launchd label (`ai.openclaw.proxy`) before relying on this for such a host. Corrected in code too — see the updated comment in `ocp`'s `cmd_restart()` (new commit, not an amend of the original — this repo's git convention is new commits over rewriting pushed history).

### Also rebased onto PR #240 (merged since this PR was opened)

`main` moved from `87b7feb` to `f6131c3` (PR #240, macOS `lsof` exit-1/empty-stdout fix) while this PR was in review. Rebased cleanly after resolving one merge conflict in `test-features.mjs` (both PRs appended a new test section at the same anchor point, right before `runAsyncTests()` — mechanical concatenation, no logic changes on either side). Full suite re-run after the rebase: all 4 of this PR's new tests still pass, and the new real-subprocess test (`--resolve-restart` against a genuinely free port) picked up #240's fix automatically — its refusal message changed from "could not determine..." to "nothing is currently listening" between the two runs, and the test's assertion was deliberately written generic (`/^✗ restart aborted:/`, not a pinned message text) specifically to tolerate exactly this kind of platform/upstream-fix-dependent variation. See the review thread for the independent reviewer's confirmation of this too.

---

## Original PR description

## Summary

`ocp update`'s common same-minor patch-bump path (`_cmd_update_light`), the stale-service-only path (`_cmd_update_restart`, PR #217), and direct `ocp restart` all delegate to bash's `cmd_restart()` in `ocp`. PR #221 fixed the *other* two restart call sites (`scripts/upgrade.mjs`'s `runFullUpgrade`/`runRollback`) to resolve which unit actually owns the OCP port instead of restarting a hard-coded name (issue #215) — but explicitly deferred `cmd_restart()` itself to this issue (#224), because it's a different layer (bash vs. Node) with no comparable test harness at the time.

PR #243 has since built that harness. This PR uses it (extended, not duplicated) to fix `cmd_restart()`.

## What changed

- **`scripts/upgrade.mjs`** — pure addition: a new `--resolve-restart` CLI mode in the existing `_isMain()` entrypoint (right next to `--post-flight-only`). Calls the *same* `resolveRestartPlan()` already wired into `runFullUpgrade`/`runRollback` — no new resolution logic, no second implementation. On success: prints the resolved restart command(s) to stdout (one per line), exit 0. On failure: prints the actionable refusal to stderr, exit non-zero.
- **`ocp`** — `cmd_restart()` now shells out to `--resolve-restart`, `eval`s whatever it printed on success, and returns 1 on refusal (previously it had **no failure exit code at all** — every path, including "✗ Proxy not responding after restart", fell through to an implicit `return 0`). The old hard-coded cascade (`dev.ocp.proxy` plist → legacy `ai.openclaw.proxy` plist → `systemctl --user restart ocp-proxy` → legacy `openclaw-proxy` → a manual `pkill`+`nohup` fallback that didn't even keep the process under a service manager) is gone, along with the now-unused `_launchd_reload` helper. `_cmd_update_light` no longer redirects `cmd_restart`'s output to `/dev/null` — a refusal is now visible on the single most common update path, not just direct `ocp restart`.
- **`test-features.mjs`** — extends PR #243's bash CLI wiring harness (did **not** build a second one): a new `overrideCmdRestart:false` mode lets the *real* sliced `cmd_restart` run (every prior test in that harness overrides it wholesale by design — see the harness's own comments), backed by new `curl`/`sleep` stub cases and a `serviceStubsSucceed` opt-in for `launchctl`/`systemctl`/`pkill`/`nohup` (default stays the strict loud-refuse stub). Plus one real (unmocked) subprocess test driving the new `--resolve-restart` CLI branch itself.

## Design constraint: one resolution implementation, not two

Per this issue's own recommended design, `cmd_restart` does **not** reimplement cgroup/`ss` parsing in bash. It shells out to `scripts/upgrade.mjs --resolve-restart`, which calls the exact same `resolveRestartPlan()` (→ `scripts/lib/restart-unit.mjs`'s `resolveOwningUnit()`/`planRestart()`) that `runFullUpgrade`/`runRollback` already use. This was not a close call — a second bash-side reimplementation would be exactly the kind of drift-prone duplication this issue's write-up warned against.

## Out of scope, deliberately not touched

- **`scripts/upgrade.mjs`'s existing code** — the new `--resolve-restart` branch is a pure addition at the bottom of the file's `_isMain()` block; no existing line is modified.
- **`docs/troubleshooting.md`, `docs/upgrading.md`, `README.md`'s restart-target-resolution sections** — PR #240 was actively rewriting this exact prose while this PR was in review (now merged); extending it here would have conflicted. Deferred.
- **`cmd_usage`'s `exit`-vs-`return` hazard** (its own `/usage` probe failure calls `exit 1`, not `return`, which can propagate out of a successful `cmd_restart` through `_cmd_update_light`/direct `ocp restart`, neither of which subshell-wrap it the way `_cmd_update_restart` already does) — pre-existing, unrelated to this issue, not worsened by this change. Confirmed unworsened by the independent review.
- **CHANGELOG.md** — the PRs merged since v3.26.0 (including #221, #230, #243) did not add `Unreleased` entries either; following that established convention rather than introducing a new one.

## `server.mjs` / `cli.js`

**Not touched.** No `cli.js` citation applies — this is restart-phase tooling (`ocp`, `scripts/upgrade.mjs`), not the proxy wire surface `ALIGNMENT.md` governs. Independently confirmed via `git diff` (empty) and the CI blacklist check.

## Test evidence

**Fails on current `main`, passes with the fix** (all four new tests, run via `node test-features.mjs` before any of `ocp`/`scripts/upgrade.mjs` were touched):

```
cmd_restart resolver wiring (#224):
  ✗ #224: cmd_restart refuses when the resolver can't determine the restart target -- no hard-coded fallback, real exit code:
      cmd_restart must exit non-zero on a resolver refusal (the "no failure exit code at all" bug);
      status=0 stdout="Restarting proxy...\nService restart failed, trying kill + restart...\n✗ Proxy not responding after restart.\n"
  ✗ #224: cmd_restart runs the resolver's actual resolved command, not the old hard-coded guess:
      must run the resolver's resolved command verbatim;
      log=["FAKE-SYSTEMCTL-CALL --user restart ocp-proxy", ...]   <- the OLD hard-coded call, not the resolved one
  ✗ #224: _cmd_update_light no longer swallows cmd_restart's refusal ...:
      ocp update (light path) must exit non-zero when the restart phase refuses; status=0
  ✗ #224: scripts/upgrade.mjs --resolve-restart (real subprocess, not mocked) refuses on a genuinely free port:
      a genuinely free port must refuse (nothing listening), not exit 0; stdout="" stderr=""
      (the flag doesn't exist yet on unfixed main -- falls through to a no-op / unrecognized-flag path)
```

**After the fix** — all four pass:

```
cmd_restart resolver wiring (#224):
restart aborted: MOCK-RESOLVER-REFUSAL-MARKER
  ✓ #224: cmd_restart refuses when the resolver can't determine the restart target -- no hard-coded fallback, real exit code
  ✓ #224: cmd_restart runs the resolver's actual resolved command, not the old hard-coded guess
restart aborted: MOCK-RESOLVER-REFUSAL-MARKER-LIGHT
  ✓ #224: _cmd_update_light no longer swallows cmd_restart's refusal (operator sees why it failed, and the exit code is non-zero)
✗ restart aborted: nothing is currently listening on the OCP port ...
  ✓ #224: scripts/upgrade.mjs --resolve-restart (real subprocess, not mocked) refuses on a genuinely free port
```

(The last message text is shown post-rebase onto PR #240 — pre-rebase it read "could not determine..."; both are refusals, which is all this test asserts, deliberately.)

## Mutation table

Every mutation applied to a **file backup** (`cp` to scratch, never `git checkout` — checkout restores the committed state and would silently discard the uncommitted tests this issue's fix needed), confirmed to produce an actionable failure, restored from the backup, `shasum -a 256`-verified byte-identical, full suite reconfirmed before the next mutation. **Independently reproduced by the reviewer** for mutations #1 and #4 (see review thread).

| # | Mutation | File | Result before restore |
|---|---|---|---|
| 1 | Neutralize the `resolve_status -ne 0` early-refusal guard (`if false; then ... fi`) | `ocp` | 2 tests FAIL: a leaked stdout command (`systemctl restart -- SHOULD-NEVER-RUN.service`, deliberately included in the mock alongside the nonzero exit code) now actually runs — `log=[...,"FAKE-SYSTEMCTL-CALL restart -- SHOULD-NEVER-RUN.service"]` |
| 2 | Replace the `eval "$cmd_line"` loop with the old hard-coded `systemctl --user restart ocp-proxy` | `ocp` | 1 test FAILS: `must run the resolver's resolved command verbatim; log=[...,"FAKE-SYSTEMCTL-CALL --user restart ocp-proxy",...]` — the OLD command ran instead of the resolved one |
| 3 | Revert `_cmd_update_light`'s fix (`cmd_restart` → `cmd_restart > /dev/null 2>&1`) | `ocp` | 1 test FAILS: `_cmd_update_light must surface cmd_restart's refusal message instead of discarding it ...; stdout="...\n  Restarting proxy...\n" stderr=""` — message swallowed again |
| 4 | `--resolve-restart`'s catch branch: `process.exit(1)` → `process.exit(0)` | `scripts/upgrade.mjs` | 1 test FAILS: `a genuinely free port must refuse (nothing listening), not exit 0; stdout="" stderr=""` |

All 4 mutations reproduced with the exact messages above; all restored and `shasum -a 256`-verified byte-identical against the pre-mutation backup before moving to the next one.

## Suite count

Post-rebase onto PR #240: **670 total** (642 original baseline + PR #240's own new tests + 4 new from this PR). Locally: passes modulo pre-existing `OCP_LOCAL_TOOLS`/`ltBoot`-fixture integration-test flakiness — confirmed present on unmodified `main` too (isolated via `git stash`), under heavy concurrent multi-agent load on this dev host, and independently reproduced by the reviewer on a fresh clone (3 runs on this PR's branch, 2 clean runs of 653/0 on unmodified `main` at the time). Never any test this PR added or touched. CI (`.github/workflows/test.yml`, isolated `ubuntu-latest` runner, runs the real full `npm test`) is green — see the CI check on this PR.

## Issue #215

This PR addresses the last of #215's three suggested remediations (the standalone `Closes #215` line at the bottom of this PR is the one that counts):
1. Resolve the PID/unit actually owning the port, and warn loudly on mismatch — landed via PR #221 for `scripts/upgrade.mjs`'s own restart phases.
2. Pre-flight warning when multiple enabled units point at the same port — landed via PR #230 (`doctor.mjs`'s `multi_unit_boot_race` check).
3. The same resolution for bash's `cmd_restart()` — **this PR**.

Independently reviewed and confirmed.

## Test plan

- [x] `bash -n ocp` / `node --check scripts/upgrade.mjs` / `node --check test-features.mjs` — syntax clean
- [x] New tests fail on unfixed `ocp`/`scripts/upgrade.mjs`, pass after the fix (shown above)
- [x] Mutation table above (1–4), each restored from a `shasum`-verified file backup, suite green after each restore — 2 of 4 independently reproduced by the reviewer
- [x] Full `npm test` locally and via CI
- [x] Rebased onto latest `origin/main` (`f6131c3`, includes merged PR #240) — one merge conflict resolved (mechanical, same-anchor test-section concatenation), verified clean
- [x] Independent review completed (Iron Rule 10) — APPROVE, one correction applied (see "Status" section above)

Closes #224
Closes #215

Refs #221, #230, #243, #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gbqUZ8HfBZpjjbzQ85oH8
