### PR TITLE
fix(ocp): graceful python3-formatter fallback for 9 read-only display commands

### DIFF
--- a/ocp
+++ b/ocp
@@ -220,7 +220,7 @@ cmd_logs() {
   local n=${1:-20}
   local level=${2:-error}
   local data
-  data=$(curl -sf --max-time 10 "$PROXY/logs?n=$n&level=$level") || { echo "Error: proxy unreachable"; return 1; }
+  data=$(curl -sf --max-time 10 "$PROXY/logs?n=$n&level=$level") || { echo "Error: proxy unreachable" >&2; return 1; }
   echo "$data" | python3 -c "
 import sys, json
 d = json.loads(sys.stdin.read())
@@ -255,7 +255,7 @@ EOF
 
 cmd_models() {
   local data
-  data=$(curl -sf --max-time 5 "$PROXY/v1/models") || { echo "Error: proxy unreachable"; return 1; }
+  data=$(curl -sf --max-time 5 "$PROXY/v1/models") || { echo "Error: proxy unreachable" >&2; return 1; }
   echo "$data" | python3 -c "
 import sys, json
 d = json.loads(sys.stdin.read())
@@ -275,7 +275,7 @@ EOF
 
 cmd_sessions() {
   local data
-  data=$(curl -sf --max-time 5 "$PROXY/sessions") || { echo "Error: proxy unreachable"; return 1; }
+  data=$(curl -sf --max-time 5 "$PROXY/sessions") || { echo "Error: proxy unreachable" >&2; return 1; }
   echo "$data" | python3 -c "
 import sys, json
 d = json.loads(sys.stdin.read())
@@ -299,12 +299,16 @@ EOF
 
 cmd_clear() {
   local result
-  result=$(curl -sf --max-time 5 -X DELETE "$PROXY/sessions") || { echo "Error: proxy unreachable"; return 1; }
+  result=$(curl -sf --max-time 5 -X DELETE "$PROXY/sessions") || { echo "Error: proxy unreachable" >&2; return 1; }
   # The DELETE above already ran (the clear itself, if the proxy answered, already happened) —
   # only the count formatting can still fail python3-absent/malformed, so the fallback below
   # says so explicitly rather than implying the clear itself didn't happen (issue #242).
+  # No `2>/dev/null` here (independent review, PR #252 round 1): the other eight `_pyfail` sites
+  # deliberately let python3's own traceback flow through to stderr alongside the `_pyfail`
+  # warning for maximum diagnostic information; this site used to suppress it inconsistently
+  # with no stated reason. Matched to the others rather than inventing an exception.
   local count
-  if count=$(echo "$result" | python3 -c "import sys,json; print(json.loads(sys.stdin.read())['cleared'])" 2>/dev/null); then
+  if count=$(echo "$result" | python3 -c "import sys,json; print(json.loads(sys.stdin.read())['cleared'])"); then
     echo "Cleared $count sessions."
   else
     _pyfail "Sessions were cleared, but the count could not be formatted" "$result"
@@ -354,12 +358,12 @@ if 'key' in d:
     print(f'  Configure in IDE: OPENAI_API_KEY={d[\"key\"]}')
 else:
     print(f'✗ {d.get(\"error\", \"Unknown error\")}')
-" || _pyfail "Could not format the new key response — the raw response above still contains the key" "$result"
+" || _pyfail "Could not format the new key response — the raw response below still contains the key" "$result"
       ;;
     revoke)
       if [[ -z "${2:-}" ]]; then echo "Usage: ocp keys revoke <name|id>"; return 1; fi
       local result
-      result=$(_curl -sf --max-time 5 -X DELETE "$PROXY/api/keys/$2") || { echo "Error: proxy unreachable or unauthorized"; return 1; }
+      result=$(_curl -sf --max-time 5 -X DELETE "$PROXY/api/keys/$2") || { echo "Error: proxy unreachable or unauthorized" >&2; return 1; }
       echo "$result" | python3 -c "
 import sys, json
 d = json.loads(sys.stdin.read())
@@ -373,7 +377,18 @@ else:
       cmd_keys_help
       ;;
     "")
-      _curl -sf --max-time 5 "$PROXY/api/keys" | python3 -c "
+      # Issue #242 review round 1 (the "10th site"): this was the ONE call site the original
+      # audit found already carrying SOME fallback -- but that fallback was a single umbrella
+      # `2>/dev/null || { generic message; exit 1; }` covering BOTH a curl failure AND a python3
+      # failure with the SAME misdiagnosis-prone text ("proxy unreachable or key management not
+      # available") regardless of which one actually happened -- the identical class of problem
+      # the other nine sites were fixed for, just with a fallback present instead of absent.
+      # Split the same way as every other site: capture curl's own result first (so a genuine
+      # unreachable proxy still gets its own accurate message), then let python3's failure route
+      # through the shared `_pyfail` helper (raw JSON preserved, not swallowed by `2>/dev/null`).
+      local data
+      data=$(_curl -sf --max-time 5 "$PROXY/api/keys") || { echo "Error: proxy unreachable or key management not available" >&2; return 1; }
+      echo "$data" | python3 -c "
 import sys, json
 d = json.loads(sys.stdin.read())
 keys = d.get('keys', [])
@@ -386,7 +401,7 @@ else:
     for k in keys:
         status = '✗ revoked' if k['revoked'] else '✓ active'
         print(f'  {k[\"name\"]:<20} {k[\"keyPreview\"]:<20} {status}  {k[\"created_at\"]}')
-" 2>/dev/null || { echo "Error: proxy unreachable or key management not available"; exit 1; }
+" || _pyfail "Could not format the API keys list" "$data"
       ;;
     *)
       echo "Unknown subcommand: $1"; cmd_keys_help; return 1 ;;
@@ -766,7 +781,7 @@ cmd_settings() {
   if [[ -z "${1:-}" ]]; then
     # GET — show all settings
     local data
-    data=$(curl -sf --max-time 5 "$PROXY/settings") || { echo "Error: proxy unreachable"; return 1; }
+    data=$(curl -sf --max-time 5 "$PROXY/settings") || { echo "Error: proxy unreachable" >&2; return 1; }
     echo "$data" | python3 -c "
 import sys, json
 d = json.loads(sys.stdin.read())

--- a/ocp
+++ b/ocp
@@ -36,6 +36,41 @@ _curl() {
 
 _json() { python3 -m json.tool 2>/dev/null || cat; }
 
+# Issue #242 (audit follow-up to #236): shared graceful-degradation fallback for the read-only
+# display commands' `<curl-or-var> | python3 -c "..."` pipelines (usage/logs/models/sessions/
+# clear/keys/settings). Under `set -euo pipefail` (ocp:7), a bare pipeline like this that is NOT
+# inside an if/while condition kills the WHOLE `ocp` invocation the instant python3 exits
+# non-zero — whether because python3 isn't on PATH (bash's own command-not-found, exit 127,
+# exactly #236's repro one level up) or because the formatter itself choked on the response body
+# (malformed JSON, an unexpected shape) — and it does so SILENTLY, because python3 is always the
+# last stage of the pipeline and nothing downstream of it has printed anything yet.
+#
+# Silence is the wrong failure mode here specifically because these are DISPLAY commands: their
+# entire job is to show the operator something. A blank `ocp usage` on a python3-less host reads
+# as "you have no usage," not "the formatter is broken" — the two are indistinguishable without
+# this fix, and the wrong one is what a user will assume. The underlying API call already
+# succeeded by the time python3 runs (curl/`_curl` is always upstream of it in every one of these
+# pipelines) — only the pretty-printing failed — so the right degraded behavior is: say so loudly,
+# and show the real (unformatted) response instead of nothing, so no information is lost even in
+# degraded mode. This matters most for `cmd_keys add`, where the formatted-only view is the ONLY
+# place the newly created key is ever shown ("you won't see it again").
+#
+# `$2` (raw) is optional: call sites that have already captured the upstream response in a
+# variable pass it; call sites with nothing meaningful to fall back to (none currently) may omit
+# it. Returns 1 (never `exit`) so `... || _pyfail "<label>" "$raw"` at each call site degrades
+# that ONE command gracefully without repeating this message nine times, and without ever using
+# `exit` from a nested function (which would be a hazard for any future caller of these functions
+# from a context expecting a `return`, per the `cmd_restart`/`cmd_usage` `exit`-vs-`return`
+# lesson documented at cmd_restart's own comment block).
+_pyfail() {
+  local label="$1" raw="${2:-}"
+  echo "⚠ ${label}: python3 is unavailable or failed to format the response (install/repair python3 for pretty output)." >&2
+  if [[ -n "$raw" ]]; then
+    echo "$raw"
+  fi
+  return 1
+}
+
 _bar() {
   local pct=$1 width=20
   local filled=$(( pct * width / 100 ))
@@ -81,7 +116,7 @@ else:
     for k in by_key:
         avg_t = f'{k[\"avg_elapsed_ms\"]/1000:.1f}s' if k['avg_elapsed_ms'] else '-'
         print(f'  {k[\"key_name\"]:<20} {k[\"requests\"]:>5} {k[\"successes\"]:>4} {k[\"errors\"]:>4} {avg_t:>9} {k[\"last_request\"]:<20}')
-"
+" || _pyfail "Could not format per-key usage data" "$data"
     return
   fi
 
@@ -132,7 +167,7 @@ else:
 
 print()
 print(f'Proxy: up {px[\"uptime\"]} | {px[\"totalRequests\"]} reqs | {px[\"activeRequests\"]} active | {px[\"errors\"]} err | {px[\"timeouts\"]} timeout')
-"
+" || _pyfail "Could not format usage data" "$data"
 }
 
 # ── status ───────────────────────────────────────────────────────────────
@@ -184,7 +219,9 @@ EOF
 cmd_logs() {
   local n=${1:-20}
   local level=${2:-error}
-  curl -sf --max-time 10 "$PROXY/logs?n=$n&level=$level" | python3 -c "
+  local data
+  data=$(curl -sf --max-time 10 "$PROXY/logs?n=$n&level=$level") || { echo "Error: proxy unreachable"; return 1; }
+  echo "$data" | python3 -c "
 import sys, json
 d = json.loads(sys.stdin.read())
 entries = d.get('entries', [])
@@ -204,7 +241,7 @@ else:
             if model: parts.append(model)
             if extra: parts.append(extra)
             print(' | '.join(parts))
-"
+" || _pyfail "Could not format log entries" "$data"
 }
 
 # ── models ───────────────────────────────────────────────────────────────
@@ -217,12 +254,14 @@ EOF
 }
 
 cmd_models() {
-  curl -sf --max-time 5 "$PROXY/v1/models" | python3 -c "
+  local data
+  data=$(curl -sf --max-time 5 "$PROXY/v1/models") || { echo "Error: proxy unreachable"; return 1; }
+  echo "$data" | python3 -c "
 import sys, json
 d = json.loads(sys.stdin.read())
 for m in d.get('data', []):
     print(f\"  {m['id']}\")
-"
+" || _pyfail "Could not format model list" "$data"
 }
 
 # ── sessions ─────────────────────────────────────────────────────────────
@@ -235,7 +274,9 @@ EOF
 }
 
 cmd_sessions() {
-  curl -sf --max-time 5 "$PROXY/sessions" | python3 -c "
+  local data
+  data=$(curl -sf --max-time 5 "$PROXY/sessions") || { echo "Error: proxy unreachable"; return 1; }
+  echo "$data" | python3 -c "
 import sys, json
 d = json.loads(sys.stdin.read())
 sessions = d.get('sessions', [])
@@ -244,7 +285,7 @@ if not sessions:
 else:
     for s in sessions:
         print(f\"  {s['id'][:16]}...  model={s['model']}  msgs={s['messages']}  last={s['lastUsed']}\")
-"
+" || _pyfail "Could not format session list" "$data"
 }
 
 # ── clear ────────────────────────────────────────────────────────────────
@@ -258,10 +299,16 @@ EOF
 
 cmd_clear() {
   local result
-  result=$(curl -sf --max-time 5 -X DELETE "$PROXY/sessions")
+  result=$(curl -sf --max-time 5 -X DELETE "$PROXY/sessions") || { echo "Error: proxy unreachable"; return 1; }
+  # The DELETE above already ran (the clear itself, if the proxy answered, already happened) —
+  # only the count formatting can still fail python3-absent/malformed, so the fallback below
+  # says so explicitly rather than implying the clear itself didn't happen (issue #242).
   local count
-  count=$(echo "$result" | python3 -c "import sys,json; print(json.loads(sys.stdin.read())['cleared'])")
-  echo "Cleared $count sessions."
+  if count=$(echo "$result" | python3 -c "import sys,json; print(json.loads(sys.stdin.read())['cleared'])" 2>/dev/null); then
+    echo "Cleared $count sessions."
+  else
+    _pyfail "Sessions were cleared, but the count could not be formatted" "$result"
+  fi
 }
 
 # ── keys ────────────────────────────────────────────────────────────────
@@ -289,6 +336,12 @@ cmd_keys() {
       result=$(_curl -sf --max-time 5 -X POST "$PROXY/api/keys" \
         -H "Content-Type: application/json" \
         -d "{\"name\": \"$2\"}" 2>&1) || { echo "Error: proxy unreachable or unauthorized"; exit 1; }
+      # Issue #242: this is the highest-stakes of the nine `_pyfail` sites — the formatted view
+      # below is the ONLY place the newly created key is ever shown ("you won't see it again").
+      # A silent death here (python3 missing/broken) would mean the key was created (the POST
+      # above already succeeded) but never seen, with no way to retrieve it again short of
+      # revoking and recreating. _pyfail's raw-JSON dump is load-bearing for this site
+      # specifically: it is what keeps the key from being lost.
       echo "$result" | python3 -c "
 import sys, json
 d = json.loads(sys.stdin.read())
@@ -301,18 +354,20 @@ if 'key' in d:
     print(f'  Configure in IDE: OPENAI_API_KEY={d[\"key\"]}')
 else:
     print(f'✗ {d.get(\"error\", \"Unknown error\")}')
-"
+" || _pyfail "Could not format the new key response — the raw response above still contains the key" "$result"
       ;;
     revoke)
       if [[ -z "${2:-}" ]]; then echo "Usage: ocp keys revoke <name|id>"; return 1; fi
-      _curl -sf --max-time 5 -X DELETE "$PROXY/api/keys/$2" | python3 -c "
+      local result
+      result=$(_curl -sf --max-time 5 -X DELETE "$PROXY/api/keys/$2") || { echo "Error: proxy unreachable or unauthorized"; return 1; }
+      echo "$result" | python3 -c "
 import sys, json
 d = json.loads(sys.stdin.read())
 if d.get('revoked'):
     print(f'✓ Key \"{d[\"idOrName\"]}\" revoked.')
 else:
     print(f'✗ Key not found or already revoked.')
-"
+" || _pyfail "Could not format the revoke response" "$result"
       ;;
     --help|-h)
       cmd_keys_help
@@ -710,7 +765,9 @@ EOF
 cmd_settings() {
   if [[ -z "${1:-}" ]]; then
     # GET — show all settings
-    curl -sf --max-time 5 "$PROXY/settings" | python3 -c "
+    local data
+    data=$(curl -sf --max-time 5 "$PROXY/settings") || { echo "Error: proxy unreachable"; return 1; }
+    echo "$data" | python3 -c "
 import sys, json
 d = json.loads(sys.stdin.read())
 print('OCP Settings')
@@ -727,7 +784,7 @@ print('Timeout Tiers (first-byte):')
 for tier in ('opus','sonnet','haiku'):
     info = t.get(tier, {})
     print(f'  {tier:<8} base={info.get(\"base\",\"?\"):>6}ms  perChar={info.get(\"perPromptChar\",\"?\")}')
-"
+" || _pyfail "Could not format settings" "$data"
   elif [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
     cmd_settings_help
   elif [[ -z "${2:-}" ]]; then

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -9827,6 +9827,39 @@ test("#242 control: cmd_keys revoke with python3 PRESENT still prints the format
   assert.ok(r.stdout.includes("revoked"), `expected the formatted revoke confirmation, got: ${JSON.stringify(r.stdout)}`);
 });
 
+// ── The "10th site" (independent review, PR #252 round 1): `ocp keys` (list/"") already carried
+// SOME fallback before this PR, but it was one umbrella `2>/dev/null || { generic message; exit
+// 1; }` covering a curl failure and a python3 failure with the SAME misleading text regardless of
+// which actually happened — the identical misdiagnosis class the other nine sites were fixed for.
+test("#242 (10th site) cmd_keys list: absent python3 shows the raw keys JSON instead of the generic 'proxy unreachable' misdiagnosis", () => {
+  const r = _bwHarnessRun({
+    args: ["keys"], pythonAbsent: true, adminKey: "test-admin-key-marker",
+    curlResponses: [{ match: "/api/keys", body: JSON.stringify({ keys: [{ name: "laptop-marker", keyPreview: "sk-ab..12", revoked: false, created_at: "2026-08-01" }] }) }],
+  });
+  assert.ok(!(r.status === 127 && r.stdout === ""), `must not reproduce #236's silent-127 signature; status=${r.status} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stderr.includes("python3 is unavailable or failed to format the response"), `expected the _pyfail warning (not the old generic 'proxy unreachable' text), got: ${JSON.stringify(r.stderr)}`);
+  assert.ok(!r.stderr.includes("proxy unreachable or key management not available"), `must NOT misattribute a python3 failure to the proxy; stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stdout.includes("laptop-marker"), `expected the raw keys JSON on stdout, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 (10th site) control: cmd_keys list with python3 PRESENT still prints the formatted table", () => {
+  const r = _bwHarnessRun({
+    args: ["keys"], adminKey: "test-admin-key-marker",
+    curlResponses: [{ match: "/api/keys", body: JSON.stringify({ keys: [{ name: "laptop-marker", keyPreview: "sk-ab..12", revoked: false, created_at: "2026-08-01" }] }) }],
+  });
+  assert.equal(r.status, 0, `expected a clean exit, got status=${r.status} stderr=${r.stderr}`);
+  assert.ok(r.stdout.includes("API Keys") && r.stdout.includes("laptop-marker"), `expected the formatted keys table, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 (10th site) control: cmd_keys list with a genuinely unreachable proxy still reports THAT (not a python3 message)", () => {
+  // No curlResponses registered for "/api/keys" -> the harness's default curl stub refuses any
+  // unhandled invocation (exit 94) -- close enough to "unreachable" for this assertion's purpose
+  // (proving the curl-failure branch's own message is unaffected by this site's restructuring).
+  const r = _bwHarnessRun({ args: ["keys"], adminKey: "test-admin-key-marker" });
+  assert.notEqual(r.status, 0, `expected a non-zero exit; status=${r.status}`);
+  assert.ok(r.stderr.includes("proxy unreachable or key management not available"), `expected the curl-failure message preserved, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
 test("#242 cmd_settings (GET): absent python3 shows the raw settings JSON instead of dying silently", () => {
   const body = JSON.stringify({
     timeout: { value: 60000, unit: "ms", desc: "x" }, firstByteTimeout: { value: 15000, unit: "ms", desc: "x" },
@@ -9851,6 +9884,57 @@ test("#242 control: cmd_settings (GET) with python3 PRESENT still prints the for
   assert.equal(r.status, 0, `expected a clean exit, got status=${r.status} stderr=${r.stderr}`);
   assert.ok(r.stdout.includes("OCP Settings"), `expected the formatted header, got: ${JSON.stringify(r.stdout)}`);
   assert.ok(r.stdout.includes("Timeout Tiers"), `expected the formatted tiers section, got: ${JSON.stringify(r.stdout)}`);
+});
+
+// ── Independent review, PR #252 round 1, fix 3: the "Error: proxy unreachable" guards THIS PR
+// introduced (logs/models/sessions/settings/clear/keys-revoke) used to write to stdout, unlike
+// `cmd_usage`'s own PRE-EXISTING guards (left untouched, per the review — see the money/control
+// tests above, none of which touch that wording). `ocp models` piped into a consumer would read
+// a stdout error line as data. No `curlResponses` entry is registered for the relevant URL below,
+// so the harness's default curl stub refuses (exit 94) -- functionally equivalent to "unreachable"
+// for the purpose of exercising this guard.
+console.log("\nocp display commands: 'proxy unreachable' guards write to stderr, not stdout (#242 review fix 3):");
+
+test("#242 fix-3 cmd_logs: 'Error: proxy unreachable' goes to stderr, stdout stays empty", () => {
+  const r = _bwHarnessRun({ args: ["logs"] });
+  assert.notEqual(r.status, 0);
+  assert.ok(r.stderr.includes("Error: proxy unreachable"), `expected the message on stderr, got: ${JSON.stringify(r.stderr)}`);
+  assert.equal(r.stdout, "", `stdout must stay clean of the error text (a consumer piping this output would read it as data); got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 fix-3 cmd_models: 'Error: proxy unreachable' goes to stderr, stdout stays empty", () => {
+  const r = _bwHarnessRun({ args: ["models"] });
+  assert.notEqual(r.status, 0);
+  assert.ok(r.stderr.includes("Error: proxy unreachable"), `expected the message on stderr, got: ${JSON.stringify(r.stderr)}`);
+  assert.equal(r.stdout, "", `stdout must stay clean; got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 fix-3 cmd_sessions: 'Error: proxy unreachable' goes to stderr, stdout stays empty", () => {
+  const r = _bwHarnessRun({ args: ["sessions"] });
+  assert.notEqual(r.status, 0);
+  assert.ok(r.stderr.includes("Error: proxy unreachable"), `expected the message on stderr, got: ${JSON.stringify(r.stderr)}`);
+  assert.equal(r.stdout, "", `stdout must stay clean; got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 fix-3 cmd_settings (GET): 'Error: proxy unreachable' goes to stderr, stdout stays empty", () => {
+  const r = _bwHarnessRun({ args: ["settings"] });
+  assert.notEqual(r.status, 0);
+  assert.ok(r.stderr.includes("Error: proxy unreachable"), `expected the message on stderr, got: ${JSON.stringify(r.stderr)}`);
+  assert.equal(r.stdout, "", `stdout must stay clean; got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 fix-3 cmd_clear: 'Error: proxy unreachable' goes to stderr, stdout stays empty", () => {
+  const r = _bwHarnessRun({ args: ["clear"] });
+  assert.notEqual(r.status, 0);
+  assert.ok(r.stderr.includes("Error: proxy unreachable"), `expected the message on stderr, got: ${JSON.stringify(r.stderr)}`);
+  assert.equal(r.stdout, "", `stdout must stay clean; got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 fix-3 cmd_keys revoke: 'Error: proxy unreachable or unauthorized' goes to stderr, stdout stays empty", () => {
+  const r = _bwHarnessRun({ args: ["keys", "revoke", "laptop-marker"], adminKey: "test-admin-key-marker" });
+  assert.notEqual(r.status, 0);
+  assert.ok(r.stderr.includes("Error: proxy unreachable or unauthorized"), `expected the message on stderr, got: ${JSON.stringify(r.stderr)}`);
+  assert.equal(r.stdout, "", `stdout must stay clean; got: ${JSON.stringify(r.stdout)}`);
 });
 
 console.log("\nRestart-unit resolution (issue #233 defect 1) — macOS lsof exit-code handling:");

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -12,7 +12,7 @@ import { createHash } from "node:crypto";
 import { strict as assert } from "node:assert";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { homedir } from "node:os";
 
 process.env.HOME = homedir(); // normalize HOME so homedir()-derived paths are stable across shells
@@ -9302,6 +9302,31 @@ function _bwHarnessRun({
   overrideCmdRestart = true,
   resolveRestartExit = 0, resolveRestartStdout = [], resolveRestartStderr = [],
   serviceStubsSucceed = false, curlHealthExit = 1,
+  // Issue #242: generic curl response fixtures for the nine read-only display commands
+  // (usage/logs/models/sessions/clear/keys/settings), none of which existed as a harness
+  // capability before this issue (every prior call site here only ever needed the `/health`
+  // arm). Each entry is `{ match, body, exit }`: `match` is matched as a `case "$*" in
+  // *"<match>"*)` substring against curl's full argv (so it discriminates by URL/path, same
+  // technique the pre-existing `/health` arm already uses), `body` is written to its own
+  // fixture file and `cat`, `exit` defaults to 0. Checked BEFORE the `/health` arm and the
+  // default refusal, in the order given — callers needing more than one endpoint per test
+  // should list the more specific match first (e.g. "/api/usage" before "/usage", since the
+  // latter is a substring of the former). Purely additive: an empty array (the default)
+  // leaves every existing call site's curl stub byte-identical to before this issue.
+  curlResponses = [],
+  // Issue #242 test-setup note (NOT a fix for a #242/#241 defect — a separate, pre-existing,
+  // previously-undiscovered one, found incidentally while adding these tests, out of scope for
+  // both PRs and left for its own issue): `_curl()`'s `curl "${_AUTH_ARGS[@]}" "$@"` references
+  // an EMPTY bash array under `set -u`. GNU bash 3.2.57 (macOS's default `/bin/bash` — the last
+  // GPLv2 release, which is what `execFileSync("bash", ...)` resolves to here, verified via
+  // `bash --version`) raises "unbound variable" for `"${arr[@]}"` when `arr` has zero elements,
+  // even though POSIX/bash>=4.4 treat that as expanding to nothing. Reproduced directly against
+  // the unmodified `ocp` functions slice with `OCP_ADMIN_KEY` unset and no `~/.ocp/admin-key`
+  // file (the harness's own default state below) — `_curl` dies before ever reaching the
+  // network call. Every _curl-based test in this file sets a non-empty `adminKey` to route
+  // around this ORTHOGONAL defect (a non-empty `_AUTH_ARGS` array never hits the empty-array
+  // path) rather than accidentally depending on it.
+  adminKey = "",
 } = {}) {
   const root = _ltMkdtemp(join(_ltTmp(), "ocp-bash-harness-"));
   try {
@@ -9406,9 +9431,24 @@ function _bwHarnessRun({
     // is recognized (controlled by curlHealthExit); anything else refuses loudly (exit 94)
     // rather than silently doing something undefined — this issue's own tests never need
     // cmd_usage's `/usage` call to succeed, so it's deliberately left unhandled here.
+    //
+    // Issue #242: curlResponses (see its own doc comment above) adds arbitrary fixture arms,
+    // checked BEFORE "/health" and the default refusal, for the nine display commands' own
+    // curl calls (/api/usage, /usage, /logs, /v1/models, /sessions, /api/keys, /settings).
+    const curlResponseFiles = curlResponses.map((r, i) => {
+      const p = join(root, `curl-resp-${i}.json`);
+      testWriteFile(p, r.body ?? "");
+      return { match: r.match, exit: r.exit ?? 0, path: p };
+    });
     mkStub("curl", [
       `echo "FAKE-CURL-CALL $*" >> "${logPath}"`,
       `case "$*" in`,
+      ...curlResponseFiles.flatMap((r) => [
+        `  *${JSON.stringify(r.match)}*)`,
+        `    cat ${JSON.stringify(r.path)}`,
+        `    exit ${r.exit}`,
+        `    ;;`,
+      ]),
       `  *"/health"*)`,
       `    exit ${curlHealthExit}`,
       `    ;;`,
@@ -9480,20 +9520,25 @@ function _bwHarnessRun({
       // pythonAbsent is false) and nothing that could contain a second, real node/git.
       PATH: `${bin}:/usr/bin:/bin`,
       OCP_TEST_LOG: logPath,
-      OCP_ADMIN_KEY: "",
+      OCP_ADMIN_KEY: adminKey,
     };
 
     // `args[0]` is now the top-level SUBCOMMAND, since the real dispatch runs for real (see the
     // driver-assembly comment above) — callers below pass `["update", ...flags]`, matching a
     // real `ocp update ...` invocation's argv shape.
-    let stdout = "", stderr = "", status = 0;
-    try {
-      stdout = execFileSync("bash", [driverPath, ...args], { cwd: root, env, encoding: "utf8" });
-    } catch (e) {
-      stdout = e.stdout ?? "";
-      stderr = e.stderr ?? "";
-      status = typeof e.status === "number" ? e.status : 1;
-    }
+    //
+    // Issue #242 fix: `execFileSync` (used here originally) only returns stdout — on a ZERO
+    // exit status it discards stderr entirely (only the `catch` branch's `e.stderr` ever
+    // captured it, i.e. only on a NONZERO exit). Every pre-#242 test here happened to only
+    // assert on stderr in a nonzero-exit (refusal) scenario, so this never surfaced. #242's own
+    // display-command tests need stderr on a successful (status 0) run too — e.g. proving a
+    // degraded-but-still-status-0 case truly carries no warning. `spawnSync` always returns
+    // `{stdout, stderr, status}` regardless of exit code, so switching to it removes the gap
+    // for every caller, not just #242's.
+    const _bwRes = spawnSync("bash", [driverPath, ...args], { cwd: root, env, encoding: "utf8" });
+    const stdout = _bwRes.stdout ?? "";
+    const stderr = _bwRes.stderr ?? "";
+    const status = typeof _bwRes.status === "number" ? _bwRes.status : 1;
     const log = testExistsSync(logPath) ? _ltRead(logPath, "utf8").split("\n").filter(Boolean) : [];
     return { stdout, stderr, status, log };
   } finally {
@@ -9586,6 +9631,226 @@ test("#236 control: cmd_update with python3 PRESENT reaches the kind dispatch an
   assert.ok(r.stdout.includes("control-warn-marker"), `expected the WARN line surfaced, got: ${JSON.stringify(r.stdout)}`);
   assert.ok(r.stdout.includes("control-info-marker"), `expected the INFO line surfaced, got: ${JSON.stringify(r.stdout)}`);
   assert.ok(r.stdout.includes("Already at latest"), `expected the noop-kind message, got: ${JSON.stringify(r.stdout)}`);
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Issue #242 (audit follow-up to #236): nine MORE `<curl-or-var> | python3 -c "..."` call sites
+// across the read-only display commands (usage/logs/models/sessions/clear/keys/settings) have
+// the identical shape #236 fixed exactly once for cmd_update's own doctor-json formatter — a
+// bare pipeline, not inside an if/while, that `set -euo pipefail` (ocp:7) kills SILENTLY the
+// instant python3 exits non-zero, whether because python3 is missing (exit 127) or because the
+// formatter itself chokes on the response body (malformed JSON). Fixed via one shared helper,
+// `_pyfail` (defined near the top of `ocp`, alongside `_json`/`_bar`), rather than nine
+// independent inline fallbacks: it prints an unmistakable warning AND echoes the raw
+// (unformatted) response so no information is lost in degraded mode — load-bearing for
+// `cmd_keys add` in particular, the only place a newly created key is ever shown.
+//
+// Each site below gets two tests: the MONEY test (pythonAbsent:true — must NOT reproduce #236's
+// signature of silent death, and must show the raw data, not a blank screen) and a CONTROL test
+// (real python3 — the formatted, happy-path output must be byte-for-byte unaffected by this
+// fix). Two representative sites (cmd_clear, cmd_keys add — chosen because one is the
+// "underlying mutation already happened, only reporting fails" case and the other is the
+// highest-stakes "only view of a value" case) also get a THIRD test proving the fallback also
+// catches a REAL (non-stubbed) python3 crashing on malformed JSON, not merely "python3 missing"
+// — this is real /usr/bin/python3 on this harness's scratch $PATH, not a fake stub, genuinely
+// exercising `json.loads` raising a `JSONDecodeError`.
+console.log("\nocp display commands survive an absent/broken python3 formatter (#242):");
+
+test("#242 cmd_usage --by-key: absent python3 shows the raw usage-by-key JSON instead of dying silently", () => {
+  const r = _bwHarnessRun({
+    args: ["usage", "--by-key"], pythonAbsent: true, adminKey: "test-admin-key-marker",
+    curlResponses: [{ match: "/api/usage", body: JSON.stringify({ byKey: [{ key_name: "laptop-marker", requests: 10, successes: 9, errors: 1, avg_elapsed_ms: 2500, last_request: "2026-08-01T00:00:00Z" }] }) }],
+  });
+  assert.ok(!(r.status === 127 && r.stdout === ""), `must not reproduce #236's silent-127 signature; status=${r.status} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stderr.includes("python3 is unavailable or failed to format the response"), `expected the _pyfail warning on stderr, got: ${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stdout.includes("laptop-marker"), `expected the raw byKey JSON (still containing the real data) on stdout, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 control: cmd_usage --by-key with python3 PRESENT still prints the formatted table (unaffected by the fix)", () => {
+  const r = _bwHarnessRun({
+    args: ["usage", "--by-key"], adminKey: "test-admin-key-marker",
+    curlResponses: [{ match: "/api/usage", body: JSON.stringify({ byKey: [{ key_name: "laptop-marker", requests: 10, successes: 9, errors: 1, avg_elapsed_ms: 2500, last_request: "2026-08-01T00:00:00Z" }] }) }],
+  });
+  assert.equal(r.status, 0, `expected a clean exit, got status=${r.status} stderr=${r.stderr}`);
+  assert.ok(r.stdout.includes("Usage by Key"), `expected the formatted header, got: ${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stdout.includes("laptop-marker"), `expected the formatted row, got: ${JSON.stringify(r.stdout)}`);
+  assert.ok(!r.stderr.includes("python3 is unavailable"), `must not print the degraded-mode warning on the happy path; stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#242 cmd_usage (main): absent python3 shows the raw plan JSON instead of dying silently", () => {
+  const body = JSON.stringify({
+    plan: {
+      currentSession: { percent: "12%", resetsIn: "3h", resetsAtHuman: "3:00 PM" },
+      weeklyLimits: { allModels: { percent: "40%", resetsIn: "2d", resetsAtHuman: "Mon 9:00 AM" } },
+      extraUsage: { status: "allowed" },
+    },
+    proxy: { uptime: "5h", totalRequests: 42, activeRequests: 0, errors: 0, timeouts: 0 },
+    models: {},
+  });
+  const r = _bwHarnessRun({ args: ["usage"], pythonAbsent: true, curlResponses: [{ match: "/usage", body }] });
+  assert.ok(!(r.status === 127 && r.stdout === ""), `must not reproduce #236's silent-127 signature; status=${r.status} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stderr.includes("python3 is unavailable or failed to format the response"), `expected the _pyfail warning, got: ${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stdout.includes("allowed"), `expected the raw plan JSON on stdout, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 control: cmd_usage (main) with python3 PRESENT still prints the formatted panel", () => {
+  const body = JSON.stringify({
+    plan: {
+      currentSession: { percent: "12%", resetsIn: "3h", resetsAtHuman: "3:00 PM" },
+      weeklyLimits: { allModels: { percent: "40%", resetsIn: "2d", resetsAtHuman: "Mon 9:00 AM" } },
+      extraUsage: { status: "allowed" },
+    },
+    proxy: { uptime: "5h", totalRequests: 42, activeRequests: 0, errors: 0, timeouts: 0 },
+    models: {},
+  });
+  const r = _bwHarnessRun({ args: ["usage"], curlResponses: [{ match: "/usage", body }] });
+  assert.equal(r.status, 0, `expected a clean exit, got status=${r.status} stderr=${r.stderr}`);
+  assert.ok(r.stdout.includes("Plan Usage Limits"), `expected the formatted header, got: ${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stdout.includes("Proxy: up 5h"), `expected the formatted proxy line, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 cmd_logs: absent python3 shows the raw log-entries JSON instead of dying silently", () => {
+  const body = JSON.stringify({ entries: [{ raw: "2026-08-01 00:00:00 ERROR test-log-entry-marker" }], level: "error" });
+  const r = _bwHarnessRun({ args: ["logs"], pythonAbsent: true, curlResponses: [{ match: "/logs?n=20&level=error", body }] });
+  assert.ok(!(r.status === 127 && r.stdout === ""), `must not reproduce #236's silent-127 signature; status=${r.status} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stderr.includes("python3 is unavailable or failed to format the response"), `expected the _pyfail warning, got: ${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stdout.includes("test-log-entry-marker"), `expected the raw entries JSON on stdout, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 control: cmd_logs with python3 PRESENT still prints the formatted log line", () => {
+  const body = JSON.stringify({ entries: [{ raw: "2026-08-01 00:00:00 ERROR test-log-entry-marker" }], level: "error" });
+  const r = _bwHarnessRun({ args: ["logs"], curlResponses: [{ match: "/logs?n=20&level=error", body }] });
+  assert.equal(r.status, 0, `expected a clean exit, got status=${r.status} stderr=${r.stderr}`);
+  assert.ok(r.stdout.includes("test-log-entry-marker"), `expected the formatted log line, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 cmd_models: absent python3 shows the raw models JSON instead of dying silently", () => {
+  const body = JSON.stringify({ data: [{ id: "claude-sonnet-5-marker" }] });
+  const r = _bwHarnessRun({ args: ["models"], pythonAbsent: true, curlResponses: [{ match: "/v1/models", body }] });
+  assert.ok(!(r.status === 127 && r.stdout === ""), `must not reproduce #236's silent-127 signature; status=${r.status} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stderr.includes("python3 is unavailable or failed to format the response"), `expected the _pyfail warning, got: ${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stdout.includes("claude-sonnet-5-marker"), `expected the raw models JSON on stdout, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 control: cmd_models with python3 PRESENT still prints the formatted list", () => {
+  const body = JSON.stringify({ data: [{ id: "claude-sonnet-5-marker" }] });
+  const r = _bwHarnessRun({ args: ["models"], curlResponses: [{ match: "/v1/models", body }] });
+  assert.equal(r.status, 0, `expected a clean exit, got status=${r.status} stderr=${r.stderr}`);
+  assert.equal(r.stdout.trim(), "claude-sonnet-5-marker", `expected the formatted model id line, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 cmd_sessions: absent python3 shows the raw sessions JSON instead of dying silently", () => {
+  const body = JSON.stringify({ sessions: [{ id: "abcdefabcdefabcdef0123456789", model: "claude-sonnet-5", messages: 3, lastUsed: "2026-08-01T00:00:00Z" }] });
+  const r = _bwHarnessRun({ args: ["sessions"], pythonAbsent: true, curlResponses: [{ match: "/sessions", body }] });
+  assert.ok(!(r.status === 127 && r.stdout === ""), `must not reproduce #236's silent-127 signature; status=${r.status} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stderr.includes("python3 is unavailable or failed to format the response"), `expected the _pyfail warning, got: ${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stdout.includes("abcdefabcdefabcdef0123456789"), `expected the raw sessions JSON on stdout, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 control: cmd_sessions with python3 PRESENT still prints the formatted session row", () => {
+  const body = JSON.stringify({ sessions: [{ id: "abcdefabcdefabcdef0123456789", model: "claude-sonnet-5", messages: 3, lastUsed: "2026-08-01T00:00:00Z" }] });
+  const r = _bwHarnessRun({ args: ["sessions"], curlResponses: [{ match: "/sessions", body }] });
+  assert.equal(r.status, 0, `expected a clean exit, got status=${r.status} stderr=${r.stderr}`);
+  assert.ok(r.stdout.includes("model=claude-sonnet-5"), `expected the formatted session row, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 cmd_clear: absent python3 still reports the clear happened (the DELETE already ran) with the raw count JSON, not a silent death", () => {
+  const r = _bwHarnessRun({ args: ["clear"], pythonAbsent: true, curlResponses: [{ match: "/sessions", body: JSON.stringify({ cleared: 7 }) }] });
+  assert.ok(!(r.status === 127 && r.stdout === ""), `must not reproduce #236's silent-127 signature; status=${r.status} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stderr.includes("Sessions were cleared, but the count could not be formatted"), `expected the clear-specific fallback message (not a generic one), got stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stdout.includes('"cleared": 7') || r.stdout.includes('"cleared":7') || r.stdout.includes("cleared"), `expected the raw {"cleared":7} JSON on stdout, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 control: cmd_clear with python3 PRESENT still prints 'Cleared N sessions.'", () => {
+  const r = _bwHarnessRun({ args: ["clear"], curlResponses: [{ match: "/sessions", body: JSON.stringify({ cleared: 7 }) }] });
+  assert.equal(r.status, 0, `expected a clean exit, got status=${r.status} stderr=${r.stderr}`);
+  assert.ok(r.stdout.includes("Cleared 7 sessions."), `expected the formatted count line, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 cmd_clear: python3 PRESENT but the response is malformed JSON — the fallback fires for a REAL crash, not just a missing binary", () => {
+  // Real (unstubbed) /usr/bin/python3 on this harness's scratch $PATH — json.loads() genuinely
+  // raises json.decoder.JSONDecodeError on this body, a different failure mode than
+  // pythonAbsent:true's exit-127 stub. Proves _pyfail's `||` guard is keyed on the PIPELINE's
+  // exit status, not merely "is python3 on PATH".
+  const r = _bwHarnessRun({ args: ["clear"], curlResponses: [{ match: "/sessions", body: "not-json-at-all" }] });
+  assert.notEqual(r.status, 0, `a malformed response must not be silently reported as success; status=${r.status}`);
+  assert.ok(r.stderr.includes("Sessions were cleared, but the count could not be formatted"), `expected the clear-specific fallback message, got stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stdout.includes("not-json-at-all"), `expected the raw (malformed) response echoed back, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 cmd_keys add: absent python3 shows the raw JSON — the ONLY place the new key is ever shown must not be lost", () => {
+  const r = _bwHarnessRun({
+    args: ["keys", "add", "laptop-marker"], pythonAbsent: true, adminKey: "test-admin-key-marker",
+    curlResponses: [{ match: "/api/keys", body: JSON.stringify({ name: "laptop-marker", key: "sk-marker-abc123" }) }],
+  });
+  assert.ok(!(r.status === 127 && r.stdout === ""), `must not reproduce #236's silent-127 signature; status=${r.status} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stderr.includes("python3 is unavailable or failed to format the response"), `expected the _pyfail warning, got: ${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stdout.includes("sk-marker-abc123"), `THE KEY ITSELF must still be visible in the raw fallback output — losing it here means it can never be retrieved again; got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 control: cmd_keys add with python3 PRESENT still prints the formatted key panel", () => {
+  const r = _bwHarnessRun({
+    args: ["keys", "add", "laptop-marker"], adminKey: "test-admin-key-marker",
+    curlResponses: [{ match: "/api/keys", body: JSON.stringify({ name: "laptop-marker", key: "sk-marker-abc123" }) }],
+  });
+  assert.equal(r.status, 0, `expected a clean exit, got status=${r.status} stderr=${r.stderr}`);
+  assert.ok(r.stdout.includes("Key created for"), `expected the formatted success header, got: ${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stdout.includes("sk-marker-abc123"), `expected the formatted key line, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 cmd_keys add: python3 PRESENT but the response is malformed JSON — the key-loss-prevention fallback fires for a REAL crash too", () => {
+  const r = _bwHarnessRun({
+    args: ["keys", "add", "laptop-marker"], adminKey: "test-admin-key-marker",
+    curlResponses: [{ match: "/api/keys", body: "not-json-at-all" }],
+  });
+  assert.notEqual(r.status, 0, `a malformed response must not be silently reported as success; status=${r.status}`);
+  assert.ok(r.stderr.includes("Could not format the new key response"), `expected the key-specific fallback message, got stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stdout.includes("not-json-at-all"), `expected the raw (malformed) response echoed back rather than losing it, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 cmd_keys revoke: absent python3 shows the raw revoke JSON instead of dying silently", () => {
+  const r = _bwHarnessRun({
+    args: ["keys", "revoke", "laptop-marker"], pythonAbsent: true, adminKey: "test-admin-key-marker",
+    curlResponses: [{ match: "/api/keys/laptop-marker", body: JSON.stringify({ revoked: true, idOrName: "laptop-marker" }) }],
+  });
+  assert.ok(!(r.status === 127 && r.stdout === ""), `must not reproduce #236's silent-127 signature; status=${r.status} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stderr.includes("python3 is unavailable or failed to format the response"), `expected the _pyfail warning, got: ${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stdout.includes("laptop-marker"), `expected the raw revoke JSON on stdout, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 control: cmd_keys revoke with python3 PRESENT still prints the formatted confirmation", () => {
+  const r = _bwHarnessRun({
+    args: ["keys", "revoke", "laptop-marker"], adminKey: "test-admin-key-marker",
+    curlResponses: [{ match: "/api/keys/laptop-marker", body: JSON.stringify({ revoked: true, idOrName: "laptop-marker" }) }],
+  });
+  assert.equal(r.status, 0, `expected a clean exit, got status=${r.status} stderr=${r.stderr}`);
+  assert.ok(r.stdout.includes("revoked"), `expected the formatted revoke confirmation, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 cmd_settings (GET): absent python3 shows the raw settings JSON instead of dying silently", () => {
+  const body = JSON.stringify({
+    timeout: { value: 60000, unit: "ms", desc: "x" }, firstByteTimeout: { value: 15000, unit: "ms", desc: "x" },
+    maxConcurrent: { value: 4, unit: "", desc: "x" }, sessionTTL: { value: 600000, unit: "ms", desc: "x" },
+    maxPromptChars: { value: 100000, unit: "", desc: "x" },
+    tiers: { opus: { base: 30000, perPromptChar: 0.001 }, sonnet: { base: 20000, perPromptChar: 0.0005 }, haiku: { base: 15000, perPromptChar: 0.0002 } },
+  });
+  const r = _bwHarnessRun({ args: ["settings"], pythonAbsent: true, curlResponses: [{ match: "/settings", body }] });
+  assert.ok(!(r.status === 127 && r.stdout === ""), `must not reproduce #236's silent-127 signature; status=${r.status} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stderr.includes("python3 is unavailable or failed to format the response"), `expected the _pyfail warning, got: ${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stdout.includes("maxPromptChars"), `expected the raw settings JSON on stdout, got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#242 control: cmd_settings (GET) with python3 PRESENT still prints the formatted panel", () => {
+  const body = JSON.stringify({
+    timeout: { value: 60000, unit: "ms", desc: "x" }, firstByteTimeout: { value: 15000, unit: "ms", desc: "x" },
+    maxConcurrent: { value: 4, unit: "", desc: "x" }, sessionTTL: { value: 600000, unit: "ms", desc: "x" },
+    maxPromptChars: { value: 100000, unit: "", desc: "x" },
+    tiers: { opus: { base: 30000, perPromptChar: 0.001 }, sonnet: { base: 20000, perPromptChar: 0.0005 }, haiku: { base: 15000, perPromptChar: 0.0002 } },
+  });
+  const r = _bwHarnessRun({ args: ["settings"], curlResponses: [{ match: "/settings", body }] });
+  assert.equal(r.status, 0, `expected a clean exit, got status=${r.status} stderr=${r.stderr}`);
+  assert.ok(r.stdout.includes("OCP Settings"), `expected the formatted header, got: ${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stdout.includes("Timeout Tiers"), `expected the formatted tiers section, got: ${JSON.stringify(r.stdout)}`);
 });
 
 console.log("\nRestart-unit resolution (issue #233 defect 1) — macOS lsof exit-code handling:");


### PR DESCRIPTION
# Pull Request

## Summary

Nine more `ocp` display commands (`usage`/`logs`/`models`/`sessions`/`clear`/`keys`/`settings`) had the same silent-death shape #236 fixed once for `cmd_update`: a bare `<curl-or-var> | python3 -c "..."` pipeline that `set -euo pipefail` kills silently when python3 is absent or crashes on malformed JSON. Fixed via one shared helper (`_pyfail`) rather than nine independent patches, with 20 new tests (failing-then-passing demonstrated) and a six-mutation verification pass.

## Endpoint Class (REQUIRED)

- [x] **Not endpoint-touching** — this is `ocp`, the bash CLI wrapper, not `server.mjs`. No request handler is modified; `server.mjs` is untouched by this PR.

## Claude Code Alignment Evidence (REQUIRED)

N/A — not endpoint-touching. No `cli.js` citation applies: this PR changes the `ocp` bash CLI's own display-command formatting (client-side output), not the proxy wire surface `ALIGNMENT.md` governs. Stated explicitly in the commit body per this repo's own convention.

## Type of change

- [x] Bug fix (graceful degradation instead of silent death when python3 is absent/broken)

## What changed

- Added `_pyfail()` (near `_json`/`_bar`, top of `ocp`): on a python3-formatter failure (missing binary OR a crash on malformed JSON), prints an unmistakable warning to stderr and echoes the raw (still-valid) response to stdout — the underlying curl call already succeeded, only the pretty-printing failed, so nothing is lost.
- Wired all nine audited call sites to it: `cmd_usage` (main + `--by-key`), `cmd_logs`, `cmd_models`, `cmd_sessions`, `cmd_clear`, `cmd_keys add`, `cmd_keys revoke`, `cmd_settings` (GET/show).
- `cmd_logs`/`cmd_models`/`cmd_sessions`/`cmd_settings` GET used to pipe curl directly into python3 with no captured variable and no curl-failure guard; restructured (mirroring `cmd_usage`'s existing pattern) so a curl failure is correctly reported as "proxy unreachable" instead of being misattributed to the python3 formatter.
- `cmd_clear` gets a bespoke if/else (not the shared `|| _pyfail` idiom): its DELETE has already mutated state by the time count-formatting can fail, so the message says "cleared, but the count could not be formatted" rather than implying nothing happened.
- `cmd_keys add` is the highest-stakes site: the formatted view is the ONLY place a newly created key is ever shown ("you won't see it again"). The raw-JSON fallback is what keeps the key from being permanently lost if python3 is broken at exactly the wrong moment.

## Reasoning: what should the user see when python3 is missing? (per task requirement)

Silently printing nothing is the worst option for a command whose entire purpose is to display something — a blank `ocp usage` reads as "you have no usage," not "the formatter is broken," and those are opposite conclusions. The chosen behavior: (1) an unmistakable stderr warning identifying the degraded mode, (2) the raw, unformatted JSON on stdout so no information is lost (the API call itself already succeeded), (3) a non-zero exit code so scripts/automation can detect degraded mode. A single shared helper (`_pyfail`) was used instead of nine independent inline fixes so behavior stays consistent across all nine sites and reviewers only need to audit one implementation.

## Testing

Extends the bash CLI wiring harness `#243` merged into `test-features.mjs` (per-repo convention: extend, don't build a second harness). `_bwHarnessRun` gains two purely-additive parameters:
- `curlResponses` — generic per-URL curl-stub fixtures (didn't exist before this PR; every prior call site only ever needed `/health`).
- `adminKey` — routes tests around a separate, pre-existing, orthogonal bug found while writing these tests (see below); default `""` preserves prior behavior for every existing test.

20 new tests (2 per site: money + control), plus a malformed-JSON variant against REAL `/usr/bin/python3` for the two highest-value sites (`cmd_clear`, `cmd_keys add`) proving the guard also catches a genuine runtime crash, not just a missing binary.

**Failing on unfixed `ocp` (via `git stash` isolating the one-line `ocp` diff from the new tests — never `git checkout`, which would discard the uncommitted tests too):**
```
=== Results: 670 passed, 20 failed ===
```
11 of the 20 new tests fail: the 9 "money" tests (status=127, empty stdout — #236's exact silent-death signature) plus 2 malformed-JSON tests (raw Python traceback instead of the graceful fallback). The 9 "control" tests pass because they only assert on unchanged happy-path behavior.

**Passing after the fix:**
```
=== Results: 682-683 passed, 7-9 failed ===
```
All 20 new tests green; the remaining 7-9 failures are the pre-existing `ltBoot` integration-test flakiness under this host's concurrent multi-agent load (AGENTS.md-documented, tracked as #248) — confirmed present on unmodified `main` too (baseline before this change: 661-662/670 passed) and unrelated to any file this PR touches.

### Mutation table

All mutations applied to a `cp`-backed file (never `git checkout`), restored and `shasum -a 256`-verified byte-identical before the next mutation. Anchor existence asserted via `grep -qF` before every mutation.

| # | Mutation | Named test(s) caught |
|---|---|---|
| 1 | `_pyfail`'s raw-dump line replaced with `:` (no-op) | All 11 relevant tests (every site that asserts on raw-data content) |
| 2 | `_pyfail`'s stderr warning line replaced with `:` (no-op) | All 11 relevant tests (every site that asserts on the warning text) |
| 3 | `_pyfail`'s `return 1` → `return 0` | The 2 malformed-JSON status assertions (`cmd_clear`, `cmd_keys add`) — precisely, once a harness stderr-capture gap (below) was fixed |
| 4 | Removed `cmd_models`' own `\|\| _pyfail` wiring | Exactly 1: `#242 cmd_models: absent python3 shows the raw models JSON...` |
| 5 | Removed `cmd_clear`'s bespoke `else` branch's `_pyfail` call | Exactly 2: both `cmd_clear` tests |
| 6 | Removed `cmd_keys add`'s own `\|\| _pyfail` wiring | Exactly 2: both `cmd_keys add` tests |

### Harness bug found and fixed

While writing mutation 3's test, found that `_bwHarnessRun`'s `execFileSync`-based invocation discarded stderr entirely on a ZERO exit status (only the thrown-error catch branch on a nonzero exit exposed `e.stderr`) — latent because no pre-#242 test needed stderr on a successful run. Switched to `spawnSync`, which always returns `{stdout, stderr, status}` regardless of exit code. This benefits every caller of `_bwHarnessRun`, not just #242's tests.

### Separate defect found, NOT fixed here (Iron Rule 11 — filed as its own issue)

`_curl()`'s `curl "${_AUTH_ARGS[@]}" "$@"` references an empty bash array under `set -u`. GNU bash 3.2.57 (macOS's default `/bin/bash`) raises "unbound variable" for `"${arr[@]}"` on a zero-element array (POSIX/bash>=4.4 correctly expand this to nothing). Reproduced directly against unmodified `ocp` with `OCP_ADMIN_KEY` unset and no `~/.ocp/admin-key` file: `_curl` dies before ever reaching the network, affecting `ocp usage --by-key` and every `ocp keys` subcommand on a single-user macOS install with no multi-key auth configured. Out of scope for this PR (different bug class — bash version compatibility, not python3); test setup routes around it with a non-empty `adminKey` fixture. Will be filed as a separate issue.

## Related

- `ALIGNMENT.md` Rule(s) invoked: none (not endpoint-touching)
- Related issue / prior PR: Closes #242. Refs #236, #217, #230, #233, #235, #225, #248 (history/context — none of these are closed by this PR).

### User-visible change self-check (铁律第五律 5.3)

- [x] This PR has no user-visible changes requiring README documentation — it's a graceful-degradation bug fix to existing commands' error handling on a python3-less/broken host, not a new command, flag, or endpoint.

### Privacy self-check (for PUBLIC repos)

- [x] No personal names, literal home paths, personal hostnames, or personal email addresses introduced.

---

## Update: rebased + independent review round 1 addressed

Rebased onto `main` @ `d2ea5a7` (PR #259 — `--target` on the full upgrade path; PR #258 — the `_AUTH_ARGS` fix, which is exactly the "separate defect" noted above, now fixed upstream as #256). Clean rebase, no conflicts with either.

Four fixes from independent review round 1 (APPROVE WITH FOLLOW-UP):

1. **Wording**: `cmd_keys add`'s `_pyfail` message said "the raw response **above** still contains the key" — `_pyfail` prints its warning first (stderr) then the raw payload after (stdout), so the data is **below**, not above. Fixed.
2. **`cmd_clear` consistency**: it was the only site suppressing python3's own traceback with `2>/dev/null`, with no stated reason. Removed the suppression to match the other sites.
3. **stdout → stderr**: the "Error: proxy unreachable" guards this PR introduced (logs/models/sessions/settings/clear/keys-revoke) wrote to stdout, unlike `cmd_usage`'s pre-existing ones (left untouched, per the review). Redirected all six to stderr — `ocp models` piped into a consumer will no longer read an error line as data.
4. **The 10th site**: `ocp keys` (list) had ONE fallback already, but it was a single umbrella message covering both a curl failure and a python3 failure with the same misleading text. Restructured to match the other nine — curl's own failure keeps its own accurate message, python3's failure now routes through `_pyfail` (raw JSON preserved).

9 new tests added (3 for the 10th site, 6 for the stderr-routing fix). Full mutation table re-run against the rebased head — all 6 original mutations plus 2 new ones, each caught by exactly the right named test(s), each restored from a `cp` backup and `shasum -a 256`-verified byte-identical before the next mutation:

| # | Mutation | Named test(s) caught |
|---|---|---|
| 1 | `_pyfail`'s raw-dump line disabled | 12 tests (11 original + new 10th-site money test) |
| 2 | `_pyfail`'s stderr warning line disabled | Same 12 |
| 3 | `_pyfail`'s `return 1` → `return 0` | The 2 malformed-JSON status assertions |
| 4 | Removed `cmd_models`' own wiring | Exactly 1 |
| 5 | Removed `cmd_clear`'s bespoke branch | Exactly 2 |
| 6 | Removed `cmd_keys add`'s own wiring | Exactly 2 |
| 7 (new) | Removed the 10th site's own wiring | Exactly 1 |
| 8 (new) | Reverted `cmd_models`'s stderr redirect | Exactly 1 (the new fix-3 test) |

Full suite green (remaining failures are the pre-existing `ltBoot` cluster, #248, present at merge-base too).
