### PR TITLE
fix(ocp): guard _curl's empty-array expansion under bash 3.2 set -u

### DIFF
--- a/ocp
+++ b/ocp
@@ -18,8 +18,20 @@ elif [[ -f "$HOME/.ocp/admin-key" ]]; then
 fi
 
 # Wrapper: curl with optional auth
+#
+# Issue #256: on the default single-user install (no OCP_ADMIN_KEY, no ~/.ocp/admin-key)
+# _AUTH_ARGS stays an empty array. GNU bash 3.2.57 -- the last GPLv2 release, which is what
+# macOS ships as /bin/bash for licensing reasons and cannot be updated -- raises "unbound
+# variable" for "${arr[@]}" on a zero-element array under `set -u` (ocp:7), even though POSIX
+# and bash >= 4.4 correctly expand this to nothing. `${_AUTH_ARGS[@]+"${_AUTH_ARGS[@]}"}` is the
+# 3.2-safe idiom: it expands to nothing when the array is empty/unset, and to the array's
+# elements (word-preserving, same as a plain "${_AUTH_ARGS[@]}") otherwise, on every bash version
+# from 3.2 through current. Audited: this is the only user-defined array expansion anywhere in
+# this script (grep for `[@]`/`[*]`) -- every other such expansion is either the unbraced special
+# parameter "$@" (safe on this bash even when empty) or bash's own always-populated
+# ${BASH_SOURCE[0]}.
 _curl() {
-  curl "${_AUTH_ARGS[@]}" "$@"
+  curl "${_AUTH_ARGS[@]+"${_AUTH_ARGS[@]}"}" "$@"
 }
 
 _json() { python3 -m json.tool 2>/dev/null || cat; }

--- a/ocp-connect
+++ b/ocp-connect
@@ -609,6 +609,20 @@ print(k if k else '')
   echo ""
 
   # Step 5: Detect shell rc files and OS
+  #
+  # Issue #256 FOLD-IN 3 (independent review of the ocp `_curl`/_AUTH_ARGS fix): this is the only
+  # OTHER user-defined bash array in this repo's two CLI scripts (ocp's own audit was scoped to
+  # `ocp` alone -- corrected here rather than left overclaiming "the only array in the whole
+  # script" without naming which script). At the time of that review this array was NOT actually
+  # empty-expandable: all three branches below (fish / macOS / Linux-other) guarantee at least one
+  # element by construction (the macOS branch unconditionally appends ~/.zshrc; the Linux-other
+  # branch has its own explicit fallback right below, keyed off `${#rc_files[@]}` -- the LENGTH
+  # operator, which IS safe on an empty array even under bash 3.2 + set -u, unlike a bare element
+  # expansion). Still fixed with the same `${arr[@]+"${arr[@]}"}` idiom used for `_AUTH_ARGS`
+  # (verified behaviorally, same as that fix, to be a no-op when the array is non-empty): the
+  # invariant above is "one edit away" from breaking (e.g. if the macOS branch's unconditional
+  # zshrc append is ever made conditional) and re-auditing every future edit against a documented
+  # invariant is worse than removing the hazard outright.
   local rc_files=()
   local is_mac=false
   [[ "$(uname)" == "Darwin" ]] && is_mac=true
@@ -634,7 +648,7 @@ print(k if k else '')
   fi
 
   # Step 6: Remove any previously written OCP LAN lines (idempotent) from all rc files
-  for rc_file in "${rc_files[@]}"; do
+  for rc_file in "${rc_files[@]+"${rc_files[@]}"}"; do
     if [[ -f "$rc_file" ]]; then
       local tmp_rc
       tmp_rc=$(mktemp)
@@ -663,7 +677,7 @@ PYEOF
   done
 
   # Step 7: Append new config to all rc files
-  for rc_file in "${rc_files[@]}"; do
+  for rc_file in "${rc_files[@]+"${rc_files[@]}"}"; do
     {
       echo ""
       echo "# OCP LAN (added by ocp connect)"
@@ -676,7 +690,7 @@ PYEOF
   done
 
   echo "  Shell config:"
-  for rc_file in "${rc_files[@]}"; do
+  for rc_file in "${rc_files[@]+"${rc_files[@]}"}"; do
     echo "    ✓ $(basename "$rc_file")"
   done
   echo "    OPENAI_BASE_URL=$base_url/v1"
@@ -750,7 +764,7 @@ PYEOF
 
   echo ""
   echo "  Done. Reload your shell to apply:"
-  for rc_file in "${rc_files[@]}"; do
+  for rc_file in "${rc_files[@]+"${rc_files[@]}"}"; do
     echo "    source $rc_file"
   done
 }

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -9781,6 +9781,152 @@ test("#224: scripts/upgrade.mjs --resolve-restart (real subprocess, not mocked) 
     `-- see comment above); stderr=${JSON.stringify(stderr)}`);
 });
 
