### PR TITLE
fix(restart-unit): refuse to restart a foreign, non-OCP unit holding the port

### DIFF
--- a/scripts/lib/restart-unit.mjs
+++ b/scripts/lib/restart-unit.mjs
@@ -87,6 +87,38 @@
  * evidence and the resulting three-way split) — this function's job is just to forward the
  * cross-check's result through to it via `probe.netstatConfirmsListener` /
  * `probe.netstatProbeFailed`.
+ *
+ * Issue #237 (independent review of the `v3.26.0..main` batch, filed alongside #234) found a
+ * different kind of gap than any of the four above: every prior fix made the resolver more
+ * HONEST about what it found, but never verified that what it found is actually OCP. Once
+ * `parseCgroupUnit` resolves a real, well-formed systemd unit name, `resolveOwningUnit` only ever
+ * compares that NAME against the hard-coded `expectedUnit` — a mismatch (`owner.mismatched`)
+ * produces a WARNING in `planRestart`, never a refusal. A port misconfigured onto a port some
+ * unrelated systemd-managed service already holds (`nginx.service`, say) resolves exactly like a
+ * legitimate but renamed OCP unit does: `kind: "system-unit"`, a real unit name, `mismatched:
+ * true`. `planRestart` then proceeds to build `sudo systemctl restart -- nginx.service`. This is
+ * the safety INVERSE of #215: #215 restarted the wrong thing because the resolver GUESSED at an
+ * identity it had no basis for; #237 restarts the wrong thing because the resolver correctly
+ * identifies a real unit that simply isn't ours, and acts on that identification anyway.
+ *
+ * Fix: `classifyCmdlineOwner` reads `/proc/<pid>/cmdline` (NUL-separated argv) for the SAME PID
+ * the cgroup probe already resolved — gathered in the same probe pass in scripts/upgrade.mjs's
+ * `resolveRestartPlan`, no separate resolution round-trip — and checks whether that process
+ * actually invokes `server.mjs`, mirroring scripts/doctor.mjs's own #230 `fingerprintSystemdUnit`
+ * serverArg check so the two "is this an OCP unit" tests can't drift apart. A CONFIRMED-foreign
+ * process (cmdline read cleanly, no server.mjs anywhere in it) short-circuits `resolveOwningUnit`
+ * straight to a new terminal `kind: "foreign-process"`, which `planRestart` refuses
+ * unconditionally — before ever reaching the mismatch-warning/sudo/system-unit machinery below,
+ * regardless of root or sudo authorization. An UNREADABLE cmdline (permission denied, PID raced)
+ * is `kind: "unknown"`, the same fail-closed terminal state every other probe failure in this file
+ * already uses — never treated as "confirmed foreign" (a false-confident answer) nor silently
+ * skipped (which would defeat the point of the check).
+ *
+ * Deliberately NOT covered by this fix (same "minimum reviewable unit" posture as defect 2 in the
+ * THIRD review above): macOS. `/proc/<pid>/cmdline` doesn't exist there, and the darwin branch
+ * below still returns `kind: "launchd"` for any confirmed listener without identifying the actual
+ * process at all (issue #233 defect 2, already tracked as its own follow-up) — extending identity
+ * verification to macOS is that same follow-up's job, not this one's.
  */
 
 // Anything accepted as a restart target must look like a real systemd unit name.
@@ -303,6 +335,51 @@ export function parseCgroupUnit(cgroupContent) {
   return { state: "no-unit", scope: null, unit: null, reason: "no cgroup line yielded a recognizable systemd unit" };
 }
 
+// --- Linux: classify /proc/<pid>/cmdline content as OCP's own server.mjs, or a foreign process ---
+// (issue #237)
+//
+// parseCgroupUnit answers "what UNIT owns this port" — never "is the process behind that unit
+// actually OCP's server.mjs". A well-formed, real systemd unit name (nginx.service, say) resolves
+// cleanly through parseCgroupUnit exactly like a legitimately-renamed OCP unit does; nothing in
+// that resolution path can tell the two apart. classifyCmdlineOwner reads /proc/<pid>/cmdline for
+// the SAME pid parseCgroupUnit's cgroup content came from (NUL-separated argv — not
+// space-separated, so a path containing a literal space is never misread as two tokens) and
+// checks whether that process actually invokes server.mjs, using the exact same test
+// scripts/doctor.mjs's #230 fingerprintSystemdUnit already uses for its own ExecStart argv[]
+// check (`a === "server.mjs" || a.endsWith("/server.mjs")`) — so "doctor.mjs would recognize this
+// as an OCP unit" and "this resolver treats it as a restart candidate" can't silently drift apart
+// into two different definitions of the same question.
+//
+// Returns one of three states — same "unknown must never be treated as safe-to-guess" posture as
+// every other classifier in this file:
+//   "ocp"      cmdline contains an argv token that is exactly "server.mjs" or ends with
+//              "/server.mjs".
+//   "foreign"  cmdline was read successfully and contains NO such token — a confident, positive
+//              "this is not us" signal (the nginx.service scenario issue #237 reports).
+//   "unknown"  /proc/<pid>/cmdline could not be read at all (permission denied — a non-root
+//              updater probing a root-owned PID under hidepid=2, the same gap parseCgroupUnit's
+//              own "unknown" state exists for — or the PID exited between the cgroup read and
+//              this one). Must NOT be read as "foreign": a false-confident "definitely not OCP"
+//              diagnosis on a process we simply couldn't inspect is exactly the wrong-but-
+//              confident answer this file's classifiers all exist to eliminate.
+export function classifyCmdlineOwner(cmdlineContent) {
+  if (cmdlineContent == null) {
+    return { state: "unknown", reason: "could not read /proc/<pid>/cmdline (permission denied, or the process exited between probes)" };
+  }
+  const argv = String(cmdlineContent).split("\0").filter(Boolean);
+  if (argv.length === 0) {
+    return { state: "unknown", reason: "empty /proc/<pid>/cmdline read" };
+  }
+  const serverArg = argv.find(a => a === "server.mjs" || a.endsWith("/server.mjs"));
+  if (!serverArg) {
+    return {
+      state: "foreign",
+      reason: `owning process's argv (${argv.join(" ")}) does not invoke server.mjs at all — this is not an OCP process`,
+    };
+  }
+  return { state: "ocp", reason: null };
+}
+
 /**
  * Resolve the owner of `probe.platform`'s OCP port from already-collected raw
  * command output. Never shells out — pass real output in from the caller.
@@ -322,17 +399,32 @@ export function parseCgroupUnit(cgroupContent) {
  *   netstatProbeFailed       macOS only: the netstat cross-check itself could not run
  *   cgroupContent  raw `/proc/<pid>/cgroup` content for the resolved PID, or
  *                   null if unreadable (Linux)
+ *   cmdlineContent raw `/proc/<pid>/cmdline` content for the resolved PID (Linux only; issue
+ *                   #237). Three states, same convention as cgroupContent:
+ *                     a string     classified via classifyCmdlineOwner
+ *                     null         the probe was ATTEMPTED and failed to read — treated as
+ *                                  "unknown" (see classifyCmdlineOwner)
+ *                     undefined    the caller never attempted this probe at all — the check is
+ *                                  SKIPPED entirely, preserving pre-#237 behavior. This is the
+ *                                  legacy/back-compat lane: scripts/upgrade.mjs's own gather
+ *                                  layer always populates this field one way or another now, so
+ *                                  in real production use it is a string or null, never
+ *                                  undefined — "undefined" only arises from a caller (or test)
+ *                                  that hasn't been wired to this check, and must not newly
+ *                                  refuse restarts that were safe before this field existed.
  *
  * Returns { kind, platform, pid, unit, scope?, mismatched, reason? }, kind one of:
- *   "system-unit"    Linux, port owned by a system-scope systemd unit
- *   "user-unit"      Linux, port owned by a user-scope systemd unit
- *   "launchd"        macOS, port is held by a process (launchd is the only
- *                    restart mechanism this repo drives on macOS)
- *   "no-unit"        Linux, a PID holds the port but isn't in any systemd unit
- *                    (a bare `node server.mjs`, most likely)
- *   "not-listening"  the tool ran cleanly and found nothing bound to the port
- *   "unknown"        could not determine ownership (see `reason`) — must never
- *                     be treated as equivalent to "not-listening"
+ *   "system-unit"      Linux, port owned by a system-scope systemd unit
+ *   "user-unit"        Linux, port owned by a user-scope systemd unit
+ *   "launchd"          macOS, port is held by a process (launchd is the only
+ *                      restart mechanism this repo drives on macOS)
+ *   "no-unit"          Linux, a PID holds the port but isn't in any systemd unit
+ *                      (a bare `node server.mjs`, most likely)
+ *   "foreign-process"  Linux, a real systemd unit owns the port but its process is CONFIRMED not
+ *                      to be OCP's server.mjs (issue #237 — e.g. nginx.service)
+ *   "not-listening"    the tool ran cleanly and found nothing bound to the port
+ *   "unknown"          could not determine ownership (see `reason`) — must never
+ *                       be treated as equivalent to "not-listening"
  */
 export function resolveOwningUnit(probe = {}) {
   const platform = probe.platform || process.platform;
@@ -366,6 +458,28 @@ export function resolveOwningUnit(probe = {}) {
   }
   if (cgroupResult.state === "no-unit") {
     return { kind: "no-unit", platform, pid: listener.pid, unit: null, mismatched: false };
+  }
+
+  // issue #237: a well-formed systemd unit name is not proof the process behind it is OCP's own
+  // server.mjs — verify the actual running process before ever treating this as a restart
+  // candidate. probe.cmdlineContent === undefined means the caller never attempted this probe at
+  // all (skip the check, preserve pre-#237 behavior for callers not yet wired to it); a string or
+  // null means it WAS attempted, and gets classified/treated-as-unknown respectively. See
+  // classifyCmdlineOwner's own comment for the full three-state rationale.
+  if (probe.cmdlineContent !== undefined) {
+    const cmdlineResult = classifyCmdlineOwner(probe.cmdlineContent);
+    if (cmdlineResult.state === "unknown") {
+      return {
+        kind: "unknown", platform, pid: listener.pid, unit: cgroupResult.unit, mismatched: false,
+        reason: `resolved unit "${cgroupResult.unit}" via cgroup, but could not confirm the owning process is OCP's server.mjs — ${cmdlineResult.reason}`,
+      };
+    }
+    if (cmdlineResult.state === "foreign") {
+      return {
+        kind: "foreign-process", platform, pid: listener.pid, unit: cgroupResult.unit, mismatched: false,
+        reason: `"${cgroupResult.unit}" (${cgroupResult.scope}-scope) owns the OCP port, but its process is not OCP's server.mjs — ${cmdlineResult.reason}`,
+      };
+    }
   }
 
   const mismatched = !!expectedUnit && cgroupResult.unit !== expectedUnit;
@@ -486,6 +600,28 @@ export function planRestart(owner, opts = {}) {
       `(a bare "node server.mjs"?). Restarting "${opts.expectedUnit}" here would spawn a second, ` +
       `orphaned process that cannot bind the port — exactly issue #215. Stop PID ${owner.pid} manually ` +
       `(or bring it under systemd) and re-run the upgrade.`
+    );
+  }
+
+  // issue #237: a real, well-formed systemd unit is not proof it's OCP's own. Unlike
+  // `mismatched` (a NAME comparison against the hard-coded expectedUnit, which only ever warns —
+  // see the warnings.push at the top of this function), this is a POSITIVE confirmation from the
+  // owning process's own /proc/<pid>/cmdline that it is definitely not server.mjs. This is the
+  // safety inverse of #215: #215 restarted the wrong thing because the resolver guessed at an
+  // identity it had no basis for; this restarts the wrong thing because the resolver correctly
+  // identifies a real unit that simply isn't ours — bouncing an unrelated production service
+  // (nginx.service, say) is outside OCP's legitimate blast radius regardless of root/sudo
+  // authorization, so this refuses unconditionally, before any of the system-unit/user-unit
+  // machinery below ever runs.
+  if (owner.kind === "foreign-process") {
+    // owner.reason (built by resolveOwningUnit) already names the unit, its scope, and the
+    // cmdline evidence — no need to re-preface it with another "the OCP port is owned by X" here.
+    throw new Error(
+      `restart aborted: ${owner.reason}. Restarting an unrelated service this tooling does not ` +
+      `manage is outside OCP's legitimate blast radius — refusing rather than repeating issue ` +
+      `#215's failure mode in the opposite direction (see issue #237). Verify what's actually ` +
+      `bound to this port (\`ss -lptn\` / \`cat /proc/${owner.pid}/cmdline\`) and either free the ` +
+      `port for OCP or point CLAUDE_PROXY_PORT elsewhere.`
     );
   }
 

--- a/scripts/lib/restart-unit.mjs
+++ b/scripts/lib/restart-unit.mjs
@@ -117,8 +117,10 @@
  * Deliberately NOT covered by this fix (same "minimum reviewable unit" posture as defect 2 in the
  * THIRD review above): macOS. `/proc/<pid>/cmdline` doesn't exist there, and the darwin branch
  * below still returns `kind: "launchd"` for any confirmed listener without identifying the actual
- * process at all (issue #233 defect 2, already tracked as its own follow-up) — extending identity
- * verification to macOS is that same follow-up's job, not this one's.
+ * process at all. That gap was originally reported as issue #233 defect 2; #233 itself is now
+ * CLOSED (split per Iron Rule 11 into its own dedicated review) and the live tracker for this
+ * specific work is issue #239 — extending identity verification to macOS is #239's job, not this
+ * one's.
  */
 
 // Anything accepted as a restart target must look like a real systemd unit name.

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -199,6 +199,11 @@ function resolveRestartPlan({ opts, port, isRollback = false, fromCommit = null 
       const listener = classifySsListener(probe.ssOutput);
       if (listener.state === "listening") {
         try { probe.cgroupContent = run(`cat /proc/${listener.pid}/cgroup`); } catch { probe.cgroupContent = null; }
+        // issue #237: read cmdline in the SAME gather step, keyed off the same listener.pid — no
+        // separate resolution pass. resolveOwningUnit (scripts/lib/restart-unit.mjs) uses this to
+        // confirm the owning process is actually OCP's server.mjs before ever treating a resolved
+        // unit as a restart candidate, instead of acting on a real-but-foreign unit name.
+        try { probe.cmdlineContent = run(`cat /proc/${listener.pid}/cmdline`); } catch { probe.cmdlineContent = null; }
       }
     }
     owner = resolveOwningUnit(probe);

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -7919,7 +7919,7 @@ test("LOW-2 (real shell, verified mechanism): ocp's doctor-check-surfacing block
 // and asserts on return values or thrown messages — never on scripts/
 // upgrade.mjs's or scripts/lib/restart-unit.mjs's source text.
 // ═══════════════════════════════════════════════════════════════════════════
-import { resolveOwningUnit, planRestart, classifySsListener, classifyLsofListener, parseCgroupUnit } from "./scripts/lib/restart-unit.mjs";
+import { resolveOwningUnit, planRestart, classifySsListener, classifyLsofListener, parseCgroupUnit, classifyCmdlineOwner } from "./scripts/lib/restart-unit.mjs";
 
 console.log("\nRestart-unit resolution (issue #215) — classifiers:");
 
@@ -8049,6 +8049,119 @@ test("MED-5: parseCgroupUnit rejects a space-containing unit segment (word-split
   const result = parseCgroupUnit(cgroup);
   assert.notEqual(result.state, "resolved");
   assert.equal(result.unit, null);
+});
+
+console.log("\nRestart-unit resolution (issue #237) — classifyCmdlineOwner:");
+
+// issue #237: a well-formed, real systemd unit name is not proof the process behind it is OCP's
+// own server.mjs — parseCgroupUnit resolving "nginx.service" tells you WHICH unit owns the port,
+// never WHETHER that unit is ours. classifyCmdlineOwner reads the SAME PID's /proc/<pid>/cmdline
+// (NUL-separated argv) and answers exactly that, mirroring doctor.mjs's #230
+// fingerprintSystemdUnit's own serverArg check (`a === "server.mjs" || a.endsWith("/server.mjs")`)
+// so "doctor.mjs would call this an OCP unit" and "this resolver treats it as a restart candidate"
+// are the same test, not two that can drift apart.
+
+test("classifyCmdlineOwner: argv invokes server.mjs directly → ocp", () => {
+  const cmdline = "node\0server.mjs\0--port\0" + "3456" + "\0";
+  assert.deepEqual(classifyCmdlineOwner(cmdline), { state: "ocp", reason: null });
+});
+
+test("classifyCmdlineOwner: argv invokes an absolute path ending in /server.mjs → ocp", () => {
+  const cmdline = "/usr/bin/node\0/home/opc/ocp/server.mjs\0";
+  assert.deepEqual(classifyCmdlineOwner(cmdline), { state: "ocp", reason: null });
+});
+
+test("classifyCmdlineOwner: nginx's real cmdline (no server.mjs anywhere) → foreign, names the argv in the reason", () => {
+  // The literal issue #237 scenario: CLAUDE_PROXY_PORT misconfigured onto a port nginx already
+  // holds. nginx is a real, systemd-managed unit — parseCgroupUnit resolves it cleanly to
+  // "nginx.service" — but its process is definitely not OCP.
+  const cmdline = "nginx: master process /usr/sbin/nginx -g daemon off;\0";
+  const result = classifyCmdlineOwner(cmdline);
+  assert.equal(result.state, "foreign");
+  assert.ok(result.reason.includes("does not invoke server.mjs"));
+  assert.ok(result.reason.includes("nginx"), `reason should name the actual argv; got: ${result.reason}`);
+});
+
+test("classifyCmdlineOwner: NUL is the argv separator, not a space — a path containing a literal space is not two tokens", () => {
+  // /proc/<pid>/cmdline is NUL-separated; naively splitting on whitespace would tear
+  // "/opt/my ocp/server.mjs" into two tokens, neither of which ends in "/server.mjs" as typed.
+  const cmdline = "/usr/bin/node\0/opt/my ocp/server.mjs\0";
+  assert.deepEqual(classifyCmdlineOwner(cmdline), { state: "ocp", reason: null });
+});
+
+test("classifyCmdlineOwner: unreadable cmdline (null) → unknown, never the false-confident 'foreign'", () => {
+  // Same "unknown must never be treated as safe-to-guess" posture as parseCgroupUnit's own
+  // null-handling: permission denied (hidepid=2, a non-root updater against a root-owned PID) or
+  // the PID exiting between the cgroup read and this one both look like this. A false "definitely
+  // NOT OCP" diagnosis on a process we simply could not inspect would be exactly the
+  // wrong-but-confident answer every classifier in this file exists to eliminate.
+  const result = classifyCmdlineOwner(null);
+  assert.equal(result.state, "unknown");
+  assert.notEqual(result.state, "foreign");
+});
+
+test("classifyCmdlineOwner: empty-string cmdline read is also 'unknown', not 'foreign'", () => {
+  assert.equal(classifyCmdlineOwner("").state, "unknown");
+});
+
+console.log("\nRestart-unit resolution (issue #237) — resolveOwningUnit + planRestart refuse a FOREIGN process holding the port:");
+
+test("resolveOwningUnit: a real systemd unit (nginx.service) whose process is confirmed NOT server.mjs resolves to 'foreign-process', not 'system-unit'", () => {
+  const owner = resolveOwningUnit({
+    platform: "linux",
+    expectedUnit: "ocp-proxy.service",
+    ssOutput: `LISTEN 0 511 0.0.0.0:80 0.0.0.0:* users:(("nginx",pid=445001,fd=6))`,
+    cgroupContent: "0::/system.slice/nginx.service\n",
+    cmdlineContent: "nginx: master process /usr/sbin/nginx -g daemon off;\0",
+  });
+  assert.equal(owner.kind, "foreign-process");
+  assert.equal(owner.unit, "nginx.service");
+  assert.equal(owner.pid, "445001");
+  assert.ok(owner.reason.includes("nginx.service"));
+});
+
+test("planRestart: 'foreign-process' always refuses — never constructs a restart command, even when root/sudo-authorized", () => {
+  const owner = {
+    kind: "foreign-process", platform: "linux", pid: "445001", unit: "nginx.service", mismatched: false,
+    reason: `"nginx.service" (system-scope) owns the OCP port, but its process is not OCP's server.mjs`,
+  };
+  assert.throws(
+    () => planRestart(owner, { expectedUnit: "ocp-proxy.service", isRoot: true, sudoAuthorized: true }),
+    /nginx\.service.*not OCP's server\.mjs/s
+  );
+});
+
+test("resolveOwningUnit + planRestart, end to end: a probe attempted but FAILED to read cmdline (null, not absent) refuses as unknown, never proceeds", () => {
+  // Distinguishes "the caller never attempted this probe" (undefined — legacy callers, backward
+  // compatible, see the test below) from "the caller attempted it and it failed" (null — the same
+  // permission/race gap parseCgroupUnit's own cgroupContent:null case exists for). A failed
+  // probe must refuse, not silently skip the check it was trying to perform.
+  const owner = resolveOwningUnit({
+    platform: "linux",
+    expectedUnit: "ocp-proxy.service",
+    ssOutput: `LISTEN 0 511 0.0.0.0:80 0.0.0.0:* users:(("nginx",pid=445001,fd=6))`,
+    cgroupContent: "0::/system.slice/nginx.service\n",
+    cmdlineContent: null,
+  });
+  assert.equal(owner.kind, "unknown");
+  assert.throws(() => planRestart(owner, { expectedUnit: "ocp-proxy.service", isRoot: true }), /could not determine|could not confirm/);
+});
+
+test("resolveOwningUnit: cmdlineContent ABSENT (undefined, not null) preserves pre-#237 behavior — backward compatible for callers not wired to the new check", () => {
+  // A caller that never attempts the cmdline probe at all (an older test fixture, or any future
+  // caller of this pure function that hasn't been updated) must not be newly refused just because
+  // a field it never populated is missing — production's own gather layer (scripts/upgrade.mjs)
+  // now ALWAYS attempts this probe, so in real use cmdlineContent is a string or explicitly null,
+  // never undefined. This is what keeps issue #215's own pre-existing mismatch-warning coverage
+  // (the "ocp.service" test just above) passing unmodified.
+  const owner = resolveOwningUnit({
+    platform: "linux",
+    expectedUnit: "ocp-proxy.service",
+    ssOutput: `LISTEN 0 511 0.0.0.0:3456 0.0.0.0:* users:(("node",pid=798931,fd=19))`,
+    cgroupContent: "0::/system.slice/ocp.service\n",
+  });
+  assert.equal(owner.kind, "system-unit");
+  assert.equal(owner.mismatched, true);
 });
 
 console.log("\nRestart-unit resolution (issue #215) — resolveOwningUnit composition:");
@@ -8222,6 +8335,53 @@ test("upgrade full path: mismatched system unit is restarted (not the hard-coded
   assert.ok(result.phases.some(p => p.name === "restart-resolve" && p.note.includes("#215")), "mismatch must surface loudly in phases");
 });
 
+test("#237: upgrade full path — a FOREIGN systemd unit (nginx.service) holding the port must refuse, never restart it, even when root", async () => {
+  // This is the headline #237 scenario, driven end to end through the SAME runUpgrade() path the
+  // test right above exercises for a legitimate mismatch: CLAUDE_PROXY_PORT collides with a port
+  // nginx already owns. Pre-#237, this probe shape resolves to kind:"system-unit",
+  // mismatched:true — the same shape as the "ocp.service" test above — and, being root, proceeds
+  // straight to `systemctl restart -- nginx.service`. That is the exact "restart the wrong,
+  // unrelated production service" failure #237 reports; refusing here is the whole point of this
+  // PR.
+  await assert.rejects(async () => {
+    await runUpgrade({
+      yes: true, dryRun: false, mockExec: true,
+      mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" }, current_version: "v3.10.0", latest_version: "v3.14.0" },
+      mockPlatform: "linux",
+      mockOwnerProbe: {
+        ssOutput: `LISTEN 0 511 0.0.0.0:3456 0.0.0.0:* users:(("nginx",pid=445001,fd=6))`,
+        cgroupContent: "0::/system.slice/nginx.service\n",
+        cmdlineContent: "nginx: master process /usr/sbin/nginx -g daemon off;\0",
+      },
+      mockIsRoot: true,
+      mockSudoAuthorized: true,
+    });
+  }, /nginx\.service.*not OCP's server\.mjs/s);
+});
+
+test("#237: the foreign-unit refusal fires before any restart command is ever constructed — no 'restart' phase with a cmd field", async () => {
+  let caught = null;
+  try {
+    await runUpgrade({
+      yes: true, dryRun: false, mockExec: true,
+      mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" }, current_version: "v3.10.0", latest_version: "v3.14.0" },
+      mockPlatform: "linux",
+      mockOwnerProbe: {
+        ssOutput: `LISTEN 0 511 0.0.0.0:3456 0.0.0.0:* users:(("nginx",pid=445001,fd=6))`,
+        cgroupContent: "0::/system.slice/nginx.service\n",
+        cmdlineContent: "nginx: master process /usr/sbin/nginx -g daemon off;\0",
+      },
+      mockIsRoot: true,
+      mockSudoAuthorized: true,
+    });
+  } catch (e) {
+    caught = e;
+  }
+  assert.ok(caught, "must reject when the port owner is a confirmed-foreign process");
+  assert.ok(!(caught.phases || []).some(p => p.name === "restart" && p.cmd),
+    `no restart COMMAND may ever be constructed for a foreign unit; phases=${JSON.stringify(caught.phases)}`);
+});
+
 test("upgrade full path: port owned by no unit aborts the whole upgrade with an actionable message (does not claim success)", async () => {
   await assert.rejects(async () => {
     await runUpgrade({
@@ -8341,6 +8501,11 @@ test("MED-6: injected runner — Linux path calls `ss`, not `lsof` (platform bra
   const run = makeFakeRun({
     "ss -lptn": `LISTEN 0 511 0.0.0.0:3456 0.0.0.0:* users:(("node",pid=798931,fd=19))`,
     "cat /proc/798931/cgroup": "0::/system.slice/ocp.service\n",
+    // issue #237: resolveOwningUnit now also reads cmdline for the resolved PID — this fixture's
+    // scenario is a legitimately-renamed OCP unit (not the foreign-process case #237 covers
+    // elsewhere), so its cmdline must actually look like server.mjs or this test would newly
+    // (and wrongly) refuse as "foreign".
+    "cat /proc/798931/cmdline": "/usr/bin/node\0/opt/ocp/server.mjs\0",
     "lsof": new Error("test: lsof must not be called on Linux"),
   });
   const result = await runUpgrade({
@@ -8398,6 +8563,8 @@ test("MED-6: injected runner — real mismatch end to end (ss+cgroup text in, su
   const run = makeFakeRun({
     "ss -lptn": `LISTEN 0 511 0.0.0.0:3456 0.0.0.0:* users:(("node",pid=798931,fd=19))`,
     "cat /proc/798931/cgroup": "0::/system.slice/ocp.service\n",
+    // issue #237: see the "Linux path calls ss" test above for why this handler is required now.
+    "cat /proc/798931/cmdline": "/usr/bin/node\0/opt/ocp/server.mjs\0",
     "sudo -n -l systemctl restart -- ocp.service": "systemctl restart -- ocp.service",
   });
   const result = await runUpgrade({
@@ -8409,10 +8576,36 @@ test("MED-6: injected runner — real mismatch end to end (ss+cgroup text in, su
   assert.deepEqual(restartCmds, ["sudo systemctl restart -- ocp.service"]);
 });
 
+test("#237: injected runner — REAL gather layer reads /proc/<pid>/cmdline and refuses a foreign process end to end (not just the pure functions)", async () => {
+  // Every test above that exercises the #237 refusal uses mockOwnerProbe, which bypasses
+  // scripts/upgrade.mjs's own gather layer (the `run(...)` calls) entirely. Per this repo's own
+  // documented lesson (independent review of PR #221, finding MED-6 — see the "real mismatch end
+  // to end" test just above): the IMPURE gather layer — which command runs, with which flags —
+  // had ZERO coverage in the first cut of #215's fix, and that's exactly where the real defects
+  // lived (a platform-branch swap survived undetected). This test drives the ACTUAL `cat
+  // /proc/<pid>/cmdline` invocation scripts/upgrade.mjs's resolveRestartPlan() now makes, via a
+  // fake command router — proving the wiring itself (not just resolveOwningUnit/planRestart in
+  // isolation) refuses a foreign systemd unit.
+  const run = makeFakeRun({
+    "ss -lptn": `LISTEN 0 511 0.0.0.0:3456 0.0.0.0:* users:(("nginx",pid=445001,fd=6))`,
+    "cat /proc/445001/cgroup": "0::/system.slice/nginx.service\n",
+    "cat /proc/445001/cmdline": "nginx: master process /usr/sbin/nginx -g daemon off;\0",
+  });
+  await assert.rejects(async () => {
+    await runUpgrade({
+      yes: true, dryRun: false, mockExec: true,
+      mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" }, current_version: "v3.10.0", latest_version: "v3.14.0" },
+      mockPlatform: "linux", mockIsRoot: true, run,
+    });
+  }, /nginx\.service.*not OCP's server\.mjs/s);
+});
+
 test("MED-4 wiring: injected runner — sudo -n -l denies THIS specific command → refuses (not a generic sudo -n true probe)", async () => {
   const run = makeFakeRun({
     "ss -lptn": `LISTEN 0 511 0.0.0.0:3456 0.0.0.0:* users:(("node",pid=798931,fd=19))`,
     "cat /proc/798931/cgroup": "0::/system.slice/ocp.service\n",
+    // issue #237: see the "Linux path calls ss" test above for why this handler is required now.
+    "cat /proc/798931/cmdline": "/usr/bin/node\0/opt/ocp/server.mjs\0",
     "sudo -n -l systemctl restart -- ocp.service": new Error("sudo: a password is required"),
   });
   await assert.rejects(async () => {
@@ -8428,6 +8621,8 @@ test("MED-4 wiring: uid===0 short-circuits sudo entirely — no sudo probe run, 
   const run = makeFakeRun({
     "ss -lptn": `LISTEN 0 511 0.0.0.0:3456 0.0.0.0:* users:(("node",pid=798931,fd=19))`,
     "cat /proc/798931/cgroup": "0::/system.slice/ocp.service\n",
+    // issue #237: see the "Linux path calls ss" test above for why this handler is required now.
+    "cat /proc/798931/cmdline": "/usr/bin/node\0/opt/ocp/server.mjs\0",
     "sudo": new Error("test: sudo must not be invoked when already root"),
   });
   const result = await runUpgrade({


### PR DESCRIPTION
# Pull Request

## Summary

Fixes issue #237: the restart resolver would restart a **foreign, non-OCP unit** that happens to
hold the OCP port. `resolveOwningUnit` (`scripts/lib/restart-unit.mjs`) resolves a port-owning
systemd unit via `/proc/<pid>/cgroup`, but only ever compares the resulting *name* against a
hard-coded `expectedUnit` — a mismatch (`owner.mismatched`) is a **warning**, never a refusal. A
port misconfigured onto a port some unrelated systemd-managed service already holds (e.g.
`nginx.service`) resolves exactly like a legitimately-renamed OCP unit does, and `planRestart`
proceeds to build `sudo systemctl restart -- nginx.service`. This PR verifies the *actual process*
via `/proc/<pid>/cmdline` before ever treating a resolved unit as a restart candidate, and refuses
unconditionally when it's confirmed not to be `server.mjs`.

## Endpoint Class (REQUIRED)

- [x] **Not endpoint-touching** — this is a fix to the restart-resolution logic in
  `scripts/lib/restart-unit.mjs` and its gather layer in `scripts/upgrade.mjs` (the `ocp update` /
  `ocp restart` CLI path). No HTTP request handler in `server.mjs` is touched. `server.mjs` does
  not appear in the diff.

## Claude Code Alignment Evidence (REQUIRED)

N/A — not endpoint-touching. `server.mjs` is untouched by this PR, so no `cli.js:NNNN` citation
applies (`ALIGNMENT.md` Rule 5 governs `server.mjs` changes only). Confirmed by re-reading the
diff: only `scripts/lib/restart-unit.mjs`, `scripts/upgrade.mjs`, and `test-features.mjs` changed.
Independently reverified by the reviewer via `gh pr diff --name-only`.

## Type of change

- [x] Bug fix / security hardening (closes a gap in the restart-resolver that lets it act on an
  identification it has no basis for)

## Design decision (per the issue's own ask — this is a design call, not a mechanical fix)

Two options were on the table:

1. **A static whitelist of known OCP unit names.** Rejected: it does not survive this fleet's own
   documented shape — two production hosts run a **system-level** `ocp.service`, one a
   **user-level** `ocp-proxy.service`, one a **launchd** `dev.ocp.proxy`. A whitelist would need
   per-host configuration to avoid false refusals on the very units it must *not* block, and does
   not generalize to any future custom unit name an operator might choose.
2. **Deriving identity from the actual running process's command line** — does it invoke *our*
   `server.mjs` at all? Chosen. It needs no configuration, degrades safely (an unreadable cmdline
   is `"unknown"`, the same fail-closed terminal state every other probe failure in this module
   already uses — never "safe to guess"), and — importantly — this repo **already has exactly this
   primitive**: `scripts/doctor.mjs`'s #230 `fingerprintSystemdUnit` fingerprints `ExecStart`'s
   `argv[]` for a `server.mjs` token to decide whether a *candidate unit definition* is OCP's. This
   PR applies the identical test to the *actual running process* via `/proc/<pid>/cmdline`, so
   "doctor.mjs would call this an OCP unit" and "the restart resolver treats this as a restart
   candidate" are the same check, not two definitions of "is this OCP" that can silently drift
   apart.

**Independent review's own framing of why this is the right call (adopted here, stronger than my
original rationale):** the change is *directionally monotone*. A false "foreign" verdict yields a
loud refusal (annoying, but safe); a false "ocp" verdict reproduces exactly pre-#237 behavior (no
new risk introduced). It can only ever turn "silently restarts nginx" into "refuses" — never the
reverse. Spoofing a fake `server.mjs` argv is a non-issue for the threat model this addresses
(misconfiguration, not an adversary controlling process names): the unit *name* still comes from
cgroup and is still re-validated by `UNIT_NAME_RE` at the shell-out boundary, so a crafted argv
buys an attacker at most a self-inflicted refusal. Fail-closed on an unreadable cmdline adds no new
false-refusal surface in practice, since under `hidepid`-style restrictions the cgroup read already
fails first and already yields `"unknown"`.

Deliberately **not** covered (own follow-up): **macOS**. `/proc/<pid>/cmdline` doesn't exist there,
and the `darwin` branch still returns `kind: "launchd"` for any confirmed listener without
verifying it's actually the `dev.ocp.proxy` process at all. That gap was originally reported as
issue #233 defect 2; **#233 itself is now CLOSED** (split per Iron Rule 11 into its own dedicated
design review) — the live, open tracker for this specific follow-up is **#239**. (Corrected after
independent review flagged the original PR body/code-comment citing #233 (now closed) as if it were
still the active tracker — see `bf95869`.) Also flagged by review and tracked separately: the
foreign-process check narrows but doesn't fully close the issue's own "expected working tree's
server.mjs" qualifier — a *different* Node app on the same host whose entrypoint also happens to be
named `server.mjs` would still classify as `"ocp"`. Reviewer judged the looser check the right
trade-off for this PR (full closure of the reported nginx-class vulnerability, no new false-refusal
surface) but asked that the residual gap be filed rather than silently dropped: **#254**.

## What changed

- `scripts/lib/restart-unit.mjs`:
  - New pure classifier `classifyCmdlineOwner(cmdlineContent)` — NUL-separated
    `/proc/<pid>/cmdline` argv, three states (`"ocp"` / `"foreign"` / `"unknown"`), mirroring every
    other classifier's "unknown must never be treated as safe" posture already established in this
    file.
  - `resolveOwningUnit` consults it immediately after cgroup resolution succeeds. A confirmed
    foreign process short-circuits to a new terminal `kind: "foreign-process"` instead of
    `"system-unit"`/`"user-unit"`.
  - `planRestart` refuses `"foreign-process"` unconditionally — before any sudo/root/system-unit
    logic runs, regardless of authorization.
  - Backward compatible: `probe.cmdlineContent === undefined` (caller never attempted the probe)
    skips the check entirely; `null` (probe attempted, failed) is `"unknown"` → refuse. Production's
    own gather layer always populates one of string/null now, never `undefined`.
- `scripts/upgrade.mjs`: the Linux gather step now also reads `/proc/<pid>/cmdline` in the **same**
  step that already reads `/proc/<pid>/cgroup` — no separate resolution pass, per the issue's own
  suggested approach.

## Test evidence

New tests in `test-features.mjs`, "issue #237" sections: classifier unit tests, `resolveOwningUnit`
+ `planRestart` composition tests, and end-to-end `runUpgrade()` wiring tests — both via
`mockOwnerProbe` **and** via a real injected `run()` fake command router (the latter specifically
closes the "impure gather layer had zero coverage" gap PR #221's own review found — see AGENTS.md's
testing-discipline section).

**Before the fix** (unmodified `main` + the two `runUpgrade()`-level tests only):

```
✗ #237: upgrade full path — a FOREIGN systemd unit (nginx.service) holding the port must refuse, never restart it, even when root: Missing expected rejection.
✗ #237: the foreign-unit refusal fires before any restart command is ever constructed ...: must reject when the port owner is a confirmed-foreign process
```

Both currently proceed all the way to constructing `systemctl restart -- nginx.service`.

**After the fix:**

```
✓ #237: upgrade full path — a FOREIGN systemd unit (nginx.service) holding the port must refuse, never restart it, even when root
✓ #237: the foreign-unit refusal fires before any restart command is ever constructed — no 'restart' phase with a cmd field
✓ #237: injected runner — REAL gather layer reads /proc/<pid>/cmdline and refuses a foreign process end to end (not just the pure functions)
```

## Mutation proof

Four mutations against `scripts/lib/restart-unit.mjs` / `scripts/upgrade.mjs`. Each: file backed up
with `cp` first (never `git checkout -- ...`, which would discard the uncommitted tests), a
Python script asserts the anchor string is present **exactly once** before mutating (so a
silently-no-op mutation can't be misread as "the guard held"), then restored from the backup and
reconfirmed with `shasum -a 256` before moving to the next mutation.

**Correction (post-review):** the original table understated mutation A's blast radius as 3 tests;
independently re-run after review flagged it — it is actually **4**. The missed one is the same
real-`run()` wiring test mutation C exists for (added mid-session, after the mutation-C gap was
found), which I'd added to mutation C's row but forgot to re-check against mutation A. Verified
directly (mutated → 4 named failures → restored → `shasum` byte-identical) before correcting this
table.

| # | Mutation | Failing tests (by name) |
|---|---|---|
| A | `resolveOwningUnit`: neutered the foreign-state branch (`if (false && cmdlineResult.state === "foreign")`) | `resolveOwningUnit: a real systemd unit (nginx.service) whose process is confirmed NOT server.mjs resolves to 'foreign-process', not 'system-unit'`; `#237: upgrade full path — a FOREIGN systemd unit ...`; `#237: the foreign-unit refusal fires before any restart command ...`; **`#237: injected runner — REAL gather layer reads /proc/<pid>/cmdline and refuses a foreign process end to end ...`** |
| B | `planRestart`: replaced the `foreign-process` refusal with a silent proceed (constructs `systemctl restart -- <unit>` instead of throwing) | `planRestart: 'foreign-process' always refuses ...`; `#237: upgrade full path — a FOREIGN systemd unit ...`; `#237: the foreign-unit refusal fires before any restart command ...` |
| C | `scripts/upgrade.mjs`: deleted the gather-layer `cat /proc/<pid>/cmdline` line entirely | `#237: injected runner — REAL gather layer reads /proc/<pid>/cmdline and refuses a foreign process end to end` (and **only** this one — by design: every `mockOwnerProbe`-based test bypasses this gather layer, which is exactly why this real-`run()` test was added after the gap was noticed during mutation testing) |
| D | `classifyCmdlineOwner`: unreadable (`null`) cmdline now falsely classified as confirmed-`"ocp"` instead of `"unknown"` | `classifyCmdlineOwner: unreadable cmdline (null) → unknown, never the false-confident 'foreign'`; `resolveOwningUnit + planRestart, end to end: a probe attempted but FAILED to read cmdline ...` |

Checksums before/after each restore were byte-identical (`shasum -a 256`) in all four cases,
including the post-review re-verification of mutation A.

## Full suite

`node test-features.mjs`, run 10+ times consecutively on this branch: **674–677 passed**, **6–9
failed** every run. Failures are, every time, exclusively the pre-existing `OCP_LOCAL_TOOLS`/
`ltBoot` live-server integration cluster documented as host-load-flaky in AGENTS.md/#248 (this repo
currently has ~30 concurrent agent worktrees on this host; independently reproduced by the reviewer
in their own separate scratch clone: 676/7, same cluster). Verified identical on a clean,
unmodified `origin/main` checkout before any change this session made. Every restart-unit test, old
and new, passed deterministically on every run — including the 4 pre-existing MED-6/MED-4 fixtures
that needed a `cat /proc/<pid>/cmdline` handler added to their fake command router (they simulate a
*legitimately renamed* OCP unit, not the foreign-process case this PR covers, so they now supply a
real `server.mjs` cmdline to stay accurate).

## Independent review

Reviewed independently (fresh-context subagent, no access to implementation reasoning) — verdict
**APPROVE**, posted as a `COMMENTED` review at
https://github.com/dtzp555-max/ocp/pull/251#pullrequestreview-4830480538 (GitHub rejects
`--approve` from the PR-author's own authenticated `gh` identity; no separate reviewer account
exists in this environment, so the formal green "Approved" state cannot be set — the review content
itself is independent). Reviewer re-ran the suite in their own scratch clone (676/7, matching), and
did their own counter-proof (reverted only the source fix, confirmed the tests fail, restored).
Reviewer's two follow-up findings (mutation table undercount; #233-vs-#239 citation; working-tree
qualifier) are addressed above and in commit `bf95869` / issue #254.

## Related

- `ALIGNMENT.md` Rule(s) invoked: none — not endpoint-touching, `server.mjs` untouched.
- Related issue: closes #237.
- Refs #215, #221, #230, #233, #239 — prior restart-resolver history (#215/#221/#230/#233 all
  closed, none reopened by this change; #239 is the live tracker for the macOS follow-up this PR
  deliberately excludes).
- See #234 for the sibling "rollback config/restart coupling" defect, filed and fixed separately
  (PR #250).
- Follow-up issue #254: working-tree qualifier not yet compared (filed per review).

### User-visible change self-check (铁律第五律 5.3)

- [x] This PR has no user-visible changes beyond a new, more specific refusal on an
  already-misconfigured-port edge case — no README documentation update needed (no new CLI
  subcommand, env var, or endpoint).

### Privacy self-check (for PUBLIC repos)

- [x] No real names, personal paths, hostnames, or personal email addresses introduced.