### PR TITLE
fix(ocp): _cmd_update_light gets post-flight verification + explicit --target no-op

### DIFF
--- a/ocp
+++ b/ocp
@@ -850,6 +850,15 @@ Usage:
   ocp update --rollback --dry-run     Preview rollback plan
   ocp update --rollback --gc          Delete old snapshots (keep last 5, or <30 days)
   ocp update --rollback --gc --dry-run    Preview what would be deleted
+
+Notes:
+  --target on the light/patch-bump path (a same-minor patch update): NOT
+  honored. That path always runs a plain `git pull origin main --ff-only`
+  regardless of any version requested via --target (issue #241) -- real
+  version-pinning there would mean a tag checkout instead of a fast-forward
+  pull, a different mechanism than this path's job. Passing --target on
+  that path prints a runtime warning rather than silently doing nothing
+  unexpected.
 EOF
 }
 
@@ -993,6 +1002,28 @@ _cmd_update_light() {
   local old_ver new_ver arg
   old_ver=$(python3 -c "import json; print(json.load(open('package.json'))['version'])" 2>/dev/null || echo "?")
 
+  # Issue #241 (deferred from #235's own review, kept to the minimum reviewable unit at the
+  # time): "$@" reaches this function (per #235's own fix) but --target was silently ignored —
+  # the light path always does a plain `git pull origin main --ff-only` regardless of any
+  # requested version. Real version-pinning here would mean switching from a fast-forward pull
+  # to a tag checkout (fetch tags, `git checkout vX.Y.Z`, and deciding what happens to
+  # --ff-only's protections) — a different mechanism, not a one-line addition, and its own design
+  # decision deliberately left for a future PR (see #241's own scope note). What IS this PR's
+  # job: stop letting that no-op be SILENT. A user passing --target here should not reasonably
+  # conclude it pinned anything just because nothing errored — this prints a runtime warning
+  # (cmd_update_help documents the same caveat) instead.
+  local _args=("$@") _i _target_seen=0 _target_val=""
+  for ((_i = 0; _i < ${#_args[@]}; _i++)); do
+    if [[ "${_args[_i]}" == "--target" ]]; then
+      _target_seen=1
+      _target_val="${_args[_i+1]:-<no value given>}"
+      break
+    fi
+  done
+  if [[ $_target_seen -eq 1 ]]; then
+    echo "  ⚠ --target $_target_val is not honored on the light/patch-bump path — it always pulls the latest origin/main regardless. Run \`ocp update --help\` for details."
+  fi
+
   # Honor --dry-run BEFORE any mutation (issue #235). This arm used to be called with NO
   # forwarding at all — `cmd_update`'s `update)` case did `_cmd_update_light "$script_dir"`,
   # dropping every flag including --dry-run — so `ocp update --dry-run` on the single most
@@ -1038,13 +1069,51 @@ _cmd_update_light() {
   echo "  Restarting proxy..."
   # Issue #224: this used to be `cmd_restart > /dev/null 2>&1`, discarding ALL of cmd_restart's
   # output — including its own refusal/failure messages, which are exactly what #224 asks to
-  # make loud rather than invisible on the single most common update path. cmd_restart's own
-  # `exit`-on-failure hazard inside cmd_usage's success path (calling `exit`, not `return`, if
-  # its own `/usage` probe fails) is pre-existing and unrelated to this change — `_cmd_update_
-  # restart` already works around that specific hazard with a `( cmd_restart ) || true` subshell
-  # (see below); direct `ocp restart` has never been wrapped that way either, so this matches
-  # existing, established behavior rather than introducing a new one.
-  cmd_restart
+  # make loud rather than invisible on the single most common update path. `( cmd_restart ) ||
+  # restart_status=$?` (a subshell, not a bare call) contains cmd_restart's own `exit`-on-failure
+  # hazard inside cmd_usage's success path (calling `exit`, not `return`, if its own `/usage`
+  # probe fails — see cmd_restart's own comment block) the same way `_cmd_update_restart`'s `(
+  # cmd_restart ) || true` already does for the sibling "restart" kind, but CAPTURES the real
+  # exit status instead of discarding it: #224 already made cmd_restart's own refusal exit
+  # non-zero and surface its message, and that signal needs to survive into this function's own
+  # exit code below, not be silently absorbed the way a bare `|| true` would.
+  local restart_status=0
+  ( cmd_restart ) || restart_status=$?
+
+  # Issue #241: this is the fix for the actual incident. The light/patch-bump path — the single
+  # most common `ocp update` invocation — used to end at cmd_restart's own return, with NO
+  # verification that the RUNNING SERVICE actually ended up serving the version the tree just
+  # landed on. cmd_restart's own success criterion (see its own body) is just "does /health
+  # respond" — it does not check the reported version at all, so a stale process that kept the
+  # port (an orphaned nohup fallback from a prior half-completed update, or a restart command
+  # that silently no-op'd) can report "✓ Proxy restarted successfully." while still serving old
+  # code. That is issue #214's original complaint ("reports success while serving old code"),
+  # and the exact incident #241 records: the tree lands on the new version, the running process
+  # stays on the old one, and a RETRY short-circuits at doctor's kind=noop check ("Already at
+  # latest. Nothing to do.", exit 0) without ever restarting — only `curl $PROXY/health` told the
+  # truth. `_cmd_update_restart` (#217) already closed this exact gap for the sibling "restart"
+  # kind via `node scripts/upgrade.mjs --post-flight-only`, which reuses postFlightOk() (compares
+  # /health's reported version against the target, not just auth.ok) instead of a second
+  # hand-rolled check — wiring the light path up the same way is what this block does. `new_ver`
+  # (re-read from package.json AFTER the git pull above, whether or not it changed) is the
+  # correct verification target: it reflects whatever version the tree actually landed on.
+  echo "  Verifying restart..."
+  local postflight_status=0
+  node "$script_dir/scripts/upgrade.mjs" --post-flight-only "v$new_ver" || postflight_status=$?
+
+  # Exit-code contract (deliberately decided here, per #235's own deferral of this exact
+  # question): a post-flight failure now makes this function — and therefore `ocp update` on
+  # this path — return non-zero, matching `_cmd_update_restart`'s own "print + return 1" pattern
+  # rather than the old implicit-success-regardless-of-outcome behavior. Checked as a combined
+  # condition (either signal failing is a failure) rather than only the post-flight result alone,
+  # so a resolver refusal that cmd_restart already reported (restart_status non-zero) is never
+  # silently overridden into success by a post-flight probe that happens to answer anyway (e.g.
+  # a DIFFERENT, unrelated process already serving the right version on the same port).
+  if [[ $restart_status -ne 0 || $postflight_status -ne 0 ]]; then
+    echo "  Run \`ocp doctor\` or \`curl \$PROXY/health\` to inspect further."
+    return 1
+  fi
+  return 0
 }
 
 # Issue #214: tree is already at latest, but the RUNNING SERVICE is stale — a previous update

--- a/ocp
+++ b/ocp
@@ -741,7 +741,26 @@ cmd_restart() {
     sleep 3
     if curl -sf --max-time 5 "$PROXY/health" > /dev/null 2>&1; then
       echo "✓ Proxy restarted successfully."
-      cmd_usage
+      # MEDIUM-2 (independent review round 1 on #241/PR #255): `cmd_usage` is called here purely
+      # as a nice-to-have post-restart display, but its OWN `/usage` probe does `exit 1` (not
+      # `return 1`) on failure — a real, non-hypothetical case right after a restart, before the
+      # proxy has warmed back up: `/usage` returns 502 whenever the upstream probe errors
+      # (server.mjs's jsonResponse(res, data.error ? 502 : 200, ...) for that route), and
+      # `curl -sf` treats any non-2xx as failure. Before this fix, that `exit 1` became THIS
+      # function's own return code — indistinguishable from a genuine restart failure to any
+      # caller checking cmd_restart's exit status. #241/PR #255 was the first caller to actually
+      # DO that (_cmd_update_light's restart_status), and it surfaced this exact conflation: a
+      # fully successful restart, with post-flight PASSING, reported as an overall failure
+      # because the cosmetic usage display happened to 502. A bare `cmd_usage || true` would NOT
+      # fix this — `exit` terminates the current process immediately, before a `||` on the
+      # calling line ever gets a chance to evaluate (it does not behave like a command returning
+      # nonzero). Wrapping the call in its OWN subshell does: `exit` inside a subshell only
+      # terminates that subshell, so `( cmd_usage ) || true` safely discards a display-only
+      # failure while a GENUINE restart failure (resolver refusal, restart command failure, or
+      # the health-check failure in the `else` branch below) still `return`s 1 on its own,
+      # unaffected — none of those paths ever reach this line. Same containment technique
+      # `_cmd_update_light` itself already relies on for the OUTER `( cmd_restart ) || ...` call.
+      ( cmd_usage ) || true
     else
       echo "✗ Proxy not responding after restart."
       return 1
@@ -852,13 +871,20 @@ Usage:
   ocp update --rollback --gc --dry-run    Preview what would be deleted
 
 Notes:
-  --target on the light/patch-bump path (a same-minor patch update): NOT
-  honored. That path always runs a plain `git pull origin main --ff-only`
-  regardless of any version requested via --target (issue #241) -- real
+  --target IS honored on the cross-minor (full) upgrade path (issue #259):
+  it pins the checkout to the exact requested release tag instead of
+  always taking the latest.
+
+  --target is NOT honored on the light/patch-bump path (a same-minor patch
+  update, issue #241): that path always runs a plain `git pull origin main
+  --ff-only` regardless of any version requested via --target -- real
   version-pinning there would mean a tag checkout instead of a fast-forward
-  pull, a different mechanism than this path's job. Passing --target on
-  that path prints a runtime warning rather than silently doing nothing
-  unexpected.
+  pull, a different mechanism than this path's job (a trade-off #259 made
+  differently for the full path, where the mechanism already IS a tag
+  checkout -- see that issue for why the two paths reach different
+  answers). Passing --target on the light path prints a runtime warning
+  (accepts both `--target vX.Y.Z` and `--target=vX.Y.Z`) rather than
+  silently doing nothing unexpected.
 EOF
 }
 
@@ -1008,20 +1034,36 @@ _cmd_update_light() {
   # requested version. Real version-pinning here would mean switching from a fast-forward pull
   # to a tag checkout (fetch tags, `git checkout vX.Y.Z`, and deciding what happens to
   # --ff-only's protections) — a different mechanism, not a one-line addition, and its own design
-  # decision deliberately left for a future PR (see #241's own scope note). What IS this PR's
-  # job: stop letting that no-op be SILENT. A user passing --target here should not reasonably
-  # conclude it pinned anything just because nothing errored — this prints a runtime warning
-  # (cmd_update_help documents the same caveat) instead.
+  # decision deliberately left for a future PR (see #241's own scope note; #259 made this exact
+  # trade-off differently for the full/cross-minor path — see cmd_update_help's own Notes: below).
+  # What IS this PR's job: stop letting that no-op be SILENT. A user passing --target here should
+  # not reasonably conclude it pinned anything just because nothing errored — this prints a
+  # runtime warning (cmd_update_help documents the same caveat) instead.
+  #
+  # LOW-6 (independent review round 1): both `--target vX.Y.Z` (two argv tokens) AND
+  # `--target=vX.Y.Z` (one token) are real, commonly-typed CLI shapes for the SAME flag — the
+  # equals form is exactly the silently-ignored pin this fix exists to eliminate, and the
+  # original version of this guard only matched the two-token form. `case` on each token catches
+  # both without a second pass. The warning itself now goes to stderr, not stdout: in piped fleet
+  # automation (`ocp update --target vX | some-log-parser`), a stdout warning would be silently
+  # read as data by whatever consumes the pipe; stderr is where a human-facing advisory belongs.
   local _args=("$@") _i _target_seen=0 _target_val=""
   for ((_i = 0; _i < ${#_args[@]}; _i++)); do
-    if [[ "${_args[_i]}" == "--target" ]]; then
-      _target_seen=1
-      _target_val="${_args[_i+1]:-<no value given>}"
-      break
-    fi
+    case "${_args[_i]}" in
+      --target)
+        _target_seen=1
+        _target_val="${_args[_i+1]:-<no value given>}"
+        break
+        ;;
+      --target=*)
+        _target_seen=1
+        _target_val="${_args[_i]#--target=}"
+        break
+        ;;
+    esac
   done
   if [[ $_target_seen -eq 1 ]]; then
-    echo "  ⚠ --target $_target_val is not honored on the light/patch-bump path — it always pulls the latest origin/main regardless. Run \`ocp update --help\` for details."
+    echo "  ⚠ --target $_target_val is not honored on the light/patch-bump path — it always pulls the latest origin/main regardless. Run \`ocp update --help\` for details." >&2
   fi
 
   # Honor --dry-run BEFORE any mutation (issue #235). This arm used to be called with NO
@@ -1097,9 +1139,29 @@ _cmd_update_light() {
   # hand-rolled check — wiring the light path up the same way is what this block does. `new_ver`
   # (re-read from package.json AFTER the git pull above, whether or not it changed) is the
   # correct verification target: it reflects whatever version the tree actually landed on.
-  echo "  Verifying restart..."
+  # MEDIUM-1 (independent review round 1): `new_ver` degrades to the literal string "?" (line
+  # ~975, pre-existing `2>/dev/null || echo "?"`) whenever THIS python3 read fails for any reason
+  # — including on the very python3-less/broken hosts issue #242 (PR #252) exists for. Driving
+  # `postFlightOk` directly shows why that is fatal here specifically: `want = String("v?" ||
+  # "").replace(/^v/, "")` strips the leading "v" and is left with the non-empty string "?", so
+  # `!want` is false and the predicate demands `body.version === "?"` — never true for any real
+  # server. `postFlightOk`'s own doc comment says an empty/unknown target should degrade to the
+  # auth-only check "rather than blocking an otherwise-good upgrade"; "v?" defeats exactly that
+  # intent because it is NOT empty. Passing an empty string instead is not an option either: the
+  # `--post-flight-only` CLI entrypoint (scripts/upgrade.mjs) deliberately fails closed on a
+  # falsy target ("Fail CLOSED on a missing/malformed target" — see its own comment) specifically
+  # to catch an accidentally-omitted flag, and relaxing that guard for a legitimate "unknown"
+  # case is a separate, more invasive design decision than this fix warrants. So: skip the
+  # strict version check entirely when we genuinely cannot determine what to check FOR, and say
+  # so explicitly rather than either (a) blocking a real success behind a check that can never
+  # pass, or (b) silently claiming a verified success that was never actually verified.
   local postflight_status=0
-  node "$script_dir/scripts/upgrade.mjs" --post-flight-only "v$new_ver" || postflight_status=$?
+  if [[ "$new_ver" == "?" ]]; then
+    echo "  ⚠ Could not determine the installed version (python3 unavailable or broken — see issue #242) — skipping strict post-flight version verification. Run \`ocp doctor\` or \`curl \$PROXY/health\` to confirm the restart actually landed." >&2
+  else
+    echo "  Verifying restart..."
+    node "$script_dir/scripts/upgrade.mjs" --post-flight-only "v$new_ver" || postflight_status=$?
+  fi
 
   # Exit-code contract (deliberately decided here, per #235's own deferral of this exact
   # question): a post-flight failure now makes this function — and therefore `ocp update` on

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -10696,6 +10696,104 @@ test("#224: _cmd_update_light no longer swallows cmd_restart's refusal (operator
     `its old "> /dev/null 2>&1"; stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
 });
 
+// ── #241: _cmd_update_light gets --post-flight-only verification + explicit --target no-op ───
+// #235 fixed the --dry-run mutation defect on the light path and deliberately deferred two more
+// items out of that PR to keep it to the minimum reviewable unit: (1) post-flight verification
+// mirroring _cmd_update_restart's own (#217) node scripts/upgrade.mjs --post-flight-only check,
+// and (2) deciding what --target should do now that "$@" reaches this function. This is the
+// fix for issue #214's actual incident, reproduced verbatim in #241: the tree lands on the new
+// version, the running service stays on the old one (cmd_restart's own success criterion is
+// just "/health responds", not "responds with the right version"), and a RETRY short-circuits at
+// doctor's kind=noop check ("Already at latest. Nothing to do.", exit 0) without ever
+// restarting -- only `curl $PROXY/health` told the truth in the real incident.
+console.log("\n_cmd_update_light post-flight verification + --target handling (#241):");
+
+test("#241 (the money test): light path reports FAILURE when post-flight verification does not confirm the new version, even though cmd_restart itself reported success", () => {
+  // overrideCmdRestart stays at its default (true): the FAKE-CMD-RESTART-CALLED stub always
+  // echoes "Restarting proxy..." / "✓ Proxy restarted successfully." and returns 0 -- exactly
+  // the pre-#241 failure mode (a restart that LOOKS successful while the service is still
+  // stale). postFlightExit:1 simulates the fake node --post-flight-only mode reporting the
+  // service never reached the target version within budget.
+  const r = _bwHarnessRun({ kind: "update", args: ["update"], postFlightExit: 1 });
+  assert.ok(r.stdout.includes("Updating OCP (light path)"), `sanity check we reached _cmd_update_light; stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(_bwCalled(r.log, "FAKE-CMD-RESTART-CALLED"), `cmd_restart must still run; log=${JSON.stringify(r.log)}`);
+  assert.ok(r.log.some((l) => l.includes("post-flight-only")), `post-flight verification must actually run; log=${JSON.stringify(r.log)}`);
+  assert.notEqual(r.status, 0,
+    `_cmd_update_light must report FAILURE when post-flight verification fails, even though ` +
+    `cmd_restart itself reported success -- this is issue #214/#241's exact incident (tree ` +
+    `updated, service stale, reported success anyway); status=${r.status}`);
+});
+
+test("#241 control: light path reports SUCCESS when post-flight verification confirms the new version (proves the money test's failure is real, not the path just always failing now)", () => {
+  const r = _bwHarnessRun({ kind: "update", args: ["update"], postFlightExit: 0 });
+  assert.equal(r.status, 0, `expected a clean exit when post-flight succeeds; status=${r.status} stderr=${r.stderr}`);
+  assert.ok(_bwCalled(r.log, "FAKE-CMD-RESTART-CALLED"), `cmd_restart must run; log=${JSON.stringify(r.log)}`);
+  assert.ok(r.log.some((l) => l.includes("post-flight-only")), `post-flight verification must run; log=${JSON.stringify(r.log)}`);
+});
+
+test("#241: post-flight verification is invoked with the version the tree actually landed on (v3.26.0, from this harness's static package.json), not a hard-coded or stale value", () => {
+  const r = _bwHarnessRun({ kind: "update", args: ["update"], postFlightExit: 0 });
+  assert.ok(r.log.some((l) => l.includes("FAKE-NODE-CALL") && l.includes("--post-flight-only") && l.includes("v3.26.0")),
+    `expected the post-flight-only call to carry the real target version; log=${JSON.stringify(r.log)}`);
+});
+
+test("#241: a resolver refusal (cmd_restart itself fails) is NOT masked into success by post-flight happening to answer anyway", () => {
+  // overrideCmdRestart:false lets the REAL cmd_restart run; the resolver refuses, so cmd_restart
+  // itself returns non-zero (restart_status). postFlightExit defaults to 0 (the fake node stub
+  // would "succeed") -- this proves the combined check does not let a lucky post-flight result
+  // paper over a restart that never actually happened.
+  const r = _bwHarnessRun({
+    kind: "update", args: ["update"], overrideCmdRestart: false,
+    resolveRestartExit: 1, resolveRestartStderr: ["restart aborted: MOCK-RESOLVER-REFUSAL-241"],
+  });
+  assert.notEqual(r.status, 0,
+    `a cmd_restart refusal must still fail the light path even when post-flight's own (mocked) ` +
+    `check would otherwise report success; status=${r.status}`);
+  assert.ok((r.stdout + r.stderr).includes("MOCK-RESOLVER-REFUSAL-241"),
+    `the refusal message must still reach the operator; stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#241: --target on the light path prints an explicit no-op warning instead of being silently ignored", () => {
+  const r = _bwHarnessRun({ kind: "update", args: ["update", "--target", "v9.9.9"] });
+  assert.ok(r.stdout.includes("--target v9.9.9 is not honored on the light/patch-bump path"),
+    `expected the explicit --target no-op warning, got: ${JSON.stringify(r.stdout)}`);
+  assert.ok(_bwCalled(r.log, "FAKE-GIT-CALL"), `--target must not BLOCK the ordinary light-path update; log=${JSON.stringify(r.log)}`);
+});
+
+test("#241 control: light path WITHOUT --target prints no --target warning at all", () => {
+  const r = _bwHarnessRun({ kind: "update", args: ["update"] });
+  assert.ok(!r.stdout.includes("is not honored on the light/patch-bump path"),
+    `must not print the --target warning when --target was never passed; got: ${JSON.stringify(r.stdout)}`);
+});
+
+test("#241: --target warning still fires under --dry-run (detected before the dry-run early-return, matching --target reaching this function per #235)", () => {
+  const r = _bwHarnessRun({ kind: "update", args: ["update", "--target", "v9.9.9", "--dry-run"] });
+  assert.ok(r.stdout.includes("--target v9.9.9 is not honored on the light/patch-bump path"),
+    `expected the warning even under --dry-run, got: ${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stdout.includes("[dry-run]"), `--dry-run itself must still be honored (no mutation); got: ${JSON.stringify(r.stdout)}`);
+  assert.ok(!_bwCalled(r.log, "FAKE-GIT-CALL"), `--dry-run must still prevent the git pull; log=${JSON.stringify(r.log)}`);
+});
+
+test("#241: cmd_update_help documents the light-path --target caveat", () => {
+  const r = _bwHarnessRun({ args: ["update", "--help"] });
+  assert.equal(r.status, 0, `expected --help to exit cleanly; status=${r.status} stderr=${r.stderr}`);
+  assert.ok(r.stdout.includes("--target"), `expected --target to be mentioned at all in help output; got: ${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stdout.includes("light/patch-bump path"), `expected the help text to name the light/patch-bump path specifically, got: ${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stdout.includes("NOT"), `expected the help text to explicitly say --target is NOT honored there, got: ${JSON.stringify(r.stdout)}`);
+});
+
+// ── Sibling non-regression: _cmd_update_restart's own --post-flight-only wiring (#217) is
+// untouched by this PR -- _cmd_update_light is a distinct function; this PR does not modify
+// _cmd_update_restart at all. Re-asserts the pre-existing "non-regression control" test's own
+// invariant explicitly under the #241 banner so a future reviewer sees it was checked here too.
+test("#241 non-regression: _cmd_update_restart (the sibling 'restart' kind) is unaffected -- still restarts + post-flight verifies, never touches git", () => {
+  const r = _bwHarnessRun({ kind: "restart", args: ["update"] });
+  assert.ok(!_bwCalled(r.log, "FAKE-GIT-CALL"), `restart kind must never touch git; log=${JSON.stringify(r.log)}`);
+  assert.ok(_bwCalled(r.log, "FAKE-CMD-RESTART-CALLED"), `cmd_restart must run; log=${JSON.stringify(r.log)}`);
+  assert.ok(_bwCalled(r.log, "FAKE-NODE-CALL") && r.log.some((l) => l.includes("post-flight-only")),
+    `post-flight verification must still run on the sibling path; log=${JSON.stringify(r.log)}`);
+});
+
 // The three tests above drive `--resolve-restart` entirely through the bash harness's FAKE
 // `node` stub (by design — see the harness's own "exec hazard" comment: a real fake-node file
 // on the scratch $PATH is what makes ocp's `exec node ...` arms unreachable BY CONSTRUCTION).

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -9645,7 +9645,7 @@ test("ocp bash harness: '# ── dispatch' anchor slice is well-formed (premise
 //                        check) refuses loudly (exit 94) rather than silently doing something
 //                        undefined — none of this issue's tests reach that far on purpose.
 function _bwHarnessRun({
-  args = [], kind = "noop", checks = [], pythonAbsent = false,
+  args = [], kind = "noop", checks = [], pythonAbsent = false, pythonPackageJsonFails = false,
   gitPullExit = 0, gitPullOutput = "Already up to date.", postFlightExit = 0,
   overrideCmdRestart = true,
   resolveRestartExit = 0, resolveRestartStdout = [], resolveRestartStderr = [],
@@ -9673,8 +9673,32 @@ function _bwHarnessRun({
   // file (the harness's own default state below) — `_curl` dies before ever reaching the
   // network call. Every _curl-based test in this file sets a non-empty `adminKey` to route
   // around this ORTHOGONAL defect (a non-empty `_AUTH_ARGS` array never hits the empty-array
-  // path) rather than accidentally depending on it.
+  // path) rather than accidentally depending on it. (This defect is fixed upstream as of #258 —
+  // this workaround is now belt-and-braces, not load-bearing — but every call site keeps it
+  // rather than depending on the fix to stay in place.)
   adminKey = "",
+  // MEDIUM-3 (independent review round 1 on #241): this harness's package.json was always
+  // STATIC ("3.26.0"), so `old_ver === new_ver` in every pre-existing test, and a mutation
+  // swapping `"v$new_ver"` for the stale `"v$old_ver"` in the real --post-flight-only call site
+  // was UNDETECTABLE — the money test named after "the version the tree actually landed on"
+  // could not tell a fresh value from a stale one, because they were always identical. Set true
+  // to make the fake `git pull` stub, on a SUCCESSFUL "pull origin main --ff-only", overwrite
+  // the harness's package.json with version "3.27.0" (a real, observable bump from the initial
+  // "3.26.0") — combine with `postFlightExpectedTarget` below to make a stale-vs-fresh mutation
+  // actually distinguishable.
+  simulateGitPullVersionBump = false,
+  // MEDIUM-3: when set, the fake `node`'s `--post-flight-only` case becomes VERSION-AWARE: it
+  // only honors `postFlightExit` when the invocation's target argument matches this string
+  // exactly (mirroring the real predicate's "wrong version -> fail" behavior); any other target
+  // (e.g. the STALE pre-pull version, under a mutation using `$old_ver` instead of `$new_ver`)
+  // is treated as a mismatch and fails with a distinct exit code. `undefined` (the default)
+  // preserves every existing test's behavior exactly: `postFlightExit` applies unconditionally,
+  // regardless of the target argument.
+  postFlightExpectedTarget = undefined,
+  // LOW-4: when true (and overrideCmdRestart stays at its default true), the STUB cmd_restart's
+  // final line becomes `exit 0` instead of `return 0`, directly reproducing the shape the outer
+  // `( cmd_restart ) || restart_status=$?` subshell in _cmd_update_light exists to contain.
+  cmdRestartStubExits = false,
 } = {}) {
   const root = _ltMkdtemp(join(_ltTmp(), "ocp-bash-harness-"));
   try {
@@ -9710,7 +9734,21 @@ function _bwHarnessRun({
       `    exit 0`,
       `    ;;`,
       `  *"scripts/upgrade.mjs --post-flight-only"*)`,
-      `    exit ${postFlightExit}`,
+      ...(postFlightExpectedTarget === undefined ? [
+        `    exit ${postFlightExit}`,
+      ] : [
+        // MEDIUM-3: version-aware -- only the EXPECTED (post-pull) target succeeds; anything
+        // else, including a STALE pre-pull version reached via a mutation, is a mismatch.
+        `    case "$*" in`,
+        `      *${JSON.stringify(postFlightExpectedTarget)}*)`,
+        `        exit ${postFlightExit}`,
+        `        ;;`,
+        `      *)`,
+        `        echo "FAKE-NODE: post-flight target mismatch -- expected ${postFlightExpectedTarget}, got: $*" >&2`,
+        `        exit 98`,
+        `        ;;`,
+        `    esac`,
+      ]),
       `    ;;`,
       // Issue #224: the new one-shot resolver mode `cmd_restart` shells out to instead of
       // reimplementing cgroup/ss parsing a second time in bash — see scripts/upgrade.mjs's
@@ -9734,6 +9772,11 @@ function _bwHarnessRun({
       `echo "FAKE-GIT-CALL $*" >> "${logPath}"`,
       `case "$*" in`,
       `  "pull origin main --ff-only")`,
+      // MEDIUM-3: simulates a REAL version bump landing on disk, so old_ver != new_ver becomes
+      // observable — every pre-existing test leaves this false and keeps package.json static.
+      ...(simulateGitPullVersionBump ? [
+        `    printf '%s' ${JSON.stringify(JSON.stringify({ version: "3.27.0" }))} > ${JSON.stringify(join(root, "package.json"))}`,
+      ] : []),
       `    echo ${JSON.stringify(gitPullOutput)}`,
       `    exit ${gitPullExit}`,
       `    ;;`,
@@ -9818,6 +9861,31 @@ function _bwHarnessRun({
         `echo "FAKE-PYTHON3-ABSENT-CALL $*" >> "${logPath}"`,
         `exit 127`,
       ].join("\n"));
+    } else if (pythonPackageJsonFails) {
+      // MEDIUM-1 (independent review round 1 on #241): `pythonAbsent` fails EVERY python3
+      // invocation, including `cmd_update`'s own doctor-kind extraction a few lines before
+      // `_cmd_update_light` is ever reached — under a fully-absent python3, `kind` itself
+      // degrades to "unknown" and the dispatch never enters the light path at all (see the
+      // sibling #236 test above), so `pythonAbsent` cannot exercise "kind extraction succeeded,
+      // but the LATER package.json version read specifically fails" — the exact shape MEDIUM-1's
+      // finding needs (a python3 that is present and working in general, but broken/flaky for
+      // one specific call, or simply hits a transient failure reading a real package.json at
+      // that moment). This selective stub delegates to the REAL /usr/bin/python3 (absolute path,
+      // not a bare `python3` call, which would resolve back to this same stub file first on the
+      // scratch $PATH and recurse) for every invocation EXCEPT the `import json;
+      // ...package.json...` version-read shape, which fails outright — reproducing "new_ver
+      // becomes '?'" without touching the unrelated kind-extraction call.
+      mkStub("python3", [
+        `case "$*" in`,
+        `  *"package.json"*)`,
+        `    echo "FAKE-PYTHON3-PACKAGEJSON-FAIL-CALL $*" >> "${logPath}"`,
+        `    exit 1`,
+        `    ;;`,
+        `  *)`,
+        `    exec /usr/bin/python3 "$@"`,
+        `    ;;`,
+        `esac`,
+      ].join("\n"));
     }
 
     // `cmd_restart` override goes AFTER the sliced source in the SAME generated file — never
@@ -9849,7 +9917,20 @@ function _bwHarnessRun({
         `  echo "FAKE-CMD-RESTART-CALLED $*" >> "${logPath}"`,
         `  echo "Restarting proxy..."`,
         `  echo "✓ Proxy restarted successfully."`,
-        `  return 0`,
+        // LOW-4 (independent review round 1): the pre-existing #224 test that drives the REAL
+        // cmd_restart uses `resolveRestartExit: 1`, which makes it `return` (not `exit`) --
+        // that path never needed the outer `( cmd_restart ) || restart_status=$?` subshell in
+        // _cmd_update_light, since `return` behaves correctly with or without it. Nothing
+        // exercised the ACTUAL hazard the subshell exists for: a `cmd_restart` whose SUCCESS
+        // path calls `exit` (cmd_usage's own pre-existing `/usage`-probe hazard, MEDIUM-2 above)
+        // terminates the entire process immediately if not contained, silently skipping
+        // everything after it -- "Verifying restart...", the post-flight call, all of it -- with
+        // no error, just a premature clean-looking exit. `cmdRestartStubExits` reproduces that
+        // shape directly against THIS stub (independent of whatever cmd_restart's real
+        // implementation happens to do after MEDIUM-2's fix), so the outer subshell's own
+        // structural correctness in _cmd_update_light is what's under test, not cmd_restart's
+        // internals.
+        cmdRestartStubExits ? `  exit 0` : `  return 0`,
         `}`,
       ].join("\n") : "# issue #224: overrideCmdRestart=false -- the REAL cmd_restart above is used as-is",
       "",
@@ -9882,7 +9963,10 @@ function _bwHarnessRun({
     // display-command tests need stderr on a successful (status 0) run too — e.g. proving a
     // degraded-but-still-status-0 case truly carries no warning. `spawnSync` always returns
     // `{stdout, stderr, status}` regardless of exit code, so switching to it removes the gap
-    // for every caller, not just #242's.
+    // for every caller, not just #242's. (#241/PR #255's own MEDIUM-1/LOW-6 tests independently
+    // needed this exact same fix — e.g. the --target warning firing on a successful, status-0
+    // run — and originally ported a duplicate of it before this rebase; this is now the single
+    // shared fix both PRs rely on.)
     const _bwRes = spawnSync("bash", [driverPath, ...args], { cwd: root, env, encoding: "utf8" });
     const stdout = _bwRes.stdout ?? "";
     const stderr = _bwRes.stderr ?? "";
@@ -10675,6 +10759,42 @@ test("#224: cmd_restart runs the resolver's actual resolved command, not the old
     `non-zero exit code (not the old implicit success); status=${r.status}`);
 });
 
+// ── MEDIUM-2 (independent review round 1, blocking): cmd_restart's own SUCCESS path calls
+// cmd_usage as a nice-to-have post-restart display, but cmd_usage's own `/usage` probe does
+// `exit 1` (not `return 1`) if it fails -- and it fails whenever `/usage` returns non-2xx, which
+// happens right after a restart before the proxy has warmed back up (a real, demonstrated case,
+// not hypothetical). Before this fix, that turned a GENUINELY SUCCESSFUL restart into an overall
+// failure -- indistinguishable from a real restart failure to anything checking cmd_restart's own
+// exit code, which #241/PR #255 was the first caller to actually do. This harness has no
+// `curlResponses` capability (that landed on the sibling #242 branch, not yet merged here), so
+// the DEFAULT curl stub's own refusal for any URL other than "*/health*" (exit 94) already
+// reproduces "the /usage probe fails" without needing one -- `curl -sf` on a non-2xx/unreachable
+// response is exactly what makes cmd_usage's own guard fire.
+test("#241 MEDIUM-2 (the money test): a healthy restart with a merely-cosmetic /usage display failure must NOT make cmd_restart itself report failure", () => {
+  const r = _bwHarnessRun({
+    args: ["restart"], overrideCmdRestart: false,
+    resolveRestartExit: 0, resolveRestartStdout: ["true"],
+    curlHealthExit: 0,
+  });
+  assert.equal(r.status, 0,
+    `a genuinely successful restart (resolver ok, restart command ok, health check ok) must ` +
+    `report success even though the COSMETIC post-restart usage display failed; status=${r.status} ` +
+    `stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stdout.includes("✓ Proxy restarted successfully."), `expected the success line; stdout=${JSON.stringify(r.stdout)}`);
+});
+
+test("#241 MEDIUM-2: the SAME scenario end-to-end through _cmd_update_light -- a healthy restart's cosmetic /usage failure must not make the light path report overall failure either", () => {
+  const r = _bwHarnessRun({
+    kind: "update", args: ["update"], overrideCmdRestart: false,
+    resolveRestartExit: 0, resolveRestartStdout: ["true"],
+    curlHealthExit: 0, postFlightExit: 0,
+  });
+  assert.equal(r.status, 0,
+    `the light path must report success when the restart genuinely succeeded and post-flight ` +
+    `passed, even though cmd_restart's own cosmetic /usage display failed; status=${r.status} ` +
+    `stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+});
+
 test("#224: _cmd_update_light no longer swallows cmd_restart's refusal (operator sees why it failed, and the exit code is non-zero)", () => {
   const r = _bwHarnessRun({
     kind: "update",
@@ -10731,10 +10851,49 @@ test("#241 control: light path reports SUCCESS when post-flight verification con
   assert.ok(r.log.some((l) => l.includes("post-flight-only")), `post-flight verification must run; log=${JSON.stringify(r.log)}`);
 });
 
-test("#241: post-flight verification is invoked with the version the tree actually landed on (v3.26.0, from this harness's static package.json), not a hard-coded or stale value", () => {
-  const r = _bwHarnessRun({ kind: "update", args: ["update"], postFlightExit: 0 });
-  assert.ok(r.log.some((l) => l.includes("FAKE-NODE-CALL") && l.includes("--post-flight-only") && l.includes("v3.26.0")),
-    `expected the post-flight-only call to carry the real target version; log=${JSON.stringify(r.log)}`);
+// MEDIUM-3 (independent review round 1): the original version of this test used this harness's
+// STATIC package.json, where old_ver === new_ver === "3.26.0" always — a mutation swapping
+// `"v$new_ver"` for the STALE `"v$old_ver"` at the real call site was therefore UNDETECTABLE
+// (both values are identical, so the mutant and the fix produce byte-identical behavior). That
+// mutant IS the bug this test is named after: verifying against the pre-pull version would let a
+// stale process serving OLD code pass post-flight, exactly re-opening #241. Fixed with a fixture
+// where the pull ACTUALLY changes the version (simulateGitPullVersionBump) and a node stub that
+// only succeeds for the CORRECT post-pull target (postFlightExpectedTarget) — so using the stale
+// value now fails this test with a target-mismatch, not merely produces the same log line.
+test("#241 MEDIUM-3: post-flight verification target reflects the version the pull ACTUALLY landed on (v3.27.0), not the stale pre-pull version (v3.26.0)", () => {
+  const r = _bwHarnessRun({
+    kind: "update", args: ["update"],
+    simulateGitPullVersionBump: true,
+    postFlightExpectedTarget: "v3.27.0",
+    postFlightExit: 0,
+  });
+  assert.equal(r.status, 0,
+    `expected success when post-flight is checked against the CORRECT (post-pull) version -- a ` +
+    `non-zero status here means the wrong (stale) version was sent; status=${r.status} stderr=${JSON.stringify(r.stderr)} log=${JSON.stringify(r.log)}`);
+  assert.ok(r.log.some((l) => l.includes("FAKE-NODE-CALL") && l.includes("--post-flight-only") && l.includes("v3.27.0")),
+    `expected the post-flight-only call to carry v3.27.0 (the version actually landed on), not v3.26.0 (stale); log=${JSON.stringify(r.log)}`);
+});
+
+// LOW-4 (independent review round 1): the outer `( cmd_restart ) || restart_status=$?` subshell
+// in _cmd_update_light was previously untested for the one thing it exists to do -- contain a
+// naked `exit` reached through cmd_restart's success path so it does not silently kill the whole
+// process. `cmdRestartStubExits` reproduces that shape directly against the harness's OWN stub
+// (independent of cmd_restart's real internals, which MEDIUM-2 above already fixed at the
+// source), proving the containment is real: if the outer parens were ever removed, `exit 0`
+// inside the (now-unwrapped) stub would terminate the ENTIRE bash process immediately -- with
+// exit code 0, looking like a clean success -- and "Verifying restart...", the post-flight call,
+// and everything after it would simply never run. Content-based assertions (not just the exit
+// code, which would misleadingly still read as "0 = fine") are what catch that.
+test("#241 LOW-4: the outer subshell around cmd_restart actually contains an exit() reached through its success path -- post-flight still runs afterward", () => {
+  const r = _bwHarnessRun({ kind: "update", args: ["update"], cmdRestartStubExits: true, postFlightExit: 0 });
+  assert.ok(_bwCalled(r.log, "FAKE-CMD-RESTART-CALLED"), `cmd_restart (stub) must have run; log=${JSON.stringify(r.log)}`);
+  assert.ok(r.log.some((l) => l.includes("FAKE-NODE-CALL") && l.includes("--post-flight-only")),
+    `post-flight verification must STILL run after a cmd_restart that exits (not returns) -- if ` +
+    `this is missing, the outer subshell failed to contain the exit and the rest of the ` +
+    `function silently never ran; log=${JSON.stringify(r.log)}`);
+  assert.ok(r.stdout.includes("Verifying restart..."),
+    `expected to reach the post-restart verification step's own output; stdout=${JSON.stringify(r.stdout)}`);
+  assert.equal(r.status, 0, `expected a clean success given postFlightExit:0; status=${r.status} stderr=${r.stderr}`);
 });
 
 test("#241: a resolver refusal (cmd_restart itself fails) is NOT masked into success by post-flight happening to answer anyway", () => {
@@ -10753,23 +10912,85 @@ test("#241: a resolver refusal (cmd_restart itself fails) is NOT masked into suc
     `the refusal message must still reach the operator; stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
 });
 
-test("#241: --target on the light path prints an explicit no-op warning instead of being silently ignored", () => {
+// ── MEDIUM-1 (independent review round 1): on a host where the package.json version read fails
+// (python3 absent/broken specifically for that call — see #242/PR #252, the exact host class
+// this incident class targets), `new_ver` degrades to the literal "?" via ocp's own pre-existing
+// `2>/dev/null || echo "?"` fallback. Driving postFlightOk() directly: target "v?" -> the
+// predicate strips the leading "v", is left with the non-empty string "?", and demands
+// `body.version === "?"` -- never true for any real server. Before this fix, a FULLY SUCCESSFUL
+// update on such a host would report failure and tell the operator to run `ocp doctor` for no
+// real reason. The fix: skip strict post-flight verification (which cannot succeed without a
+// known target anyway) and say so explicitly instead of either blocking a real success or
+// silently claiming a verified one.
+test("#241 MEDIUM-1 (the money test): a python3 failure isolated to the package.json version read does NOT force the light path to report failure", () => {
+  const r = _bwHarnessRun({
+    kind: "update", args: ["update"], pythonPackageJsonFails: true,
+    // postFlightExit deliberately NOT set to 0 here -- if the code wrongly still called
+    // --post-flight-only with "v?", the fake node stub's DEFAULT (0) would coincidentally look
+    // like success, hiding the bug. The real defect is calling it AT ALL with an unverifiable
+    // target and then depending on postFlightOk's own real (unmocked) logic, which the sibling
+    // MEDIUM-1 control test below verifies directly.
+  });
+  assert.equal(r.status, 0,
+    `a python3 failure isolated to the version read must not turn a real restart success into a ` +
+    `reported failure; status=${r.status} stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stderr.includes("Could not determine the installed version") && r.stderr.includes("skipping strict post-flight version verification"),
+    `expected an explicit degraded-mode warning telling the operator verification was skipped, not silently claimed; stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(!r.log.some((l) => l.includes("FAKE-NODE-CALL") && l.includes("--post-flight-only")),
+    `--post-flight-only must not be invoked with an unverifiable "v?" target at all; log=${JSON.stringify(r.log)}`);
+});
+
+test("#241 MEDIUM-1 control: with python3 fully healthy, the SAME scenario still runs strict post-flight verification normally", () => {
+  const r = _bwHarnessRun({ kind: "update", args: ["update"], postFlightExit: 0 });
+  assert.equal(r.status, 0, `expected success; status=${r.status} stderr=${r.stderr}`);
+  assert.ok(r.log.some((l) => l.includes("FAKE-NODE-CALL") && l.includes("--post-flight-only") && l.includes("v3.26.0")),
+    `expected the normal (non-degraded) post-flight call with the real version; log=${JSON.stringify(r.log)}`);
+  assert.ok(!r.stderr.includes("Could not determine the installed version"),
+    `must not print the degraded-mode warning when python3 is healthy; stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#241 MEDIUM-1: postFlightOk() itself, driven directly, confirms WHY 'v?' is unverifiable -- the predicate this fix routes around", () => {
+  // Direct, unmocked exercise of the real predicate (imported at the top of this file's upgrade
+  // full-path section) -- this is the evidence for the fix above, not a duplicate of it.
+  assert.equal(postFlightOk({ auth: { ok: true }, version: "3.27.0" }, "v3.27.0"), true,
+    "a matching version must pass");
+  assert.equal(postFlightOk({ auth: { ok: true }, version: "3.27.0" }, "v?"), false,
+    "target 'v?' must NOT pass against any real version -- this is the MEDIUM-1 defect made concrete");
+  assert.equal(postFlightOk({ auth: { ok: true }, version: "3.27.0" }, ""), true,
+    "an EMPTY target degrades to the auth-only check and passes -- 'v?' is categorically different from empty, which is why substituting an empty string was considered and rejected (the CLI's own --post-flight-only entrypoint fails closed on a falsy/empty target argument by design)");
+});
+
+// LOW-6 (independent review round 1): the warning moved to stderr (a stdout warning would be
+// silently read as data by piped fleet automation), and both `--target vX.Y.Z` (two tokens) and
+// `--target=vX.Y.Z` (one token, the equals form) must be detected — the equals form is exactly
+// the silently-ignored pin this fix exists to eliminate, and the original guard only matched the
+// two-token form.
+test("#241: --target (two-token form) on the light path prints an explicit no-op warning on STDERR instead of being silently ignored", () => {
   const r = _bwHarnessRun({ kind: "update", args: ["update", "--target", "v9.9.9"] });
-  assert.ok(r.stdout.includes("--target v9.9.9 is not honored on the light/patch-bump path"),
-    `expected the explicit --target no-op warning, got: ${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stderr.includes("--target v9.9.9 is not honored on the light/patch-bump path"),
+    `expected the explicit --target no-op warning on stderr, got: ${JSON.stringify(r.stderr)}`);
+  assert.ok(!r.stdout.includes("is not honored on the light/patch-bump path"),
+    `the warning must NOT also land on stdout (piped automation would read it as data); stdout=${JSON.stringify(r.stdout)}`);
   assert.ok(_bwCalled(r.log, "FAKE-GIT-CALL"), `--target must not BLOCK the ordinary light-path update; log=${JSON.stringify(r.log)}`);
 });
 
-test("#241 control: light path WITHOUT --target prints no --target warning at all", () => {
+test("#241 LOW-6: --target=vX.Y.Z (equals form, one token) is ALSO detected, not just the two-token form", () => {
+  const r = _bwHarnessRun({ kind: "update", args: ["update", "--target=v9.9.9"] });
+  assert.ok(r.stderr.includes("--target v9.9.9 is not honored on the light/patch-bump path"),
+    `expected the equals form to be recognized and its value extracted; stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(_bwCalled(r.log, "FAKE-GIT-CALL"), `--target=... must not BLOCK the ordinary light-path update; log=${JSON.stringify(r.log)}`);
+});
+
+test("#241 control: light path WITHOUT --target prints no --target warning at all (either form, either stream)", () => {
   const r = _bwHarnessRun({ kind: "update", args: ["update"] });
-  assert.ok(!r.stdout.includes("is not honored on the light/patch-bump path"),
-    `must not print the --target warning when --target was never passed; got: ${JSON.stringify(r.stdout)}`);
+  assert.ok(!r.stdout.includes("is not honored on the light/patch-bump path") && !r.stderr.includes("is not honored on the light/patch-bump path"),
+    `must not print the --target warning when --target was never passed; stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
 });
 
 test("#241: --target warning still fires under --dry-run (detected before the dry-run early-return, matching --target reaching this function per #235)", () => {
   const r = _bwHarnessRun({ kind: "update", args: ["update", "--target", "v9.9.9", "--dry-run"] });
-  assert.ok(r.stdout.includes("--target v9.9.9 is not honored on the light/patch-bump path"),
-    `expected the warning even under --dry-run, got: ${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stderr.includes("--target v9.9.9 is not honored on the light/patch-bump path"),
+    `expected the warning even under --dry-run, got stderr=${JSON.stringify(r.stderr)}`);
   assert.ok(r.stdout.includes("[dry-run]"), `--dry-run itself must still be honored (no mutation); got: ${JSON.stringify(r.stdout)}`);
   assert.ok(!_bwCalled(r.log, "FAKE-GIT-CALL"), `--dry-run must still prevent the git pull; log=${JSON.stringify(r.log)}`);
 });


### PR DESCRIPTION
# Pull Request

## Summary

`_cmd_update_light` (the light/patch-bump path, the single most common `ocp update` invocation) had no post-flight verification and silently ignored `--target`. Fixed both, deferred from #235's own review to keep that PR to the minimum reviewable unit.

## Endpoint Class (REQUIRED)

- [x] **Not endpoint-touching** — this is `ocp`, the bash CLI wrapper's update-dispatch logic, not `server.mjs`. No request handler is modified; `server.mjs` is untouched by this PR.

## Claude Code Alignment Evidence (REQUIRED)

N/A — not endpoint-touching. No `cli.js` citation applies.

## Type of change

- [x] Bug fix (post-flight verification addresses issue #214's "reports success while serving old code" gap on the light path; `--target` no-op is made explicit instead of silent)

## What changed

1. **Post-flight verification.** `_cmd_update_light` now calls `node scripts/upgrade.mjs --post-flight-only "v$new_ver"` after `cmd_restart`, reusing `postFlightOk()` (compares `/health`'s reported version against the target, not just `auth.ok`) — the same predicate `_cmd_update_restart` (#217) already uses for the sibling "restart" kind. `cmd_restart`'s own call switches from a bare invocation to `( cmd_restart ) || restart_status=$?`: still a subshell (containing `cmd_restart`'s own `exit`-on-failure hazard the same way `_cmd_update_restart`'s existing `( cmd_restart ) || true` does), but it now *captures* the real exit status instead of discarding it, since #224 already made `cmd_restart`'s own refusal exit non-zero and that signal must survive into this function's combined exit-code check.
2. **Exit-code contract** (the actual design decision #235 deferred): a post-flight failure now makes the light path return non-zero, matching `_cmd_update_restart`'s "print + return 1" pattern.
3. **`--target` handling**: made the pre-existing silent no-op explicit. `_cmd_update_light` detects `--target` in its argv and prints a runtime warning; `cmd_update_help` documents the same caveat. Real version-pinning on this path (a tag checkout instead of a fast-forward pull) is a different mechanism and its own design decision, deliberately deferred — this PR only makes the current no-op honest.

## Testing

Extends the bash CLI wiring harness from #243 (`test-features.mjs`) — no second harness built. 9 new tests covering: the money test (post-flight failure → light path reports FAILURE even though `cmd_restart` itself reported success — literally issue #214/#241's incident), its control, a wiring check (post-flight carries the real target version), a check that a `cmd_restart` refusal is never masked by a lucky post-flight probe, the `--target` warning (plain + `--dry-run`) plus its negative control, a `cmd_update_help` documentation check, and a non-regression check on the untouched sibling `_cmd_update_restart`.

**Failing on unfixed `ocp`** (via `git stash` isolating the `ocp` diff — never `git checkout`, which would discard the uncommitted tests too):
```
=== Results: 667 passed, 12 failed ===
```
6 of the 9 new tests fail (the money test, its control, the target-version wiring check, both `--target` warning tests, and the help-text check). The 3 that pass on unfixed `ocp` correctly do so — they test existing, unrelated behavior.

**Passing after the fix:**
```
=== Results: 671-673 passed, 6-8 failed ===
```
All 9 new tests green; remaining failures are the pre-existing `ltBoot` integration-test flakiness under this host's concurrent load (AGENTS.md-documented, tracked #248) — confirmed present on unmodified `main` too and unrelated to any file this PR touches.

### Mutation table

All mutations applied to a `cp`-backed file (never `git checkout`), restored and `shasum -a 256`-verified byte-identical before the next mutation. Anchor existence asserted before every mutation.

| # | Mutation | Named test(s) caught |
|---|---|---|
| A | Removed the `--post-flight-only` call entirely | The 3 tests asserting post-flight actually ran |
| B | Neutralized the combined exit-code check (`if false; then ... fi`) | The money test **and** the pre-existing #224 exit-code test (double coverage) |
| C | Removed the `--target` detection/warning block | Both `--target` runtime-warning tests |
| D | Removed `cmd_update_help`'s new `Notes:` section | The help-text documentation test |
| E | Reverted to `( cmd_restart ) \|\| true` (discarding its exit status again) | The "resolver refusal not masked" test **and** the pre-existing #224 exit-code test (double coverage) |

### Separate defect found — now resolved upstream

#241's own issue text assumed `--target` is honored on the FULL (cross-minor) upgrade path. It was not at the time this PR was opened (filed as #257). PR #259 has since landed and made `--target` real on the full path; see the "Update: rebase + review round 1" section below for how this PR's own help text was updated to reflect that.

## Related

- `ALIGNMENT.md` Rule(s) invoked: none (not endpoint-touching)
- Related issue / prior PR: Closes #241. Refs #214, #217, #224, #235, #225, #248 (history/context — none of these are closed by this PR).

### User-visible change self-check (铁律第五律 5.3)

- [x] This PR has user-visible changes → `ocp update --help`'s output gains a `Notes:` section documenting `--target`'s light-path caveat (see the `ocp` diff, `cmd_update_help`). `ocp update` on the light path can now exit non-zero on a post-flight failure where it previously always returned 0 — a deliberate, documented behavior change per this PR's own exit-code-contract decision above.

### Privacy self-check (for PUBLIC repos)

- [x] No personal names, literal home paths, personal hostnames, or personal email addresses introduced.

---

## Update: rebased + independent review round 1 addressed (REQUEST CHANGES → fixed)

Rebased onto `main` @ `d2ea5a7` (PR #259 — `--target` now real on the full/cross-minor path; PR #258 — the `_AUTH_ARGS` fix filed as #256). Clean rebase, no conflicts.

Five findings, two blocking-behavioral, one blocking-test, two smaller:

**MEDIUM-1 (blocking)**: on a host where the package.json version read fails, `new_ver` degraded to `"?"`, and the light path called `--post-flight-only "v?"` — a target that can never pass (`postFlightOk` demands an exact non-empty match). A fully successful update on such a host reported failure for no reason. Fixed: skip strict post-flight verification when `new_ver == "?"` and say so explicitly on stderr, rather than blocking a real success or silently claiming a verified one. (Passing an empty target instead was considered and rejected — the CLI entrypoint deliberately fails closed on a falsy target by design.)

**MEDIUM-2 (blocking)**: `cmd_restart`'s success path calls `cmd_usage` as a nice-to-have display, but `cmd_usage`'s own `/usage` probe does `exit 1` (not `return 1`) on failure — real right after a restart, before the proxy warms up. That `exit 1` became `cmd_restart`'s own return code, conflated with a genuine restart failure once `_cmd_update_light` started checking it: a fully successful restart with post-flight PASSING reported as overall failure. Fixed: `( cmd_usage ) || true` — a subshell (bare `cmd_usage || true` would NOT work; `exit` bypasses a `||` on the calling line entirely) — the same containment technique already used for the outer `cmd_restart` call.

**MEDIUM-3 (blocking, test)**: the "version the tree actually landed on" test used this harness's static package.json (`old_ver === new_ver` always), so a mutation using the stale `$old_ver` instead of `$new_ver` was undetectable. Fixed with a fixture that actually bumps the version (`simulateGitPullVersionBump`) and a version-aware post-flight stub (`postFlightExpectedTarget`) — the stale-value mutation now fails with a target mismatch.

**LOW-4 (test)**: the outer `( cmd_restart ) || restart_status=$?` subshell had no test proving it actually contains an `exit()` — the only real-cmd_restart test used a resolver refusal, which `return`s. New `cmdRestartStubExits` harness option drives a stub that `exit`s instead, proving post-flight still runs afterward (proof the subshell is load-bearing, not vestigial).

**LOW-6**: `--target=vX.Y.Z` (equals form) was not detected, only `--target vX.Y.Z` was — exactly the silently-ignored pin this fix exists to eliminate. Both forms now detected via `case`; the warning also moved to stderr (was stdout — piped fleet automation would have read it as data).

**MEDIUM-5 (re-checked, not actionable)**: resolved by #259 landing. Help text now explicitly states `--target` IS honored on the full path (per #259) and contrasts it with the light path's own deliberate no-op, instead of leaving the full path's status ambiguous.

12 new/updated tests. Also ported the `execFileSync` → `spawnSync` harness stderr-capture fix from the sibling #242/PR #252 branch (not yet merged to main, so not inherited by this rebase) — several of this round's own tests need stderr on a successful run.

### Mutation table (re-run in full on the rebased+fixed head)

| # | Mutation | Named test(s) caught |
|---|---|---|
| 1 | Removed the `--post-flight-only` call from inside the (non-"?") branch | 5: money test, control, MEDIUM-3, LOW-4, MEDIUM-1 control |
| 2 | Neutralized the combined exit-code check | 3: pre-existing #224 test + money test + resolver-refusal-not-masked test |
| 3 | Removed the `--target` detection block entirely | 3: all three `--target` runtime tests |
| 4 | Removed `cmd_update_help`'s `Notes:` section | 1: help-text test |
| 5 | Reverted to `\|\| true` (discarding restart's exit status) | 2: pre-existing #224 test + resolver-refusal-not-masked test |
| 6 (new) | Removed MEDIUM-1's `new_ver == "?"` guard | Exactly 1: MEDIUM-1 money test |
| 7 (new) | Reverted MEDIUM-2's subshell to bare `cmd_usage` | Exactly 2: both MEDIUM-2 tests |
| 8 (new) | Swapped in the stale `$old_ver` (the literal MEDIUM-3 bug) | Exactly 1: MEDIUM-3 test |
| 9 (new) | Removed only the subshell parens (kept status capture) | Exactly 1: LOW-4 test |
| 10 (new) | Removed only the `--target=*` case arm | Exactly 1: LOW-6 equals-form test |

Full suite green (712/720 locally; remaining 8 are the pre-existing `ltBoot` cluster, #248, present at merge-base too).

---

## Update: rebased onto merged main (5ce59f9 → includes #252 + #265), semantic reconciliation

`origin/main` moved to include #252 (merged) and #265 (macOS restart-target identity verification, `scripts/lib/restart-unit.mjs`/`scripts/upgrade.mjs` only — does not touch `ocp`). Rebase hit two conflicts in `test-features.mjs` (both purely additive-parameter collisions between this PR's own harness additions and #252's, not disagreements — `ocp` itself auto-merged cleanly with zero conflicts):

1. `_bwHarnessRun`'s parameter list: #252 added `curlResponses`/`adminKey`; this PR independently added `simulateGitPullVersionBump`/`postFlightExpectedTarget`/`cmdRestartStubExits` at the same insertion point. Resolved by union — both sets of parameters kept.
2. The `execFileSync` → `spawnSync` harness fix: this PR had ported a duplicate of #252's own fix (both branches hit the identical stderr-capture gap independently). Resolved by keeping the single canonical version, dropping the redundant port.

Three semantic checks done per the coordinator's request, not just a mechanical merge:

1. **`cmd_usage` is where the two PRs meet.** #252 rewired its failure output (new stderr guards, `_pyfail` wiring) but left `cmd_usage`'s own two PRE-EXISTING curl-unreachable guards untouched (still `exit 1`, still stdout — confirmed by diffing `d2ea5a7..origin/main -- ocp`). This PR's MEDIUM-2 fix (`( cmd_usage ) || true` inside `cmd_restart`) only relies on subshell containment of *whatever* causes `cmd_usage` to terminate the process — it doesn't care which internal guard fired or which stream it wrote to. Re-verified with both MEDIUM-2 tests passing post-rebase, and mutation 7 (revert to bare `cmd_usage`) reproduces the *exact same* failure signature as before rebase (`stdout` still contains `#252`'s unchanged `"Error: proxy unreachable"` text) — confirming the message the operator sees is the one #252 intended, unchanged.
2. **`new_ver`/`old_ver`.** Diffed byte-for-byte identical between the old base and the new one (`git show origin/main:ocp | grep new_ver=`) — #252 never touched `_cmd_update_light`. MEDIUM-1's trigger condition is unaffected; mutation 6 still fails on exactly the same test.
3. **Harness duplication.** Confirmed a single `spawnSync` import, a single `const _bwRes = spawnSync(...)` call site, no leftover conflict markers.

Full mutation table re-run on the rebased+reconciled head — **all 10 entries**, not just the touched ones — each restored from a `cp` file backup, `shasum -a 256`-verified byte-identical before the next mutation, anchor asserted before every mutation. Every result matches the pre-rebase table exactly (same test names, same counts) — no coverage silently dropped:

| # | Mutation | Named test(s) caught (unchanged from pre-rebase) |
|---|---|---|
| 1 | Removed the `--post-flight-only` call | 5: money test, control, MEDIUM-3, LOW-4, MEDIUM-1 control |
| 2 | Neutralized the combined exit-code check | 3: pre-existing #224 test + money test + resolver-refusal-not-masked |
| 3 | Removed the `--target` detection block | 3: all three `--target` runtime tests |
| 4 | Removed `cmd_update_help`'s `Notes:` section | 1: help-text test |
| 5 | Reverted to `\|\| true` (discarding restart status) | 2: pre-existing #224 test + resolver-refusal-not-masked |
| 6 | Removed MEDIUM-1's `new_ver == "?"` guard | Exactly 1: MEDIUM-1 money test |
| 7 | Reverted MEDIUM-2's subshell to bare `cmd_usage` | Exactly 2: both MEDIUM-2 tests (same failure signature as pre-rebase, confirming reconciliation point 1) |
| 8 | Swapped in the stale `$old_ver` | Exactly 1: MEDIUM-3 test |
| 9 | Removed only the subshell parens | Exactly 1: LOW-4 test |
| 10 | Removed only the `--target=*` case arm | Exactly 1: LOW-6 equals-form test |

Full suite: 761/771 locally; remaining 10 failures are the pre-existing `ltBoot` cluster (#248) — under active work by another agent right now per the coordinator, so this count is expected to shift independent of this PR.
