### PR TITLE
fix(upgrade): rollback restart guard keys on unit IDENTITY, not scope

### DIFF
--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -259,6 +259,34 @@ function resolveRestartPlan({ opts, port, isRollback = false, fromCommit = null 
     );
   }
 
+  // issue #234 (second independent review of #221, post-merge): the refusal above only fires for
+  // a SYSTEM-scope mismatch — it keys on `owner.kind`, i.e. SCOPE, not on unit IDENTITY. But
+  // rollback's restore step (scripts/lib/snapshot.mjs's tryCopy calls / runRollback's own tryCopy
+  // calls above) only EVER writes `expectedUnit`'s own file — never any other unit's, user-scope
+  // included. A user-scope unit under a DIFFERENT name from `expectedUnit` is exactly as untouched
+  // by the restore as a system unit is: nothing above this line has EVER written its config, and
+  // restarting it would restart whatever config was already there before the rollback started,
+  // while "${expectedUnit}"'s just-restored file sits on disk unused. That is precisely the field
+  // report in #234 — "restored: ocp-proxy.service, restarted: ocp.service" — except here the
+  // restarted unit is user-scope too, so the SYSTEM-unit check above never even sees it. Guard on
+  // IDENTITY (owner.unit !== expectedUnit) for this case, exactly as issue #234 prescribes,
+  // instead of extending the scope check to somehow cover it.
+  if (isRollback && owner.kind === "user-unit" && owner.unit !== expectedUnit) {
+    const manualCmd = `systemctl --user restart -- ${owner.unit}`;
+    throw new Error(
+      `rollback aborted: the OCP port is owned by a DIFFERENT user-scope unit ("${owner.unit}"), but ` +
+      `rollback only ever restores "${expectedUnit}"'s own config (scripts/lib/snapshot.mjs's ` +
+      `tryCopy calls / runRollback's own tryCopy calls in scripts/upgrade.mjs always target that ` +
+      `exact file, never "${owner.unit}"'s). Restarting "${owner.unit}" would not make the rollback ` +
+      `take effect: it would restart config the rollback never touched, while "${expectedUnit}"'s ` +
+      `freshly-restored file sits unused. The working tree has ALREADY been rolled back to ` +
+      `${fromCommit || "the snapshot's from-commit"} (the git-checkout phase, which ran before this ` +
+      `check) — if "${owner.unit}" runs from that same tree, only a restart is outstanding: run ` +
+      `\`${manualCmd}\` manually to pick that up, and separately reconcile "${owner.unit}"'s own ` +
+      `config against "${expectedUnit}"'s restored file by hand if they differ.`
+    );
+  }
+
   const plan = planRestart(owner, {
     expectedUnit,
     isRoot,

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -8475,6 +8475,53 @@ test("MED-8: rollback DOES restart a matching USER unit, and issues daemon-reloa
   assert.ok(reloadIdx < restartIdx, "daemon-reload must happen BEFORE the restart, so the restored unit file is actually picked up");
 });
 
+console.log("\nRestart-unit resolution (issue #234) — rollback guard must key on UNIT IDENTITY, not scope:");
+
+// Found by a second independent review of #221, post-merge. The SYSTEM-unit refusal above
+// (MED-8) keys on `owner.kind === "system-unit"` — SCOPE, not IDENTITY. Rollback's restore step
+// (scripts/lib/snapshot.mjs's tryCopy calls / runRollback's own tryCopy calls in
+// scripts/upgrade.mjs) only ever writes `expectedUnit`'s own file — never any OTHER unit's,
+// user-scope included. A user-scope unit under a DIFFERENT name is just as untouched by the
+// restore as a system unit is, and slipped through this refusal unrefused before the #234 fix,
+// letting rollback restart config it never touched while "ocp-proxy.service"'s freshly-restored
+// file went unused — silently dropping the rollback's configuration half. See issue #234.
+
+test("#234: rollback aborts when a DIFFERENT user-scope unit owns the port than the one whose config was restored", async () => {
+  await assert.rejects(async () => {
+    await runUpgrade({
+      rollback: true, yes: true, mockExec: true,
+      mockPlatform: "linux",
+      mockSnapshots: [{ name: "upgrade-snapshot-2026-05-11T08:30:00Z", path: "/tmp/snap-x" }],
+      mockSnapshotMeta: { fromCommit: "abc1234", fromVersion: "v3.10.0", toVersion: "v3.14.0", path: "/tmp/snap-x" },
+      mockOwnerProbe: {
+        ssOutput: `LISTEN 0 511 127.0.0.1:3456 0.0.0.0:* users:(("node",pid=888736,fd=19))`,
+        cgroupContent: "0::/user.slice/user-1000.slice/user@1000.service/app.slice/custom-ocp.service\n",
+      },
+    });
+  }, /rollback aborted: the OCP port is owned by a DIFFERENT user-scope unit \("custom-ocp\.service"\), but rollback only ever restores "ocp-proxy\.service"'s own config/);
+});
+
+test("#234: the mismatched-user-unit refusal never actually restarts the wrong unit (no restart COMMAND runs, only the bookkeeping failure phase)", async () => {
+  let caught = null;
+  try {
+    await runUpgrade({
+      rollback: true, yes: true, mockExec: true,
+      mockPlatform: "linux",
+      mockSnapshots: [{ name: "upgrade-snapshot-2026-05-11T08:30:00Z", path: "/tmp/snap-x" }],
+      mockSnapshotMeta: { fromCommit: "abc1234", fromVersion: "v3.10.0", toVersion: "v3.14.0", path: "/tmp/snap-x" },
+      mockOwnerProbe: {
+        ssOutput: `LISTEN 0 511 127.0.0.1:3456 0.0.0.0:* users:(("node",pid=888736,fd=19))`,
+        cgroupContent: "0::/user.slice/user-1000.slice/user@1000.service/app.slice/custom-ocp.service\n",
+      },
+    });
+  } catch (e) {
+    caught = e;
+  }
+  assert.ok(caught, "rollback must reject on a mismatched user-scope unit");
+  assert.ok(!caught.phases.some(p => p.name === "restart" && p.cmd),
+    `no restart COMMAND may run against a unit whose config was never restored; phases=${JSON.stringify(caught.phases)}`);
+});
+
 test("MED-8: rollback on macOS does NOT run daemon-reload (systemd-only concept)", async () => {
   const result = await runUpgrade({
     rollback: true, yes: true, mockExec: true,


### PR DESCRIPTION
# Pull Request

## Summary

Fixes issue #234: rollback restores one systemd unit's config but could restart a *different*
user-scope unit, silently dropping the configuration half of the rollback guarantee. The existing
refusal in `scripts/upgrade.mjs`'s `resolveRestartPlan()` only keyed on **scope**
(`owner.kind === "system-unit"`); it never caught a mismatched **user-scope** unit, which is exactly
what rollback's own restore step (`scripts/lib/snapshot.mjs` / `runRollback`'s `tryCopy` calls) never
touches either. This PR adds a second guard keyed on **unit identity**
(`owner.unit !== expectedUnit`) so a mismatched user-scope unit refuses the same way a system-scope
one already does.

## Endpoint Class (REQUIRED)

- [x] **Not endpoint-touching** — this is a fix to `scripts/upgrade.mjs`'s rollback restart-resolution
  logic (the `ocp update --rollback` CLI path). No HTTP request handler in `server.mjs` is touched by
  this PR. `server.mjs` does not appear in the diff at all.

## Claude Code Alignment Evidence (REQUIRED)

N/A — not endpoint-touching. `server.mjs` is untouched by this PR, so no `cli.js:NNNN` citation
applies (`ALIGNMENT.md` Rule 5 governs `server.mjs` changes only). Confirmed by re-reading the diff:
only `scripts/upgrade.mjs` and `test-features.mjs` changed.

## Type of change

- [x] Bug fix (closes a gap in the restart-resolver rollback guard added by PR #221 and reviewed
  again post-merge)

## What changed

`scripts/upgrade.mjs`'s `resolveRestartPlan()` had exactly one rollback-specific refusal:

```js
if (isRollback && owner.kind === "system-unit") { throw ...; }
```

This refuses correctly when the port is owned by a SYSTEM-scope unit (rollback never restores
system-scope config). But rollback's restore step only ever writes **one specific file**:
`~/.config/systemd/user/ocp-proxy.service` (`expectedUnit`, hard-coded). A **user-scope** unit
under any *other* name — e.g. a hand-rolled `custom-ocp.service` — falls through this check
entirely (`owner.kind` is `"user-unit"`, not `"system-unit"`) and reaches `planRestart()`, which
only *warns* on `owner.mismatched` and then restarts whatever it resolved. The result, live:

```
restored : ~/.config/systemd/user/ocp-proxy.service
restarted: systemctl --user restart -- custom-ocp.service
```

— the exact defect #234 reports. The fix adds a second, additive guard:

```js
if (isRollback && owner.kind === "user-unit" && owner.unit !== expectedUnit) { throw ...; }
```

with a message distinct from the SYSTEM-unit refusal's wording (names the specific unit whose
config *was* restored vs. the one that would have been restarted, and gives the exact manual
`systemctl --user restart` command). The pre-existing SYSTEM-unit guard, and every test covering
it (MED-8, MED-E, MED-F), is untouched.

Deliberately **not** touched by this PR (out of scope, tracked separately): #237, the sibling
defect where the resolver restarts a unit that isn't OCP's `server.mjs` at all (a foreign service
like `nginx.service`). That is a different failure mode — an *identity* problem independent of
rollback's config-coupling problem this PR fixes — and ships as its own PR per Iron Rule 11.

## Test evidence

Two new tests in `test-features.mjs`, section "Restart-unit resolution (issue #234)":

1. `#234: rollback aborts when a DIFFERENT user-scope unit owns the port than the one whose config
   was restored`
2. `#234: the mismatched-user-unit refusal never actually restarts the wrong unit (no restart
   COMMAND runs, only the bookkeeping failure phase)`

**Before the fix** (unmodified `main` + these two tests only):

```
✗ #234: the mismatched-user-unit refusal never actually restarts the wrong unit ...: rollback must reject on a mismatched user-scope unit
✗ #234: rollback aborts when a DIFFERENT user-scope unit owns the port than the one whose config was restored: Missing expected rejection.
```

(The bug is real and reproducible: it also printed the pre-existing `[restart] WARNING: the OCP
port is actually served by "custom-ocp.service" ...` and then proceeded, exactly matching the
issue's field report.)

**After the fix:**

```
✓ #234: rollback aborts when a DIFFERENT user-scope unit owns the port than the one whose config was restored
✓ #234: the mismatched-user-unit refusal never actually restarts the wrong unit (no restart COMMAND runs, only the bookkeeping failure phase)
```

## Mutation proof

| Step | Action | Result |
|---|---|---|
| 1 | `shasum -a 256 scripts/upgrade.mjs` before mutation | `8822cd31...23f681d` |
| 2 | Assert-then-mutate script confirmed the anchor `if (isRollback && owner.kind === "user-unit" && owner.unit !== expectedUnit) {` appears **exactly once**, then rewrote it to `if (false && isRollback && ...)` (guard neutered) | anchor found, mutation applied |
| 3 | Ran suite | Both named tests above **fail** (`rollback must reject on a mismatched user-scope unit`, `Missing expected rejection.`) — the guard's absence is caught by name, not by count |
| 4 | Restored `scripts/upgrade.mjs` from the pre-mutation **file backup** (`cp`, never `git checkout -- ...`) | |
| 5 | `shasum -a 256` post-restore vs. pre-mutation backup | **identical** (`8822cd31...23f681d` both) |
| 6 | Re-ran suite | Both tests pass again |

## Full suite

`node test-features.mjs`, run 7 times consecutively on this branch: **664–665 passed**, **7–9
failed** every run. The failures are, every single time, exclusively the pre-existing
`OCP_LOCAL_TOOLS`/`ltBoot` live-server integration cluster documented as host-load-flaky in
AGENTS.md/#248 (confirmed: this repo currently has ~30 concurrent agent worktrees running on this
host; `ps aux | grep node` showed 40 node processes at time of testing). This exact cluster,
with the exact same non-deterministic membership, was verified on a **clean, unmodified
`origin/main` checkout** before any change in this PR — it is not caused by this diff. Every
restart-unit/rollback test, old and new, passed deterministically on all 7 runs.

## Related

- `ALIGNMENT.md` Rule(s) invoked: none — not endpoint-touching, `server.mjs` untouched.
- Related issue: closes #234.
- Refs #215, #221, #230, #233 — prior restart-resolver history (all closed; none reopened by this
  change).
- See #237 for the sibling "foreign unit" defect, filed and fixed separately.

### User-visible change self-check (铁律第五律 5.3)

- [x] This PR has no user-visible changes beyond a more specific refusal message on an already-rare
  rollback edge case — no README documentation update needed (no new CLI subcommand, env var, or
  endpoint).

### Privacy self-check (for PUBLIC repos)

- [x] No real names, personal paths, hostnames, or personal email addresses introduced.