+// ── ocp `_curl`'s empty-array expansion under bash 3.2 + `set -u` (issue #256) ─────────────────
+// `ocp`'s auth wrapper (near the top of the file) is:
+//   _AUTH_ARGS=()
+//   if [[ -n "${OCP_ADMIN_KEY:-}" ]]; then _AUTH_ARGS=(-H "Authorization: Bearer $OCP_ADMIN_KEY")
+//   elif [[ -f "$HOME/.ocp/admin-key" ]]; then _AUTH_ARGS=(-H "...$(cat "$HOME/.ocp/admin-key")")
+//   fi
+//   _curl() { curl "${_AUTH_ARGS[@]}" "$@"; }
+// On the default single-user install (no OCP_ADMIN_KEY, no ~/.ocp/admin-key) `_AUTH_ARGS` stays
+// an empty array. `ocp:7` runs under `set -euo pipefail`. GNU bash 3.2.57 — the LAST GPLv2
+// release, which is what macOS ships as `/bin/bash` for licensing reasons and cannot be updated —
+// raises "unbound variable" for `"${arr[@]}"` on a zero-element array, even though POSIX and
+// bash >= 4.4 correctly expand this to nothing. Every `_curl`-based command (`ocp usage --by-key`,
+// `ocp keys`) therefore dies before ever reaching the network call, on exactly the configuration
+// most single-user installs run.
+//
+// Audit performed for this fix (grep for every `"${...[@]}"` / `"${...[*]}"` expansion in `ocp`,
+// per this issue's own ask): `_AUTH_ARGS` at `ocp:22` is the ONLY user-defined bash array in the
+// whole script (the only `name=(...)` assignments in the file), and it is expanded at exactly one
+// call site. Every other `[...]`-shaped expansion is one of:
+//   - `"$@"` (11 sites) — the UNBRACED special parameter. Verified directly against this host's
+//     real /bin/bash 3.2.57: `"$@"` with zero positional parameters does NOT raise "unbound
+//     variable" under `set -u`, in a function or at top level. (The braced forms `"${@}"`/
+//     `"${*}"` DO raise it on this same bash — bash treats the braced special-parameter form
+//     through the same zero-element-array code path as a real array. `ocp` uses neither braced
+//     form anywhere — grep confirms zero hits.)
+//   - `${BASH_SOURCE[0]}` (3 sites) — a bash-maintained array bash itself always populates for a
+//     running script; not user-controlled and never empty in this script's usage.
+// Conclusion: `ocp:22` is the only hazardous site. Fixed here with the 3.2-safe idiom
+// `${_AUTH_ARGS[@]+"${_AUTH_ARGS[@]}"}` (verified on this host's real bash 3.2.57 to expand to
+// nothing when the array is empty, and to preserve every element, including embedded spaces,
+// when it is not — both properties re-verified below, behaviorally, not by reading the source).
+//
+// Design decision recorded here (not just the PR body): fix the expansion, do NOT add a minimum-
+// bash-version gate. A version gate would turn "one subcommand crashes" into "the tool refuses to
+// run at all" for exactly the population this bug affects — stock macOS, which cannot update
+// `/bin/bash` past 3.2.57 for licensing reasons and is not "an oversight", it is macOS's permanent
+// default state. The idiom fix is strictly better: it is correct on 3.2 AND a no-op on bash >= 4.4
+// (re-verified below), so there is no version trade-off to make.
+//
+// Interpreter pinning (per this issue's own ask): tests below invoke `/bin/bash` by absolute path,
+// not `bash` resolved off some ambient $PATH and not `env bash` — on THIS host that is genuinely
+// bash 3.2.57, so a failure here is a real reproduction, not a modern-bash false negative. Stated
+// honestly: on a Linux CI runner (this repo's `.github/workflows/test.yml`), `/bin/bash` is
+// typically bash 5.x, which never exhibits the empty-array "unbound variable" behavior regardless
+// of this fix — the pre-fix/post-fix distinction below is therefore only load-bearing on a host
+// whose real `/bin/bash` is old (macOS being the known, common case). On such a host these tests
+// still assert real, meaningful behavior (the command completes and actually reaches curl), they
+// just cannot distinguish buggy-vs-fixed the way they can on this dev host. This is a property of
+// which bash binary is present, not a gap in the harness — recorded rather than left implicit.
+console.log("\nocp `_curl` empty-array expansion under bash 3.2 `set -u` (issue #256):");
+
+const _cuOcpPath = spotJoin(_spotDir, "ocp");
+
+// Runs the REAL, unmodified `ocp` file (never a hand-copied slice) via `/bin/bash <path> <args>`,
+// with its own scratch $HOME (no `.ocp/admin-key` — the file is simply never created) and its own
+// scratch $PATH carrying a stub `curl`. `OCP_ADMIN_KEY` is not merely set empty but genuinely
+// ABSENT from the child's environment: `execFileSync`'s `env` option REPLACES the child's
+// environment wholesale rather than merging with this process's own, so the child cannot inherit
+// a real `OCP_ADMIN_KEY` even if this test-runner process happens to have one. This is the exact
+// configuration the issue names: "the common single-user, no-multi-key-auth case".
+// Never touches the real, separately-running production OCP: the stub `curl` on the scratch $PATH
+// intercepts every call `_curl`/`ocp` would otherwise make, so no real network I/O happens at all.
+function _cuRun(args, curlCaseBody) {
+  const root = _ltMkdtemp(join(_ltTmp(), "ocp-curl-emptyarr-"));
+  try {
+    const home = join(root, "home");
+    const bin = join(root, "bin");
+    tMkdirSync(home, { recursive: true });
+    tMkdirSync(bin, { recursive: true });
+
+    const logPath = join(root, "log.txt");
+    testWriteFile(logPath, "");
+
+    const curlStubPath = join(bin, "curl");
+    testWriteFile(curlStubPath, [
+      `#!/usr/bin/env bash`,
+      `echo "FAKE-CURL-CALL $*" >> "${logPath}"`,
+      `case "$*" in`,
+      ...curlCaseBody,
+      `esac`,
+      "",
+    ].join("\n"));
+    _ltChmod(curlStubPath, 0o755);
+
+    const env = {
+      HOME: home,
+      PATH: `${bin}:/usr/bin:/bin`,
+    };
+
+    let stdout = "", stderr = "", status = 0;
+    try {
+      stdout = execFileSync("/bin/bash", [_cuOcpPath, ...args], { cwd: root, env, encoding: "utf8" });
+    } catch (e) {
+      stdout = e.stdout ?? "";
+      stderr = e.stderr ?? "";
+      status = typeof e.status === "number" ? e.status : 1;
+    }
+    const log = testExistsSync(logPath) ? _ltRead(logPath, "utf8").split("\n").filter(Boolean) : [];
+    return { stdout, stderr, status, log };
+  } finally {
+    _ltRm(root, { recursive: true, force: true });
+  }
+}
+
+test("ocp `ocp keys` (list) must not die with 'unbound variable' when _AUTH_ARGS is empty (bash 3.2 set -u, issue #256)", () => {
+  const r = _cuRun(["keys"], [
+    `  *"/api/keys"*)`,
+    `    echo '{"keys": []}'`,
+    `    exit 0`,
+    `    ;;`,
+    `  *)`,
+    `    echo "FAKE-CURL: unhandled invocation: $*" >&2`,
+    `    exit 90`,
+    `    ;;`,
+  ]);
+  assert.ok(!/unbound variable/.test(r.stderr),
+    `must not crash with 'unbound variable' (the #256 bug); stderr=${JSON.stringify(r.stderr)}`);
+  assert.equal(r.status, 0,
+    `expected a clean exit; status=${r.status} stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(r.log.some((l) => l.startsWith("FAKE-CURL-CALL")),
+    `_curl must actually reach curl (proves the array expansion itself did not crash first); log=${JSON.stringify(r.log)}`);
+  assert.ok(r.stdout.includes("No API keys configured."),
+    `expected the real list-keys output all the way through; stdout=${JSON.stringify(r.stdout)}`);
+});
+
+test("ocp `ocp usage --by-key` must not die with 'unbound variable' when _AUTH_ARGS is empty (bash 3.2 set -u, issue #256)", () => {
+  const r = _cuRun(["usage", "--by-key"], [
+    `  *"/api/usage"*)`,
+    `    echo '{"byKey": []}'`,
+    `    exit 0`,
+    `    ;;`,
+    `  *)`,
+    `    echo "FAKE-CURL: unhandled invocation: $*" >&2`,
+    `    exit 90`,
+    `    ;;`,
+  ]);
+  assert.ok(!/unbound variable/.test(r.stderr),
+    `must not crash with 'unbound variable' (the #256 bug); stderr=${JSON.stringify(r.stderr)}`);
+  assert.equal(r.status, 0,
+    `expected a clean exit; status=${r.status} stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(r.log.some((l) => l.startsWith("FAKE-CURL-CALL")),
+    `_curl must actually reach curl (proves the array expansion itself did not crash first); log=${JSON.stringify(r.log)}`);
+  assert.ok(r.stdout.includes("No usage data yet."),
+    `expected the real by-key usage output all the way through; stdout=${JSON.stringify(r.stdout)}`);
+});
+
 runAsyncTests().then(() => Promise.all(pendingAsync)).then(() => {
   closeDb();
   console.log(`\n=== Results: ${passed} passed, ${failed} failed ===\n`);

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -9797,9 +9797,9 @@ test("#224: scripts/upgrade.mjs --resolve-restart (real subprocess, not mocked) 
 // most single-user installs run.
 //
 // Audit performed for this fix (grep for every `"${...[@]}"` / `"${...[*]}"` expansion in `ocp`,
-// per this issue's own ask): `_AUTH_ARGS` at `ocp:22` is the ONLY user-defined bash array in the
-// whole script (the only `name=(...)` assignments in the file), and it is expanded at exactly one
-// call site. Every other `[...]`-shaped expansion is one of:
+// per this issue's own ask): `_AUTH_ARGS` at `ocp:22` is the ONLY user-defined bash array IN `ocp`
+// ITSELF (the only `name=(...)` assignment in that one file), and it is expanded at exactly one
+// call site. Every other `[...]`-shaped expansion in `ocp` is one of:
 //   - `"$@"` (11 sites) — the UNBRACED special parameter. Verified directly against this host's
 //     real /bin/bash 3.2.57: `"$@"` with zero positional parameters does NOT raise "unbound
 //     variable" under `set -u`, in a function or at top level. (The braced forms `"${@}"`/
@@ -9808,10 +9808,21 @@ test("#224: scripts/upgrade.mjs --resolve-restart (real subprocess, not mocked) 
 //     form anywhere — grep confirms zero hits.)
 //   - `${BASH_SOURCE[0]}` (3 sites) — a bash-maintained array bash itself always populates for a
 //     running script; not user-controlled and never empty in this script's usage.
-// Conclusion: `ocp:22` is the only hazardous site. Fixed here with the 3.2-safe idiom
+// Conclusion: `ocp:22` is the only hazardous site IN `ocp`. Fixed here with the 3.2-safe idiom
 // `${_AUTH_ARGS[@]+"${_AUTH_ARGS[@]}"}` (verified on this host's real bash 3.2.57 to expand to
 // nothing when the array is empty, and to preserve every element, including embedded spaces,
 // when it is not — both properties re-verified below, behaviorally, not by reading the source).
+//
+// SCOPE CORRECTION (independent review, FOLD-IN 3): the paragraph above, as originally written,
+// said "_AUTH_ARGS is the ONLY user-defined array in the whole script" without naming which
+// script — this repo ships TWO bash CLI entrypoints (`ocp` and `ocp-connect`), and the audit
+// above was scoped to `ocp` only. `ocp-connect` has its own user-defined array (`rc_files`,
+// declared `ocp-connect:612`, expanded bare at four sites) with the identical affected
+// population (any bash 3.2 host) — it happened not to be a LIVE bug (every code path guarantees
+// at least one element before any expansion runs), but was "one edit away", per the same review.
+// Fixed with the same idiom in `ocp-connect` directly (see that file's own comment at its
+// declaration) rather than left as a documented-but-fragile invariant. The static lint test
+// immediately below covers BOTH files going forward, so this scope gap cannot recur silently.
 //
 // Design decision recorded here (not just the PR body): fix the expansion, do NOT add a minimum-
 // bash-version gate. A version gate would turn "one subcommand crashes" into "the tool refuses to
@@ -9857,7 +9868,21 @@ function _cuRun(args, curlCaseBody) {
     const curlStubPath = join(bin, "curl");
     testWriteFile(curlStubPath, [
       `#!/usr/bin/env bash`,
+      // Issue #256 FOLD-IN 2 (independent review): the original stub logged only `$*` (a
+      // space-flattened join of all args), which cannot distinguish "curl received zero extra
+      // args" from "curl received one spurious EMPTY-STRING arg, then the real args" -- exactly
+      // the shape of the plausible near-miss fix `${_AUTH_ARGS[@]:-}` (verified separately: on
+      // this host's real bash 3.2, that expands an EMPTY array to ONE empty-string argument, not
+      // zero -- real curl rejects a literal blank argument with "option : blank argument where
+      // content is expected", exit 2). `$*` silently absorbed that spurious empty element into
+      // the surrounding whitespace, so a test asserting only `startsWith("FAKE-CURL-CALL")` and a
+      // clean exit could not tell the two forms apart. Recording argc and each argv element on
+      // its own line (never joined) makes an inserted empty leading argument visible and
+      // countable, independent of `$*`'s own routing use below (kept unchanged -- it only
+      // selects which canned response the stub returns, it is not the safety assertion).
       `echo "FAKE-CURL-CALL $*" >> "${logPath}"`,
+      `printf 'FAKE-CURL-ARGC=%d\\n' "$#" >> "${logPath}"`,
+      `for _a in "$@"; do printf 'FAKE-CURL-ARG=%s\\n' "$_a" >> "${logPath}"; done`,
       `case "$*" in`,
       ...curlCaseBody,
       `esac`,
@@ -9885,6 +9910,17 @@ function _cuRun(args, curlCaseBody) {
   }
 }
 
+// Issue #256 FOLD-IN 2: reconstructs the EXACT argv curl actually received, from the
+// element-by-element log lines the stub above now writes (see that stub's own comment) --
+// distinguishes "zero extra arguments" from "one spurious empty-string argument, then the real
+// ones", which `$*`-based logging could not.
+function _cuArgv(log) {
+  const argcLine = log.find((l) => l.startsWith("FAKE-CURL-ARGC="));
+  const argc = argcLine ? Number(argcLine.slice("FAKE-CURL-ARGC=".length)) : null;
+  const args = log.filter((l) => l.startsWith("FAKE-CURL-ARG=")).map((l) => l.slice("FAKE-CURL-ARG=".length));
+  return { argc, args };
+}
+
 test("ocp `ocp keys` (list) must not die with 'unbound variable' when _AUTH_ARGS is empty (bash 3.2 set -u, issue #256)", () => {
   const r = _cuRun(["keys"], [
     `  *"/api/keys"*)`,
@@ -9904,6 +9940,17 @@ test("ocp `ocp keys` (list) must not die with 'unbound variable' when _AUTH_ARGS
     `_curl must actually reach curl (proves the array expansion itself did not crash first); log=${JSON.stringify(r.log)}`);
   assert.ok(r.stdout.includes("No API keys configured."),
     `expected the real list-keys output all the way through; stdout=${JSON.stringify(r.stdout)}`);
+  // Issue #256 FOLD-IN 2: pins the EXACT argv, not just "curl was reached and didn't crash" --
+  // catches the plausible near-miss `${_AUTH_ARGS[@]:-}` (passes the two assertions above, since
+  // it doesn't crash and does reach curl, but injects a spurious leading empty-string argument).
+  const { argc, args } = _cuArgv(r.log);
+  assert.equal(argc, 4,
+    `expected exactly 4 curl arguments (-sf, --max-time, 5, the URL) -- an extra leading empty ` +
+    `string (the ${"${_AUTH_ARGS[@]:-}"} near-miss) would make this 5; got argc=${argc} args=${JSON.stringify(args)}`);
+  assert.equal(args[0], "-sf",
+    `expected the first REAL argument, not an injected empty string; args=${JSON.stringify(args)}`);
+  assert.ok(args.every((a) => a !== ""),
+    `no curl argument may be an empty string; args=${JSON.stringify(args)}`);
 });
 
 test("ocp `ocp usage --by-key` must not die with 'unbound variable' when _AUTH_ARGS is empty (bash 3.2 set -u, issue #256)", () => {
@@ -9925,6 +9972,113 @@ test("ocp `ocp usage --by-key` must not die with 'unbound variable' when _AUTH_A
     `_curl must actually reach curl (proves the array expansion itself did not crash first); log=${JSON.stringify(r.log)}`);
   assert.ok(r.stdout.includes("No usage data yet."),
     `expected the real by-key usage output all the way through; stdout=${JSON.stringify(r.stdout)}`);
+  // Issue #256 FOLD-IN 2: same exact-argv pinning as the "ocp keys" test above.
+  const { argc, args } = _cuArgv(r.log);
+  assert.equal(argc, 4,
+    `expected exactly 4 curl arguments (-sf, --max-time, 15, the URL) -- an extra leading empty ` +
+    `string (the ${"${_AUTH_ARGS[@]:-}"} near-miss) would make this 5; got argc=${argc} args=${JSON.stringify(args)}`);
+  assert.equal(args[0], "-sf",
+    `expected the first REAL argument, not an injected empty string; args=${JSON.stringify(args)}`);
+  assert.ok(args.every((a) => a !== ""),
+    `no curl argument may be an empty string; args=${JSON.stringify(args)}`);
+});
+
+// ── issue #256 FOLD-IN 1 (independent review): static lint, catches what the runtime tests
+// above structurally cannot on Linux CI ────────────────────────────────────────────────────────
+// `.github/workflows/test.yml` runs on `ubuntu-latest`, whose `/bin/bash` is 5.x -- the
+// empty-array-under-set-u "unbound variable" behavior this whole issue is about NEVER fires on
+// bash >= 4.4, on ANY input. The two runtime tests above therefore pass on that CI runner WITH OR
+// WITHOUT the fix -- they are a real regression guard only on a host whose real `/bin/bash` is
+// old (this dev machine; stock macOS generally). This static check closes that gap: it scans the
+// actual source text of `ocp` and `ocp-connect` for every user-defined bash array declaration,
+// then asserts every expansion of that array is wrapped in the 3.2-safe idiom
+// (`${name[@]+"${name[@]}"}`) rather than expanded bare. A future regression that reintroduces a
+// bare `${anything[@]}` expansion of a user-defined array fails THIS check on every platform,
+// including the Linux CI runner where the runtime tests cannot see it at all.
+//
+// Deliberately narrow, per this repo's own testing-discipline note ("a textual assertion is fine
+// for a premise of the harness or a slice boundary, never the behavior under test"): this check
+// is NOT a substitute for the runtime tests above (it cannot prove the idiom actually expands
+// correctly at runtime -- that's what the behavioral tests already prove, on a real bash 3.2). It
+// is a structural guard against the ONE way this specific bug class can silently reappear in
+// source that a dynamic test on Linux CI cannot observe: a hand-edit that deletes the idiom.
+// `${#name[@]}` (the LENGTH operator, not an element expansion) is correctly excluded -- verified
+// separately (see ocp-connect's own `rc_files` audit comment) that it is safe on bash 3.2 even on
+// an empty array, so it is not part of this bug class and must not be flagged.
+console.log("\nocp/ocp-connect: no user-defined bash array expanded bare under set -u (static lint, issue #256 FOLD-IN 1):");
+
+// Finds every `name=(...)`, `name+=(...)`, `local name=(...)` bash array ASSIGNMENT in `source`
+// and returns the unique array names declared. Deliberately does not attempt full bash parsing --
+// scoped to exactly the declaration shape used anywhere in this repo's two CLI scripts today
+// (verified below: this must find at least one name in each file, or the premise itself is wrong).
+function _lintArrayDeclNames(source) {
+  const names = new Set();
+  const re = /^\s*(?:local\s+|declare\s+-a\s+)?([A-Za-z_][A-Za-z0-9_]*)\+?=\(/gm;
+  let m;
+  while ((m = re.exec(source))) names.add(m[1]);
+  return [...names];
+}
+
+// Blanks out every FULL comment line (optional leading whitespace, then `#`) so prose explaining
+// the idiom -- which necessarily has to WRITE OUT `${name[@]}` in order to describe it, exactly
+// as this file's own comments above and ocp/ocp-connect's own fix comments do -- is never mistaken
+// for a live, unguarded expansion. Deliberately line-based, not a full bash tokenizer: correct for
+// this repo's actual comment style (every explanatory comment in ocp/ocp-connect/this file is a
+// whole line starting with `#`), and a false NEGATIVE this simple approach could theoretically
+// permit (an unguarded expansion hidden after a trailing `# comment` on the SAME line as real
+// code) does not occur anywhere in either script today -- verified by the fact this function,
+// before this fix, correctly found nothing to strip on any CODE line, only on pure-comment ones.
+function _lintBlankCommentLines(source) {
+  return source.split("\n").map((line) => (/^\s*#/.test(line) ? "" : line)).join("\n");
+}
+
+// For each declared array name, removes every occurrence of the SAFE idiom
+// `${name[@]+"${name[@]}"}` from the source first (so its own inner `${name[@]}` -- which is
+// literally present as the idiom's substitution text -- is never mistaken for a bare, unguarded
+// expansion), then checks whether any `${name[@]}` / `${name[*]}` survives in what's left. A
+// survivor is an unguarded expansion. `${#name[@]}` (length) is a DIFFERENT parameter expansion
+// form entirely (no `[@]`/`[*]` immediately after `name`) and is never matched by either regex
+// below -- excluded by construction, not by a special case.
+function _lintUnguardedArrayExpansions(source, names) {
+  const code = _lintBlankCommentLines(source);
+  const findings = [];
+  for (const name of names) {
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const guardedRe = new RegExp(`\\$\\{${escaped}\\[@\\]\\+"\\$\\{${escaped}\\[@\\]\\}"\\}`, "g");
+    const withoutGuarded = code.replace(guardedRe, "");
+    const bareRe = new RegExp(`\\$\\{${escaped}\\[[@*]\\]\\}`, "g");
+    const bareMatches = withoutGuarded.match(bareRe);
+    if (bareMatches) findings.push({ name, count: bareMatches.length });
+  }
+  return findings;
+}
+
+const _lintOcpPath = spotJoin(_spotDir, "ocp");
+const _lintOcpConnectPath = spotJoin(_spotDir, "ocp-connect");
+
+test("lint premise: array-declaration scan finds at least one array in ocp and in ocp-connect (anchor/regex-drift guard)", () => {
+  const ocpNames = _lintArrayDeclNames(_ltRead(_lintOcpPath, "utf8"));
+  const ocpConnectNames = _lintArrayDeclNames(_ltRead(_lintOcpConnectPath, "utf8"));
+  assert.ok(ocpNames.includes("_AUTH_ARGS"), `expected to find _AUTH_ARGS in ocp; found=${JSON.stringify(ocpNames)}`);
+  assert.ok(ocpConnectNames.includes("rc_files"), `expected to find rc_files in ocp-connect; found=${JSON.stringify(ocpConnectNames)}`);
+});
+
+test("ocp: every user-defined array expansion is guarded (no bare \"${name[@]}\" under set -u)", () => {
+  const source = _ltRead(_lintOcpPath, "utf8");
+  const names = _lintArrayDeclNames(source);
+  const findings = _lintUnguardedArrayExpansions(source, names);
+  assert.deepEqual(findings, [],
+    `unguarded array expansion(s) in ocp: ${JSON.stringify(findings)} -- wrap with ` +
+    `\${name[@]+"\${name[@]}"} (see _AUTH_ARGS for the pattern)`);
+});
+
+test("ocp-connect: every user-defined array expansion is guarded (no bare \"${name[@]}\" under set -u)", () => {
+  const source = _ltRead(_lintOcpConnectPath, "utf8");
+  const names = _lintArrayDeclNames(source);
+  const findings = _lintUnguardedArrayExpansions(source, names);
+  assert.deepEqual(findings, [],
+    `unguarded array expansion(s) in ocp-connect: ${JSON.stringify(findings)} -- wrap with ` +
+    `\${name[@]+"\${name[@]}"} (see rc_files for the pattern)`);
 });
 
 runAsyncTests().then(() => Promise.all(pendingAsync)).then(() => {


### PR DESCRIPTION
## Summary

`ocp`'s `_curl()` wrapper expands `"${_AUTH_ARGS[@]}"`, a bash array that stays empty on the
default single-user install (no `OCP_ADMIN_KEY`, no `~/.ocp/admin-key`). GNU bash 3.2.57 — the
last GPLv2 release, which is what macOS ships as `/bin/bash` for licensing reasons and cannot be
upgraded — raises `unbound variable` for `"${arr[@]}"` on a zero-element array under `set -u`
(`ocp:7`), even though POSIX and bash >= 4.4 correctly expand it to nothing. Every `_curl`-based
command (`ocp usage --by-key`, `ocp keys`) died before ever reaching the network call, on exactly
the configuration most single-user installs run — invisible on the maintainer's own machine only
because that machine has an admin key.

Reproduced end-to-end per the issue's own evidence (not redone here); fixed with the 3.2-safe
idiom, audited every other bracketed expansion in `ocp`, and added regression tests that exercise
the real, unmodified `ocp` under this host's real `/bin/bash` 3.2.57.

**Does not touch `server.mjs`.**

Closes #256

---

## ✅ Independent review: approved, three fold-ins requested and landed

All three folded in below (`ocp-connect` hardening, a Linux-CI-effective static lint, and
exact-argv pinning in the runtime tests) — see "Fold-ins from review" near the bottom.

---

## Audit: every `"${...[@]}"` / `"${...[*]}"` expansion **in `ocp`**

```
$ grep -n '\[@\]' ocp
22:  curl "${_AUTH_ARGS[@]}" "$@"
598:    self_r="${BASH_SOURCE[0]}"
774:  self="${BASH_SOURCE[0]}"
1029:  self="${BASH_SOURCE[0]}"

$ grep -nE '^\s*[A-Za-z_][A-Za-z0-9_]*\+?=\(' ocp     # every array assignment in the file
13:_AUTH_ARGS=()
15:  _AUTH_ARGS=(-H "Authorization: Bearer $OCP_ADMIN_KEY")
17:  _AUTH_ARGS=(-H "Authorization: Bearer $(cat "$HOME/.ocp/admin-key")")

$ grep -nE '\$\{?\*\}?|\$\{@\}' ocp                    # braced special-parameter forms
(no hits)
```

`_AUTH_ARGS` is the **only user-defined array in `ocp` itself**, expanded at **exactly one call
site** (`ocp:22`). Every other bracketed expansion in `ocp` is one of:

- **`"$@"` (11 sites)** — the *unbraced* special parameter. Verified directly on this host's real
  `/bin/bash` 3.2.57 that this does **not** raise `unbound variable` with zero positional
  parameters, either inside a function or at top level:
  ```
  $ /bin/bash -c 'set -u; f(){ echo "$@"; echo ok; }; f'; echo exit=$?
  ok
  exit=0
  ```
  The *braced* forms `"${@}"` / `"${*}"` **do** raise it on the same bash (bash routes the braced
  special-parameter form through the same zero-element-array code path as a real array):
  ```
  $ /bin/bash -c 'set -u; f(){ echo "${@}"; echo ok; }; f'
  /bin/bash: @: unbound variable
  ```
  `ocp` uses **only** the unbraced form — zero hits for `${@}`/`${*}` anywhere in the file — so
  none of the 11 `"$@"` sites are hazardous.
- **`${BASH_SOURCE[0]}` (3 sites)** — a bash-maintained array bash itself always populates for a
  running script; not user-controlled, never empty in this usage.

**Conclusion: `ocp:22` is the only hazardous site in `ocp`.** (This repo ships a *second* bash CLI
entrypoint, `ocp-connect`, which was **not** in scope for this original audit — reviewer caught
that the wording above overclaimed "the only array in the whole script" without naming which
script. `ocp-connect` has its own array, `rc_files`, with the identical latent shape; see
"Fold-ins from review" below for the audit correction and the fix.)

## Fix and design decision

```bash
_curl() {
  curl "${_AUTH_ARGS[@]+"${_AUTH_ARGS[@]}"}" "$@"
}
```

`${arr[@]+"${arr[@]}"}` is the standard bash-3.2-safe idiom: the `${arr[@]+word}` form only
substitutes `word` when `arr[@]` is set (non-empty for an array), so on an empty array the whole
expansion is empty; on a non-empty array it expands to the array's own quoted elements, byte- and
word-boundary-identical to a plain `"${arr[@]}"`. Verified directly on this host's bash 3.2.57 for
both cases (empty array expands to nothing; non-empty array preserves an embedded space intact).

**Decided against a minimum-bash-version gate.** The issue explicitly raises this as an option: a
version check that fails loudly is better than an "unbound variable" crash at an arbitrary line —
but weighed against who it would break. `/bin/bash` 3.2.57 is not an oversight on macOS; it is
the platform's permanent default (bash 3.2 is the last GPLv2 release Apple will ship). A version
gate requiring bash >= 4.4 would convert "one subcommand crashes" into "the tool refuses to start
at all" for every default macOS installation — exactly the population this bug affects, and
exactly the population the issue flags as highest priority *because* it's the default state, not
an edge case. The idiom fix has no equivalent downside: it is provably correct on 3.2 and a
no-op on bash >= 4.4 (same expansion result either way), so there's no real trade-off to make by
choosing it over a gate. Fixed the expansion; did not add a gate.

## Tests: fail on current main, pass with the fix (both runs shown)

Two new tests in `test-features.mjs` drive the **real, unmodified** `ocp` file via
`/bin/bash <path> <args>` — absolute path, not `env bash` or PATH-resolved `bash` — so on this
dev host (where `/bin/bash` really is 3.2.57) this is a true reproduction, not a modern-bash false
negative. Each test gets its own scratch `$HOME` (no `~/.ocp/admin-key` — the file is simply never
created, never read) and scratch `$PATH` with a stub `curl` (no real network I/O at all, so the
separately-running production OCP on this host is never touched). `OCP_ADMIN_KEY` is genuinely
**absent** from the child's environment (not merely empty).

**Before the fix** (test added first, `ocp` still unpatched):
```
ocp `_curl` empty-array expansion under bash 3.2 `set -u` (issue #256):
/Users/.../ocp: line 22: _AUTH_ARGS[@]: unbound variable
  ✗ ocp `ocp keys` (list) must not die with 'unbound variable' when _AUTH_ARGS is empty (bash 3.2 set -u, issue #256): must not crash with 'unbound variable' (the #256 bug); stderr="/Users/.../ocp: line 22: _AUTH_ARGS[@]: unbound variable\n"
  ✗ ocp `ocp usage --by-key` must not die with 'unbound variable' when _AUTH_ARGS is empty (bash 3.2 set -u, issue #256): expected a clean exit; status=1 stdout="Error: proxy unreachable or usage API not available\n" stderr=""

=== Results: 677 passed, 10 failed ===
```
Notably the second test fails *silently* rather than visibly: `cmd_usage`'s `--by-key` branch
captures `_curl`'s combined stdout+stderr via `$(... 2>&1)`, so the real `unbound variable` text
is captured into the `data` variable and then **discarded** — the user only ever sees a generic,
wrong "proxy unreachable or usage API not available", never learning the proxy was never even
contacted. That's arguably worse than the visible crash `ocp keys` produces.

**After the fix (including both fold-ins below):**
```
ocp `_curl` empty-array expansion under bash 3.2 `set -u` (issue #256):
  ✓ ocp `ocp keys` (list) must not die with 'unbound variable' when _AUTH_ARGS is empty (bash 3.2 set -u, issue #256)
  ✓ ocp `ocp usage --by-key` must not die with 'unbound variable' when _AUTH_ARGS is empty (bash 3.2 set -u, issue #256)

ocp/ocp-connect: no user-defined bash array expanded bare under set -u (static lint, issue #256 FOLD-IN 1):
  ✓ lint premise: array-declaration scan finds at least one array in ocp and in ocp-connect (anchor/regex-drift guard)
  ✓ ocp: every user-defined array expansion is guarded (no bare "${name[@]}" under set -u)
  ✓ ocp-connect: every user-defined array expansion is guarded (no bare "${name[@]}" under set -u)

=== Results: 684 passed, 6 failed ===
```
(The remaining failures are the pre-existing, host-load-dependent `OCP_LOCAL_TOOLS` `ltBoot`
integration cluster — see "CI / full suite" below; same cluster, same names, present identically
in a baseline run taken *before any change in this PR*, on unmodified `main`.)

**Interpreter-pinning honesty, stated explicitly per the issue's own ask:** on this dev host
`/bin/bash` is genuinely 3.2.57, so the fail→pass transition above is a real reproduction. On a
Linux CI runner, `/bin/bash` is typically bash 5.x, which never exhibits the empty-array
`unbound variable` behavior regardless of this fix — so on that platform these two RUNTIME tests
still assert real, meaningful behavior (the command completes and genuinely reaches `curl`), but
cannot distinguish buggy-vs-fixed the way they do here. **This is exactly the gap FOLD-IN 1's
static lint closes** — see below.

## Fold-ins from review

**FOLD-IN 1 (MEDIUM) — the regression guard doesn't run where merges are gated.** Correct: the
two runtime tests pass on the Linux CI runner (`.github/workflows/test.yml`, `ubuntu-latest`) with
or without the fix, since that runner's `/bin/bash` is 5.x. Added a **static** lint test
(`ocp: every user-defined array expansion is guarded` / `ocp-connect: every user-defined array
expansion is guarded`) that scans the actual source of both scripts for every user-defined array
declaration and fails if any expansion of it is bare (not wrapped in the 3.2-safe idiom) — this
runs, and can fail, on *any* platform, closing exactly the gap the runtime tests cannot close on
Linux CI.

Comment-blind by construction, found the hard way: the first version of this lint flagged a
**false positive** against `ocp`'s own audit comment, which has to *write out* the bare pattern
(`"${_AUTH_ARGS[@]}"`) in prose in order to explain it. Fixed by blanking full comment lines
before scanning — verified by re-running after the fix (see the mutation table below, which now
correctly finds nothing to flag in the fixed files).

**FOLD-IN 2 (LOW/MED) — surviving mutant: the near-miss `${_AUTH_ARGS[@]:-}`.** Correct: the
original stub logged only `$*` (space-joined), which can't tell "zero args" from "one spurious
empty-string arg, then the real ones". Verified independently:
```
$ /bin/bash -c 'set -u; arr=(); f(){ printf "[%s]" "${arr[@]:-}"; echo; }; f'
[]
$ curl "" --version > /dev/null 2>&1; echo exit=$?
exit=2
```
Both #256 tests now record argv element-by-element (`FAKE-CURL-ARGC=`, `FAKE-CURL-ARG=` per line,
never joined) and assert the exact argument count and that no argument is empty — the near-miss
is now caught by name (see mutation table).

**FOLD-IN 3 (LOW) — `ocp-connect` has the identical latent shape.** Correct: `rc_files`
(`ocp-connect:612`), expanded bare at four sites (`:637`, `:666`, `:679`, `:753` in the pre-review
line numbering). Confirmed not currently live (all three branches — fish / macOS / Linux-other —
guarantee at least one element before any expansion runs; `${#rc_files[@]}`, the LENGTH operator
used for the Linux-other fallback check, is independently verified safe on bash 3.2 even when
empty: `/bin/bash -c 'set -u; arr=(); echo "${#arr[@]}"'` → `0`, no crash). Fixed with the same
idiom at all four expansion sites rather than left as a documented invariant — a documented
invariant is exactly what FOLD-IN 1's lint now makes unnecessary to hand-maintain. Also corrected
this PR's own audit wording (see "Audit" section above) to name `ocp` specifically rather than
overclaim "the whole script".

### Mutation table, fold-in round

| # | Mutation | Named test(s) caught | Restore method |
|---|---|---|---|
| G | `ocp`'s guard reverted to the near-miss `${_AUTH_ARGS[@]:-}` | Both #256 runtime tests' NEW argv assertions (`argc=5`, leading empty string) — the static lint does **NOT** catch this (different expansion form, not bare — stated explicitly as the two guards' complementary scope, not a gap) | `cp` from backup, `shasum -a 256` verified identical |
| H | `ocp`'s guard reverted to the fully bare original form | Both #256 runtime tests AND the new `ocp: every user-defined array expansion is guarded` lint test | `cp` from backup, `shasum -a 256` verified identical |
| I | One of `ocp-connect`'s four `rc_files` sites reverted to bare | `ocp-connect: every user-defined array expansion is guarded` — with the exact count (1), proving the lint is precise, not just "something somewhere" | `cp` from backup, `shasum -a 256` verified identical |

Each: backed up first (`shasum -a 256` confirmed identical before mutating), anchor grepped and
confirmed found before editing, ran `npm test`, confirmed the named test(s) failed with the
expected shape, restored via `cp` (never `git checkout --`), re-confirmed `shasum -a 256`
byte-identity. Run serially against a clean baseline.

## Mutation table (original round)

| Step | Action | Result |
|---|---|---|
| 1 | `cp ocp ocp.fixed.backup`, `shasum -a 256` both | Identical — backup confirmed byte-exact before mutating |
| 2 | Assert anchor `_AUTH_ARGS[@]+"${_AUTH_ARGS[@]}"}` present in `ocp` | Found (both in the added comment and the live `_curl` body) — mutation would not be silently skipped |
| 3 | Mutate: revert `_curl()` body to the original unguarded `curl "${_AUTH_ARGS[@]}" "$@"` | Applied; confirmed via `grep` that the guarded idiom is gone from the live code line |
| 4 | `npm test` | Both named tests fail again, verbatim reproducing the pre-fix output: `ocp: line 34: _AUTH_ARGS[@]: unbound variable` |
| 5 | Restore: `cp ocp.fixed.backup ocp` (never `git checkout --`) | Applied |
| 6 | `shasum -a 256 ocp ocp.fixed.backup` | Identical hash — restore verified byte-exact |
| 7 | `npm test` | Both named tests green again |

## CI / full suite

`npm test` baseline (taken on unmodified `origin/main` @ `65927cb`, *before* any change in this
PR, to characterize pre-existing flakiness per this repo's own #248):
- Run 1: 676 passed, 9 failed
- Run 2: 678 passed, 7 failed

Post-fold-in-round (final run): 684 passed, 6 failed — every failure in the same named
`OCP_LOCAL_TOOLS`/`ltBoot` integration cluster, unrelated to `ocp`/`ocp-connect`/bash, unrelated to
this PR (`server.mjs` is untouched), and reproduced identically before this PR touched anything.
Matches the documented host-load flakiness (#248).

## Files changed

- `ocp` — the fix (`_curl()`, +comment)
- `ocp-connect` — FOLD-IN 3 (`rc_files` guarded at all four sites, +audit comment)
- `test-features.mjs` — two runtime regression tests (strengthened with exact-argv pinning per
  FOLD-IN 2), three static lint tests (FOLD-IN 1), audit-wording correction (FOLD-IN 3)

No `cli.js` citation is provided because this PR does not touch `server.mjs` and makes no
assertion about what Claude Code / `cli.js` does.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
