### PR TITLE
fix(upgrade): honor --target on the FULL (cross-minor) upgrade path

### DIFF
--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -12,7 +12,7 @@
  *   rollback      restore from snapshot
  */
 import { runDoctor } from "./doctor.mjs";
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { existsSync, copyFileSync } from "node:fs";
@@ -379,8 +379,29 @@ export async function runPostFlightCheck(target, opts = {}) {
 // Kept pure (no git access) so `runUpgrade`'s --dry-run preview can call this too without ever
 // shelling out — a preview does not need to confirm the tag actually exists, only the real
 // execution path does (see runFullUpgrade's own tag-existence check, right after this is called).
+//
+// SECURITY (independent review finding, HIGH — fixed here): the regex below is anchored at BOTH
+// ends (`^...$`), not just the start. The original, unanchored form (`^(\d+)\.(\d+)\.(\d+)` with
+// no trailing `$`) happily matched a PREFIX of an arbitrary string — e.g.
+// `_targetSemverParts("3.99.0 ; touch /tmp/PWNED ; false")` returned `{major:3,minor:99,patch:0}`,
+// silently discarding everything from the space onward. Because `resolveUpgradeTarget` (below,
+// pre-fix) returned the RAW input string rather than a value rebuilt from the parsed integers,
+// that discarded suffix survived downstream, where it was interpolated directly into an
+// `execSync` template string in `runFullUpgrade` (`git -C ${ocpDir} rev-parse --verify
+// refs/tags/${pinnedTarget}` and `git -C ${ocpDir} checkout ${upgradeTarget}`) — `execSync` runs
+// its argument through `/bin/sh`, so the `; touch ... ; false` portion executed as an
+// independent shell command regardless of whether the `git` portion succeeded. Verified: the
+// crafted payload above made the tag-existence check "cleanly" refuse (git's own exit code was
+// masked by the trailing `; false`), while the injected `touch` ran anyway, during validation,
+// before the refusal was ever reported. The fix has two independent layers, both required
+// ("belt and braces" per review): (1) this anchor makes ANY string containing extra characters
+// fail to parse at all, so it never reaches `resolveUpgradeTarget`'s return; (2) even if this
+// anchor is ever loosened again by a future edit, `runFullUpgrade` now invokes `git` via
+// `execFileSync(file, [args...])` (see below) instead of a shell template string, which never
+// invokes `/bin/sh` at all — a malformed argv element is passed to `git` as a single, inert
+// argument, never parsed as shell syntax.
 function _targetSemverParts(v) {
-  const m = String(v).replace(/^v/, "").match(/^(\d+)\.(\d+)\.(\d+)/);
+  const m = String(v).match(/^v?(\d+)\.(\d+)\.(\d+)$/);
   return m ? { major: +m[1], minor: +m[2], patch: +m[3] } : null;
 }
 function _targetSemverCompare(a, b) {
@@ -392,7 +413,15 @@ function _targetSemverCompare(a, b) {
 }
 function resolveUpgradeTarget({ target: rawTarget, currentVersion }) {
   if (!rawTarget) return { target: null, pinned: false };
-  const requested = rawTarget.startsWith("v") ? rawTarget : `v${rawTarget}`;
+  const parsed = _targetSemverParts(rawTarget);
+  if (!parsed) {
+    throw new Error(`--target ${rawTarget} is not a parseable vX.Y.Z version`);
+  }
+  // SECURITY: rebuilt from the PARSED INTEGER PARTS, never `rawTarget` itself (see the security
+  // note above `_targetSemverParts`) — this is what makes a shell-metacharacter payload
+  // structurally impossible to carry downstream, independent of whether the anchored regex
+  // above is ever loosened by a future edit.
+  const requested = `v${parsed.major}.${parsed.minor}.${parsed.patch}`;
   const cmp = _targetSemverCompare(requested, currentVersion);
   if (cmp === null) {
     throw new Error(`--target ${rawTarget} is not a parseable vX.Y.Z version`);
@@ -506,6 +535,32 @@ async function runFullUpgrade({ doctor, opts }) {
       );
     }
   };
+  // SECURITY (issue #257 review, HIGH): argv-form sibling of `exec` above, for the one command in
+  // this function whose arguments can carry a user-supplied value (`upgradeTarget`, from
+  // `--target`) — `execFileSync(file, args)` never invokes `/bin/sh`, so an argv element can
+  // never be reinterpreted as shell syntax, unlike `exec`'s template-string form. `cmd` (the
+  // human-readable display string recorded into `phases`, e.g. for existing tests asserting on
+  // `.cmd.includes("checkout vX.Y.Z")`) is built via `.join(" ")` purely for bookkeeping/display
+  // — it is NEVER itself executed.
+  const execArgv = (file, args, label) => {
+    const cmd = [file, ...args].join(" ");
+    if (opts.mockExec) {
+      phases.push({ name: label, cmd, status: "skipped-mock" });
+      return "";
+    }
+    try {
+      const out = execFileSync(file, args, { stdio: ["pipe", "pipe", "pipe"] }).toString();
+      phases.push({ name: label, cmd, status: "ok" });
+      return out;
+    } catch (err) {
+      const detail = err.stderr?.toString().trim();
+      phases.push({ name: label, cmd, status: "fail", stderr: detail });
+      throw Object.assign(
+        new Error(`phase ${label} failed: ${detail || err.message}`),
+        { phases, cmd }
+      );
+    }
+  };
   const ocpDir = opts.ocpDir || join(homedir(), "ocp");
   // opts.mockPort (test hook, mirrors opts.mockPlatform): lets tests drive resolveRestartPlan's
   // port validation (HIGH-1 follow-up below) with a deliberately malformed value without
@@ -530,8 +585,14 @@ async function runFullUpgrade({ doctor, opts }) {
       : opts.mockExec
         ? true
         : (() => {
+            // SECURITY: argv form, never a shell template string (see the security note above
+            // resolveUpgradeTarget) — execFileSync passes `pinnedTarget` as ONE inert argument to
+            // `git` directly, with no `/bin/sh` in between to reinterpret it. Defense in depth:
+            // by the time execution reaches here, `pinnedTarget` is already normalized (rebuilt
+            // from parsed integers, never raw input), so this would already be safe even as a
+            // shell string — this is the second, independent layer, not reliance on the first.
             try {
-              execSync(`git -C ${ocpDir} rev-parse --verify refs/tags/${pinnedTarget}`, { stdio: ["pipe", "pipe", "pipe"] });
+              execFileSync("git", ["-C", ocpDir, "rev-parse", "--verify", `refs/tags/${pinnedTarget}`], { stdio: ["pipe", "pipe", "pipe"] });
               return true;
             } catch { return false; }
           })();
@@ -560,9 +621,13 @@ async function runFullUpgrade({ doctor, opts }) {
     // phase 3: fetch + install
     // Issue #257: checkout `upgradeTarget` (the validated --target pin, when given), not
     // unconditionally `doctor.latest_version` — this is the actual fix; everything above is
-    // resolving/validating what that value should be.
+    // resolving/validating what that value should be. SECURITY (review, HIGH): the checkout uses
+    // `execArgv` (argv form), not `exec` (shell template string) — `upgradeTarget` can carry
+    // user-supplied content via --target, so it must never be concatenated into a string that
+    // reaches `/bin/sh`. `fetch`/`npm install` carry no user-supplied value, so they stay on the
+    // plain `exec` helper.
     exec(`git -C ${ocpDir} fetch --tags --quiet`, "fetch+install");
-    exec(`git -C ${ocpDir} checkout ${upgradeTarget}`, "fetch+install");
+    execArgv("git", ["-C", ocpDir, "checkout", upgradeTarget], "fetch+install");
     exec(`npm --prefix ${ocpDir} install --no-audit --no-fund`, "fetch+install");
 
     // phase 4: reconfigure — writes the service unit/plist ONLY (config + legacy-unit

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -354,6 +354,59 @@ export async function runPostFlightCheck(target, opts = {}) {
   return { ok, lastSeen, target: String(target || "").replace(/^v/, "") };
 }
 
+// Issue #257: `--target` was parsed from argv (see `_isMain()` below) and threaded into
+// `runUpgrade(opts)`, but `opts.target` was never actually READ anywhere in `runUpgrade`,
+// `runFullUpgrade`, `runFreshInstall`, or `runRollback` — the full (cross-minor) upgrade path
+// always checked out `doctor.latest_version`, silently ignoring any pin. This is the fix for
+// that path specifically.
+//
+// Scope, decided here rather than left implicit: this does NOT let `--target` bypass doctor's
+// own kind selection (current-vs-latest comparison, decided before either caller below ever
+// runs) — it only decides WHICH tag gets checked out once doctor has ALREADY chosen the
+// "upgrade" kind. Whether `--target` should be able to force an upgrade doctor wouldn't
+// otherwise recommend (e.g. an arbitrary downgrade) is the larger design question the issue
+// itself raises ("does --target bypass doctor's own kind selection entirely?") and explicitly
+// defers — out of scope for this fix, which closes the "dead code" bug, not that open question.
+// Consistency with the light path's own --target handling (issue #241, PR #255, still under
+// review as of this PR): that path made --target a warning-only no-op because its mechanism
+// (`git pull origin main --ff-only`) has no tag-checkout step to redirect at all — honoring a
+// pin there means SWAPPING mechanisms (pull -> tag checkout), a separate design decision #255
+// deliberately deferred. The full path's mechanism ALREADY is a tag checkout
+// (`git checkout ${target}` below) — redirecting which tag is a small, in-mechanism change, not
+// a mechanism swap, which is why this PR reaches a different, still-coherent answer instead of
+// mirroring #255's no-op for consistency's own sake.
+//
+// Kept pure (no git access) so `runUpgrade`'s --dry-run preview can call this too without ever
+// shelling out — a preview does not need to confirm the tag actually exists, only the real
+// execution path does (see runFullUpgrade's own tag-existence check, right after this is called).
+function _targetSemverParts(v) {
+  const m = String(v).replace(/^v/, "").match(/^(\d+)\.(\d+)\.(\d+)/);
+  return m ? { major: +m[1], minor: +m[2], patch: +m[3] } : null;
+}
+function _targetSemverCompare(a, b) {
+  const A = _targetSemverParts(a), B = _targetSemverParts(b);
+  if (!A || !B) return null; // unparseable -- caller must treat as "cannot compare", not 0
+  if (A.major !== B.major) return A.major - B.major;
+  if (A.minor !== B.minor) return A.minor - B.minor;
+  return A.patch - B.patch;
+}
+function resolveUpgradeTarget({ target: rawTarget, currentVersion }) {
+  if (!rawTarget) return { target: null, pinned: false };
+  const requested = rawTarget.startsWith("v") ? rawTarget : `v${rawTarget}`;
+  const cmp = _targetSemverCompare(requested, currentVersion);
+  if (cmp === null) {
+    throw new Error(`--target ${rawTarget} is not a parseable vX.Y.Z version`);
+  }
+  if (cmp <= 0) {
+    throw new Error(
+      `--target ${requested} is not newer than the current version (${currentVersion}) — the ` +
+      `upgrade path only moves forward; use \`ocp update --rollback\` to go back to a previous ` +
+      `snapshot instead`
+    );
+  }
+  return { target: requested, pinned: true };
+}
+
 export async function runUpgrade(opts = {}) {
   const dryRun = !!opts.dryRun;
   const yes = !!opts.yes;
@@ -384,8 +437,15 @@ export async function runUpgrade(opts = {}) {
   if (dryRun) {
     plan.push(`[plan] would proceed with ${kind} path`);
     if (kind === "upgrade") {
+      // Issue #257: preview must show what the real run would ACTUALLY check out, not always
+      // doctor.latest_version — otherwise `--dry-run --target vX.Y.Z` promises one thing and the
+      // real (non-dry-run) invocation, right below, does another. resolveUpgradeTarget() throws
+      // on an invalid/non-forward target even here — a preview should not claim to plan something
+      // the real run would refuse.
+      const { target: previewPinned } = resolveUpgradeTarget({ target: opts.target, currentVersion: doctor.current_version });
+      const previewTarget = previewPinned || doctor.latest_version;
       plan.push(`[plan] phase 1: snapshot to ~/.ocp/upgrade-snapshot-<ts>/`);
-      plan.push(`[plan] phase 2: git checkout ${doctor.latest_version} && npm install`);
+      plan.push(`[plan] phase 2: git checkout ${previewTarget} && npm install`);
       plan.push(`[plan] phase 3: node setup.mjs --reconfigure-only`);
       plan.push(`[plan] phase 4: launchctl bootout/bootstrap`);
       plan.push(`[plan] phase 5: post-flight /health + /v1/models`);
@@ -452,9 +512,41 @@ async function runFullUpgrade({ doctor, opts }) {
   // mutating the real process.env — a global that would otherwise leak across tests.
   const port = opts.mockPort || process.env.CLAUDE_PROXY_PORT || String(DEFAULT_PORT);
 
+  // Issue #257: resolve --target BEFORE any mutation (deliberately outside the try/catch below,
+  // and before phase 1 is even recorded) — an invalid or unknown pin must refuse loudly with no
+  // snapshot taken and no git/npm command run, not fail partway through. resolveUpgradeTarget()
+  // itself only checks shape + direction (pure, no git); the tag's actual EXISTENCE is checked
+  // here, separately, because that part legitimately needs git and is execution-only (the
+  // --dry-run preview above deliberately does not need to confirm existence, only shape).
+  // opts.mockTargetExists (test hook, same convention as opts.mockPort/opts.mockPlatform) lets
+  // tests drive both branches without a real git tree; absent that, opts.mockExec defaults to
+  // "assume it exists" (matching this function's existing mockExec-is-bookkeeping-only
+  // convention below — every other real git/npm call in this function is already skipped the
+  // same way under mockExec).
+  const { target: pinnedTarget } = resolveUpgradeTarget({ target: opts.target, currentVersion: doctor.current_version });
+  if (pinnedTarget) {
+    const tagExists = opts.mockTargetExists !== undefined
+      ? opts.mockTargetExists
+      : opts.mockExec
+        ? true
+        : (() => {
+            try {
+              execSync(`git -C ${ocpDir} rev-parse --verify refs/tags/${pinnedTarget}`, { stdio: ["pipe", "pipe", "pipe"] });
+              return true;
+            } catch { return false; }
+          })();
+    if (!tagExists) {
+      throw new Error(
+        `--target ${pinnedTarget} is not a known release tag (checked refs/tags/${pinnedTarget} ` +
+        `in ${ocpDir}). Run \`git -C ${ocpDir} tag -l\` to see available versions.`
+      );
+    }
+  }
+  const upgradeTarget = pinnedTarget || doctor.latest_version;
+
   try {
     // phase 1: pre-flight (doctor already passed; just record)
-    phases.push({ name: "pre-flight", status: "ok", note: `kind=upgrade from=${doctor.current_version} to=${doctor.latest_version}` });
+    phases.push({ name: "pre-flight", status: "ok", note: `kind=upgrade from=${doctor.current_version} to=${upgradeTarget}` });
 
     // phase 2: snapshot
     const fromCommit = opts.mockExec
@@ -462,12 +554,15 @@ async function runFullUpgrade({ doctor, opts }) {
       : execSync(`git -C ${ocpDir} rev-parse HEAD`).toString().trim();
     snapshotPath = opts.mockExec
       ? "/tmp/mock-snapshot"
-      : writeSnapshot({ homeDir: homedir(), fromCommit, fromVersion: doctor.current_version, toVersion: doctor.latest_version });
+      : writeSnapshot({ homeDir: homedir(), fromCommit, fromVersion: doctor.current_version, toVersion: upgradeTarget });
     phases.push({ name: "snapshot", path: snapshotPath, status: "ok" });
 
     // phase 3: fetch + install
+    // Issue #257: checkout `upgradeTarget` (the validated --target pin, when given), not
+    // unconditionally `doctor.latest_version` — this is the actual fix; everything above is
+    // resolving/validating what that value should be.
     exec(`git -C ${ocpDir} fetch --tags --quiet`, "fetch+install");
-    exec(`git -C ${ocpDir} checkout ${doctor.latest_version}`, "fetch+install");
+    exec(`git -C ${ocpDir} checkout ${upgradeTarget}`, "fetch+install");
     exec(`npm --prefix ${ocpDir} install --no-audit --no-fund`, "fetch+install");
 
     // phase 4: reconfigure — writes the service unit/plist ONLY (config + legacy-unit
@@ -520,14 +615,18 @@ async function runFullUpgrade({ doctor, opts }) {
           const out = execSync(`curl -sf --max-time 2 http://127.0.0.1:${port}/health`).toString();
           const body = JSON.parse(out);
           lastSeen = body.version;
-          if (postFlightOk(body, doctor.latest_version)) { ok = true; break; }
+          // Issue #257: verify against upgradeTarget (the validated pin, when given) — checking
+          // against doctor.latest_version unconditionally would report a PINNED upgrade as
+          // "failed" once the service correctly landed on the (older, requested) target, or
+          // wrongly "succeeded" if some other process happened to already be serving latest.
+          if (postFlightOk(body, upgradeTarget)) { ok = true; break; }
         } catch { /* retry */ }
         await new Promise(r => setTimeout(r, 1000));
       }
       if (!ok) {
         phases.push({
           name: "post-flight", status: "fail",
-          message: `health did not return auth.ok=true AND version=${doctor.latest_version} within 10s`
+          message: `health did not return auth.ok=true AND version=${upgradeTarget} within 10s`
             + (lastSeen ? ` (last saw version=${lastSeen} — a stale process may still hold the port; check \`ss -ltnp\` / \`lsof -i\`)` : ""),
         });
         throw new Error("post-flight failed");
@@ -548,7 +647,11 @@ async function runFullUpgrade({ doctor, opts }) {
       console.error(`[gc] warn: snapshot GC failed: ${e.message}`);
     }
 
-    return { path: "upgrade", executed: true, changed: true, snapshotPath, phases };
+    // `target` (issue #257): the ACTUAL version this upgrade landed on — the validated --target
+    // pin when one was given, doctor.latest_version otherwise. Observable/testable independent
+    // of the real (non-mockExec) git/curl branches above, which this suite never exercises for
+    // real (see this file's own test-features.mjs coverage note).
+    return { path: "upgrade", executed: true, changed: true, snapshotPath, phases, target: upgradeTarget };
   } catch (err) {
     if (snapshotPath && !err.snapshotPath) {
       Object.assign(err, {

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -1792,6 +1792,108 @@ test("#257: an unparseable --target is refused with a clear message rather than 
   assert.ok(/not a parseable/.test(caught.message), `expected an actionable message, got: ${caught.message}`);
 });
 
+// ── #257 SECURITY (independent review finding, HIGH) ────────────────────────────────────────────
+// A shell-metacharacter --target payload used to be accepted by the OLD unanchored regex (it
+// matched only a PREFIX of the string, silently discarding the rest), and the raw string --
+// metacharacters included -- was then interpolated into an `execSync` template string, which
+// runs through /bin/sh. The injected command executed DURING VALIDATION, before the tag was
+// ultimately (and separately) refused -- so a test that only asserts "the pin was refused" would
+// have passed against the vulnerable code; the refusal was never protection, it just happened to
+// also occur. This test asserts BOTH: the pin is refused, AND the payload's injected command
+// never ran (a marker file inside a disposable scratch directory -- never touching the real ~/ocp
+// tree or any real credential -- must not exist afterward).
+//
+// mockExec:false is deliberate and required here: mockExec:true would skip the real git call
+// entirely (tagExists defaults to true), which means the vulnerable shell-interpolation line
+// would never even run under mockExec -- the vulnerability could only ever be demonstrated (or
+// ruled out) with real execution. Safe to run for real: this specific payload's own trailing
+// `; false` guarantees the compound shell command's exit status is non-zero, so validation
+// refuses (throws) immediately after -- BEFORE runFullUpgrade's `try` block / phase 1 is ever
+// reached -- meaning no snapshot, no npm install, no setup.mjs, no restart ever runs, regardless
+// of whether the code being tested is the vulnerable version or the fixed one. `ocpDir` points at
+// a throwaway temp directory created fresh for this test and removed in `finally` -- it does not
+// need to be a real git repository (the injected command runs via the shell's `;` separator
+// regardless of whether the preceding `git` invocation succeeds).
+//
+// Belt-and-braces note, verified directly (mutation-tested, not assumed): even if the
+// tag-existence guard itself were ever neutered by a future regression, this specific test setup
+// has a SECOND, independent safety net -- `ocpDir` is a plain empty directory, not a real git
+// repository, so `runFullUpgrade`'s very next real command (phase 2's `git -C ${ocpDir}
+// rev-parse HEAD`, to compute the snapshot's fromCommit) fails immediately with "not a git
+// repository", aborting before `writeSnapshot()` -- which targets the REAL homedir(), not
+// ocpDir -- is ever reached. Confirmed empirically: neutering the tag-existence throw and
+// re-running this test does NOT create any file under the real ~/.ocp/upgrade-snapshot-*/.
+test("#257 SECURITY: a --target shell-metacharacter payload is refused AND never reaches a shell (marker file must not exist)", async () => {
+  const scratchDir = _ltMkdtemp(join(_ltTmp(), "ocp-257-injection-"));
+  try {
+    const markerPath = join(scratchDir, "PWNED");
+    const payload = `v3.99.0 ; touch ${markerPath} ; false`;
+    let caught = null;
+    try {
+      await runUpgrade({
+        yes: true, dryRun: false, mockExec: false, ocpDir: scratchDir,
+        target: payload,
+        mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" },
+                      current_version: "v3.10.0", latest_version: "v3.14.0" },
+      });
+    } catch (e) { caught = e; }
+    assert.ok(caught, "a shell-metacharacter --target payload must be refused, not silently accepted");
+    assert.ok(!_ltExists(markerPath),
+      `SECURITY: the payload's injected command must NEVER execute -- a marker file at ` +
+      `${markerPath} would prove --target reached a real shell. A refusal message alone does ` +
+      `NOT prove this: the vulnerable code also refused this exact payload, AFTER the injected ` +
+      `command had already run (verified independently before this fix).`);
+  } finally {
+    _ltRm(scratchDir, { recursive: true, force: true });
+  }
+});
+
+// Isolates the ANCHORED-REGEX layer specifically (the OLD unanchored `/^(\d+)\.(\d+)\.(\d+)/`,
+// with no trailing `$`, matched only a PREFIX and silently discarded everything after it). This
+// is deliberately a DIFFERENT test from the SECURITY test above: a metacharacter payload is
+// caught by rebuild-from-parts (below) even if the anchor alone regresses, so a test built
+// around a metacharacter payload cannot, by itself, prove the anchor is doing anything. This
+// payload carries no metacharacters at all -- just a valid vX.Y.Z prefix followed by ordinary
+// trailing text -- so it isolates: does the validator REJECT malformed input, or does it
+// silently truncate and accept a truthy-looking prefix?
+test("#257: trailing garbage after a valid-looking vX.Y.Z prefix is refused, not silently truncated and accepted", async () => {
+  let caught = null;
+  try {
+    await runUpgrade({
+      yes: true, dryRun: false, mockExec: true,
+      target: "v3.12.0-drift-extra-text",
+      mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" },
+                    current_version: "v3.10.0", latest_version: "v3.14.0" },
+    });
+  } catch (e) { caught = e; }
+  assert.ok(caught, "a --target with trailing garbage after a valid-looking prefix must be refused, not silently truncated and accepted as the prefix alone");
+  assert.ok(/not a parseable/.test(caught.message), `expected an actionable message, got: ${caught.message}`);
+});
+
+// Isolates the REBUILD-FROM-PARSED-INTEGERS layer specifically. A leading zero is the cleanest
+// input that distinguishes "return the raw string unchanged (only prefixing 'v' if missing)"
+// (the pre-review-fix approach) from "rebuild v${major}.${minor}.${patch} from the PARSED
+// integers" (this fix): both accept "v03.12.0" as parseable and both agree it's newer than
+// v3.10.0, but only the rebuilt form produces the CANONICAL "v3.12.0" a real release tag would
+// actually be named -- the raw/prefix-only form would silently carry "v03.12.0" through to
+// `git checkout`/`rev-parse --verify refs/tags/v03.12.0`, which does not match any real tag
+// (`v3.12.0`), on a real repository. This is a correctness property distinct from the injection
+// fix above, but is exactly what the review's "return a NORMALIZED string" requirement covers.
+test("#257: --target with a leading zero (v03.12.0) is normalized to the canonical v3.12.0, not passed through with the zero preserved", async () => {
+  const result = await runUpgrade({
+    yes: true, dryRun: false, mockExec: true,
+    target: "v03.12.0",
+    mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" },
+                  current_version: "v3.10.0", latest_version: "v3.14.0" },
+  });
+  assert.equal(result.target, "v3.12.0", `expected the canonical, zero-stripped form; got ${JSON.stringify(result.target)}`);
+  const fetchInstallCmds = result.phases.filter((p) => p.name === "fetch+install").map((p) => p.cmd);
+  assert.ok(fetchInstallCmds.some((c) => c.includes("checkout v3.12.0")),
+    `expected checkout of the CANONICAL v3.12.0, not the raw v03.12.0; got cmds=${JSON.stringify(fetchInstallCmds)}`);
+  assert.ok(!fetchInstallCmds.some((c) => c.includes("v03.12.0")),
+    `must not carry the raw, non-canonical 'v03.12.0' through to git; got cmds=${JSON.stringify(fetchInstallCmds)}`);
+});
+
 test("#257: --dry-run preview for the full path shows the PINNED target, not doctor.latest_version", async () => {
   const result = await runUpgrade({
     dryRun: true, target: "v3.12.0",

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -1660,6 +1660,167 @@ test("upgrade full path executes 5 phases", async () => {
   }
 });
 
+// ── --target on the FULL (cross-minor) upgrade path (issue #257) ───────────────────────────────
+// `--target` was parsed from argv and threaded into runUpgrade(opts), but opts.target was never
+// actually READ anywhere in runUpgrade / runFullUpgrade / runFreshInstall / runRollback — the
+// full path always checked out doctor.latest_version regardless of any pin. Fixed narrowly: this
+// does NOT let --target bypass doctor's own kind selection (current-vs-latest, decided before
+// runFullUpgrade is ever called) — it only decides WHICH tag gets checked out once doctor has
+// ALREADY chosen the "upgrade" kind. See scripts/upgrade.mjs's own comment above
+// resolveUpgradeTarget() for the full scope reasoning and the (deliberate) divergence from
+// PR #255's light-path no-op.
+//
+// Coverage note (stated explicitly, not left implicit): every test below uses mockExec:true or
+// the --dry-run path, matching EVERY existing runFullUpgrade test in this file (see "upgrade
+// full path executes 5 phases" right above, and the entire "Restart-unit resolution ... upgrade
+// wiring" section later in this file) — none of them ever drive the REAL (non-mockExec) git
+// checkout / npm install / curl post-flight branches, because doing so would mean real git/npm
+// mutation and a real network probe against whatever happens to be at ~/ocp on the host running
+// this suite. The wiring for --target inside those specific real branches (the post-flight
+// curl-check target and writeSnapshot's toVersion field) shares the exact same `upgradeTarget`
+// local variable as the checkout command and the returned `result.target` field, both of which
+// ARE exercised below — but is not independently exercised by an automated test, for the same
+// reason nothing else in this function's real branches is.
+console.log("\n--target on the full upgrade path (issue #257):");
+
+test("#257 (the money test): --target on a cross-minor upgrade is honored -- checkout uses the pinned tag, not doctor.latest_version", async () => {
+  const result = await runUpgrade({
+    yes: true, dryRun: false, mockExec: true,
+    target: "v3.12.0",
+    mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" },
+                  current_version: "v3.10.0", latest_version: "v3.14.0" },
+  });
+  const fetchInstallCmds = result.phases.filter(p => p.name === "fetch+install").map(p => p.cmd);
+  assert.ok(fetchInstallCmds.some(c => c.includes("checkout v3.12.0")),
+    `expected checkout of the PINNED target v3.12.0, got cmds=${JSON.stringify(fetchInstallCmds)}`);
+  assert.ok(!fetchInstallCmds.some(c => c.includes("checkout v3.14.0")),
+    `must NOT silently checkout doctor.latest_version (v3.14.0) when --target was given; got cmds=${JSON.stringify(fetchInstallCmds)}`);
+  assert.equal(result.target, "v3.12.0", `result.target must record the actual pinned target used; got ${JSON.stringify(result.target)}`);
+});
+
+test("#257 control: without --target, the full upgrade path still checks out doctor.latest_version (unchanged default)", async () => {
+  const result = await runUpgrade({
+    yes: true, dryRun: false, mockExec: true,
+    mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" },
+                  current_version: "v3.10.0", latest_version: "v3.14.0" },
+  });
+  const fetchInstallCmds = result.phases.filter(p => p.name === "fetch+install").map(p => p.cmd);
+  assert.ok(fetchInstallCmds.some(c => c.includes("checkout v3.14.0")),
+    `expected the unchanged default (checkout latest_version); got cmds=${JSON.stringify(fetchInstallCmds)}`);
+  assert.equal(result.target, "v3.14.0", `result.target must fall back to doctor.latest_version; got ${JSON.stringify(result.target)}`);
+});
+
+test("#257: --target without a leading 'v' is normalized before checkout (matches the vX.Y.Z tag convention)", async () => {
+  const result = await runUpgrade({
+    yes: true, dryRun: false, mockExec: true,
+    target: "3.12.0",
+    mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" },
+                  current_version: "v3.10.0", latest_version: "v3.14.0" },
+  });
+  const fetchInstallCmds = result.phases.filter(p => p.name === "fetch+install").map(p => p.cmd);
+  assert.ok(fetchInstallCmds.some(c => c.includes("checkout v3.12.0")),
+    `expected the normalized 'v3.12.0', got cmds=${JSON.stringify(fetchInstallCmds)}`);
+});
+
+test("#257: a --target that is not a known release tag is refused BEFORE any mutation (no snapshot taken)", async () => {
+  let caught = null;
+  try {
+    await runUpgrade({
+      yes: true, dryRun: false, mockExec: true,
+      target: "v3.12.0", mockTargetExists: false,
+      mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" },
+                    current_version: "v3.10.0", latest_version: "v3.14.0" },
+    });
+  } catch (e) { caught = e; }
+  assert.ok(caught, "must reject a --target that is not a known release tag");
+  assert.ok(/not a known release tag/.test(caught.message), `expected an actionable message, got: ${caught.message}`);
+  assert.equal(caught.snapshotPath, undefined,
+    `must refuse BEFORE ever taking a snapshot (no partial mutation); got snapshotPath=${JSON.stringify(caught.snapshotPath)}`);
+  assert.equal(caught.phases, undefined,
+    `must refuse before phase bookkeeping even starts; got phases=${JSON.stringify(caught.phases)}`);
+});
+
+test("#257: a --target that IS a known release tag (mockTargetExists:true) proceeds normally", async () => {
+  const result = await runUpgrade({
+    yes: true, dryRun: false, mockExec: true,
+    target: "v3.12.0", mockTargetExists: true,
+    mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" },
+                  current_version: "v3.10.0", latest_version: "v3.14.0" },
+  });
+  assert.equal(result.target, "v3.12.0");
+});
+
+test("#257: --target older than current_version is refused -- the full upgrade path only moves forward", async () => {
+  let caught = null;
+  try {
+    await runUpgrade({
+      yes: true, dryRun: false, mockExec: true,
+      target: "v3.9.0",
+      mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" },
+                    current_version: "v3.10.0", latest_version: "v3.14.0" },
+    });
+  } catch (e) { caught = e; }
+  assert.ok(caught, "must reject a --target older than current_version");
+  assert.ok(/not newer than the current version/.test(caught.message), `expected an actionable message, got: ${caught.message}`);
+});
+
+test("#257: --target equal to current_version is refused (not a forward upgrade)", async () => {
+  let caught = null;
+  try {
+    await runUpgrade({
+      yes: true, dryRun: false, mockExec: true,
+      target: "v3.10.0",
+      mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" },
+                    current_version: "v3.10.0", latest_version: "v3.14.0" },
+    });
+  } catch (e) { caught = e; }
+  assert.ok(caught, "must reject a --target equal to current_version");
+  assert.ok(/not newer than the current version/.test(caught.message), `expected an actionable message, got: ${caught.message}`);
+});
+
+test("#257: an unparseable --target is refused with a clear message rather than reaching git with a bad ref", async () => {
+  let caught = null;
+  try {
+    await runUpgrade({
+      yes: true, dryRun: false, mockExec: true,
+      target: "banana",
+      mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" },
+                    current_version: "v3.10.0", latest_version: "v3.14.0" },
+    });
+  } catch (e) { caught = e; }
+  assert.ok(caught, "must reject an unparseable --target");
+  assert.ok(/not a parseable/.test(caught.message), `expected an actionable message, got: ${caught.message}`);
+});
+
+test("#257: --dry-run preview for the full path shows the PINNED target, not doctor.latest_version", async () => {
+  const result = await runUpgrade({
+    dryRun: true, target: "v3.12.0",
+    mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" },
+                  current_version: "v3.10.0", latest_version: "v3.14.0" },
+  });
+  assert.ok(result.plan.some((l) => l.includes("checkout v3.12.0")), `expected preview to show the pinned target; plan=${JSON.stringify(result.plan)}`);
+  assert.ok(!result.plan.some((l) => l.includes("checkout v3.14.0")), `preview must not show latest_version when --target pins elsewhere; plan=${JSON.stringify(result.plan)}`);
+});
+
+test("#257 control: --dry-run preview without --target still shows doctor.latest_version (unchanged default)", async () => {
+  const result = await runUpgrade({
+    dryRun: true,
+    mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" },
+                  current_version: "v3.10.0", latest_version: "v3.14.0" },
+  });
+  assert.ok(result.plan.some((l) => l.includes("checkout v3.14.0")), `expected the unchanged default preview; plan=${JSON.stringify(result.plan)}`);
+});
+
+test("#257: --dry-run with an invalid --target still throws (dry-run skips MUTATION, not validation)", async () => {
+  await assert.rejects(async () => {
+    await runUpgrade({
+      dryRun: true, target: "v3.9.0",
+      mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" },
+                    current_version: "v3.10.0", latest_version: "v3.14.0" },
+    });
+  }, /not newer than the current version/);
+});
+
 // ── Reconfigure-only service mode (#226) ──────────────────────────────────
 // #215: on a host where a competing systemd/launchd unit already owns the OCP port, an
 // upgrade's reconfigure step (setup.mjs) must not enable-at-boot or start the service it


### PR DESCRIPTION
## Summary

`scripts/upgrade.mjs`'s CLI entrypoint parses `--target` into `opts.target` and threads it into
`runUpgrade(opts)`, but nothing in `runUpgrade`, `runFullUpgrade`, `runFreshInstall`, or
`runRollback` ever reads `opts.target` — the full (cross-minor) upgrade path always checked out
`doctor.latest_version`, silently ignoring any pin. `ocp update --target v3.13.0` on a cross-minor
doctor decision upgraded to whatever `doctor.latest_version` resolved to instead of the requested
version.

This PR wires `--target` into the checkout step, validated, for the full upgrade path only.

**Does not touch `server.mjs`. Does not touch `ocp`** (deliberately — see "Coherence with #255"
below).

Closes #257

---

## ⚠ Update: HIGH-severity shell-injection finding from independent review, fixed

Independent review of this PR found `--target` shell-injectable, and firing **before** the
tag-existence refusal rather than being blocked by it. Full details in the "Security review round"
section below, after the original design write-up. Two independent, both-required fixes landed in
a follow-up commit on this branch (`d1e489f`); the vulnerable window never shipped past review.

---

## Design decision 1: scope — does NOT bypass doctor's own kind selection

Doctor decides `kind` (noop/restart/update/upgrade/fresh_install) from current-vs-latest
comparison *before* `runFullUpgrade` is ever called. This fix does not touch that decision — it
only decides **which tag** gets checked out once doctor has *already* chosen the `"upgrade"`
kind. A user pinning `--target v3.13.0` while doctor independently concluded "you're behind,
upgrade" gets checked out to `v3.13.0` instead of whatever `doctor.latest_version` is — exactly
the incident the issue reports.

The issue itself raises a bigger, separate question: *"does `--target` bypass doctor's own kind
selection entirely?"* — e.g. should `--target v3.9.0` be able to force a downgrade even when
doctor says `noop`/`restart`? That is explicitly left open here. Answering it would mean deciding
whether `--target` can override doctor's kind computation altogether, which is a materially larger
change than closing a dead-argument bug, and the issue itself frames it as a separate, deferred
question rather than something this fix needs to resolve.

As a narrow, explicit safety rail *within* this fix's own scope: a requested target must be
strictly newer than `current_version` (see validation below) — the full-upgrade path only moves
forward. This isn't answering the bigger bypass question; it's refusing an accidental typo'd
downgrade through a path whose whole reason for existing is "you're behind, catch up."

## Design decision 2: coherence with PR #255 (light path), not identical treatment

PR #255 (open, under review) made `--target` a **warning-only no-op** on the light/patch-bump
path. Issue #257 explicitly invites checking whether matching that choice for consistency's own
sake would be wrong here — it would be. The two paths' mechanisms are different in a way that
matters:

- **Light path**: `git pull origin main --ff-only`. There is no tag-checkout step to redirect —
  honoring `--target` here means *swapping the mechanism itself* (pull → tag checkout), a
  materially larger change #255 correctly scoped out.
- **Full path**: already does `git checkout ${target}` as its core mechanism. Redirecting *which*
  tag gets checked out is a small, in-mechanism change — there is no swap required.

Given that, making the full path a no-op too (to "match" #255) would be actively worse: it would
leave a silently-ignored pin on the one path where honoring it is cheap and mechanically obvious,
for no reason other than superficial consistency with a path facing a genuinely different
constraint. This PR reaches a different, still-coherent answer instead of mirroring #255.

`ocp`'s `cmd_update_help` text (`--target v3.13.0  Pin a specific version`) is left untouched:
with this fix, that text is now *accurate* for the full path — it was already accurate before
#255's own no-op warning addresses the light path's own documentation gap separately. No shared
edit, no merge-conflict risk with #255's in-flight changes to `ocp`.

## The fix

`resolveUpgradeTarget({ target, currentVersion })` (pure, no git access) validates shape and
direction only — used by both the `--dry-run` preview and the real execution path, so the preview
can never promise something the real run would refuse:
- Missing `--target` → `{ target: null, pinned: false }` (unchanged default: `doctor.latest_version`).
- Not a parseable `vX.Y.Z` → throws.
- Not strictly newer than `current_version` → throws (see decision 1).
- Otherwise → the normalized (leading-`v`) target.

`runFullUpgrade` additionally checks the target is a **real, existing release tag**
(`git rev-parse --verify refs/tags/<target>`, read-only) before taking a snapshot or running any
git/npm command — validation happens entirely before the `try` block that wraps all mutation, so
an invalid pin refuses with **no partial state**: no snapshot, no checkout, nothing. (Doctor's own
pre-flight, called moments earlier in the same `ocp update` invocation, already runs
`git fetch --tags --quiet`, so this check is normally against already-fresh tags — no redundant
fetch added.)

The resolved `upgradeTarget` then replaces every place the function previously assumed
`doctor.latest_version` was the actual destination: the snapshot's `toVersion`, the checkout
command, the real (non-mocked) post-flight version check and its failure message, and a new
`target` field on the returned result object.

---

## Security review round (HIGH, fixed)

**Finding.** `_targetSemverParts`'s regex was anchored only at the start
(`^(\d+)\.(\d+)\.(\d+)`, no trailing `$`), so it matched a PREFIX of arbitrary input —
`_targetSemverParts("3.99.0 ; touch /tmp/PWNED ; false")` returned a "valid"
`{major:3,minor:99,patch:0}`. `resolveUpgradeTarget` then returned that RAW string (only
`v`-prefixed if missing), not a value rebuilt from the parsed integers. The raw string was
interpolated into `execSync` template strings at two git call sites (`rev-parse --verify
refs/tags/${pinnedTarget}` and `checkout ${upgradeTarget}`), and `execSync` runs its argument
through `/bin/sh`. Reviewer-verified end to end in a throwaway directory:
- `--target 'v3.99.0 ; touch <marker> ; false'` → the pin is refused with a clean "not a known
  release tag" error, but the injected `touch` had already run — the refusal was never
  protection, the damage happened during validation.
- `--target 'v3.99.0 ; true'` (worse) → the rev-parse probe exits 0 → validation PASSES → the run
  proceeds into `npm install`, `setup.mjs --reconfigure-only`, and a real service restart, on a
  tree that was never actually checked out.

Independently re-confirmed before touching any code (not taken on trust):
```
$ node -e '... _targetSemverParts("3.99.0 ; /usr/bin/touch /tmp/PWNED-verify ; false") ...'
unanchored match result: { major: 3, minor: 99, patch: 0 }

$ node -e '... execSync(`git -C <scratch> rev-parse --verify refs/tags/v3.99.0 ; touch <marker> ; false`) ...'
rev-parse threw as expected (status 1 )
marker file exists: true
```

**Fix — two independent layers, both required ("belt and braces"):**
1. `_targetSemverParts`'s regex is now anchored at both ends (`^v?(\d+)\.(\d+)\.(\d+)$`), and
   `resolveUpgradeTarget` returns a value **rebuilt from the parsed integers**
   (`` `v${major}.${minor}.${patch}` ``), never the raw input.
2. Both git calls that take a `--target`-derived value now run via
   `execFileSync(file, [args...])` (argv form) — never a shell template string. No `/bin/sh` is
   invoked at all, so even a hypothetical future regression in layer 1 cannot reach a shell.
   (`npm install` / `fetch --tags`, which carry no `--target`-derived value, are left on the
   plain `exec()` string helper — not in scope for this finding.)

**New tests, each isolating one layer** (so each is independently mutation-catchable, not just
"the security test passes"):
- **`#257 SECURITY`**: the exact reviewer payload, run through a REAL (non-mocked) execution path
  against a disposable scratch directory (never the real `~/ocp` tree, never a real credential).
  Asserts BOTH that the pin is refused AND that a marker file the payload would have created does
  **not** exist — a refusal-only assertion would have passed against the vulnerable code (this is
  the review's own point, reproduced below).
- **`trailing garbage after a valid-looking vX.Y.Z prefix`**: no metacharacters — isolates the
  anchored-regex layer specifically. This is the *only* test that catches an anchor regression,
  because the rebuild layer independently neutralizes the metacharacter case (see mutation D
  below).
- **`leading zero (v03.12.0) is normalized to v3.12.0`**: isolates the rebuild-from-parsed-
  integers layer specifically. This is the *only* test that catches a regression back to naive
  raw-string-with-"v"-prefix, since the anchored regex alone doesn't distinguish the two forms
  for well-formed input (see mutation E below).

**Fail-before/pass-after for the SECURITY test** (swapped in the previously-pushed, pre-review
commit `49938ad`, restored via `cp`+`shasum -a 256` after, never `git checkout --`):
```
Before (commit 49938ad, i.e. this PR's own state at the time of review):
  ✗ #257 SECURITY: a --target shell-metacharacter payload is refused AND never reaches a shell (marker file must not exist): SECURITY: the payload's injected command must NEVER execute -- a marker file at .../PWNED would prove --target reached a real shell. ...

After (this fix):
  ✓ #257 SECURITY: a --target shell-metacharacter payload is refused AND never reaches a shell (marker file must not exist)
```

**Mutation table, security round** (run serially, each backed up via `cp`+`shasum -a 256`,
anchor-grepped before mutating, restored via `cp`+`shasum -a 256` after — never `git checkout --`):

| # | Mutation | Named test(s) caught | SECURITY test result |
|---|---|---|---|
| D | De-anchored the regex (dropped trailing `$`) | `#257: trailing garbage after a valid-looking vX.Y.Z prefix is refused ...` | **Still passes** — rebuild-from-parts (layer 2) independently neutralizes this specific payload |
| E | Reverted the rebuild to naive `rawTarget.startsWith("v") ? rawTarget : "v"+rawTarget` | `#257: --target with a leading zero (v03.12.0) is normalized ...` | **Still passes** — the anchored regex (layer 1) still rejects the metacharacter payload before this line is ever reached |
| F (exploratory, not a required catch) | Reverted layers 1 AND 2 together (full revert to the pre-review vulnerable shape), **keeping** the argv-form (`execFileSync`) call sites | D's and E's own tests correctly fail (proving the regression is real) | **Still passes** — argv form alone still blocks the injection even with both other layers gone, directly confirming the "belt and braces" claim |

Mutations D and E each demonstrate that the OTHER unmutated layer independently compensates for
the classic metacharacter payload — this is not a gap, it's the intended overlap. Mutation F
(run explicitly, not just asserted) is the direct experimental confirmation that argv-form is a
structurally independent backstop, not merely "also correct given the other two layers hold."

Also re-ran the original three mutations (checkout target, "not newer than current" guard,
tag-existence guard) against the current code shape (the checkout call site is now `execArgv`
instead of `exec`) to confirm they still catch correctly post-refactor — all three still caught by
their original named tests.

## Tests: fail on current main, pass with the fix (both runs shown)

Fourteen tests total added to `test-features.mjs` (eleven from the original round, three from the
security round above), all using `mockExec:true`, `--dry-run`, or (the SECURITY test only) a real
execution path against a disposable scratch directory — matching **every existing
`runFullUpgrade` test in this file** for anything that isn't specifically testing real-shell
safety.

**Before the fix** (tests added first, against unmodified `scripts/upgrade.mjs` from
`origin/main` — swapped in via `git show origin/main:scripts/upgrade.mjs`, restored from a file
backup afterward, never `git checkout --`):
```
--target on the full upgrade path (issue #257):
  ✗ #257: --dry-run preview for the full path shows the PINNED target, not doctor.latest_version: expected preview to show the pinned target; plan=[...,"[plan] phase 2: git checkout v3.14.0 && npm install",...]
  ✓ #257 control: --dry-run preview without --target still shows doctor.latest_version (unchanged default)
  ✗ #257 (the money test): --target on a cross-minor upgrade is honored -- checkout uses the pinned tag, not doctor.latest_version: expected checkout of the PINNED target v3.12.0, got cmds=["git -C /Users/.../ocp fetch --tags --quiet","git -C /Users/.../ocp checkout v3.14.0","npm --prefix /Users/.../ocp install --no-audit --no-fund"]
  ✗ #257 control: without --target, the full upgrade path still checks out doctor.latest_version (unchanged default): result.target must fall back to doctor.latest_version; got undefined
  ✗ #257: --target without a leading 'v' is normalized before checkout (matches the vX.Y.Z tag convention): expected the normalized 'v3.12.0', got cmds=[...checkout v3.14.0...]
  ✗ #257: a --target that is not a known release tag is refused BEFORE any mutation (no snapshot taken): must reject a --target that is not a known release tag
  ✗ #257: a --target that IS a known release tag (mockTargetExists:true) proceeds normally: Expected values to be strictly equal: ...
  ✗ #257: --target older than current_version is refused -- the full upgrade path only moves forward: must reject a --target older than current_version
  ✗ #257: --target equal to current_version is refused (not a forward upgrade): must reject a --target equal to current_version
  ✗ #257: an unparseable --target is refused with a clear message rather than reaching git with a bad ref: must reject an unparseable --target
  ✗ #257: --dry-run with an invalid --target still throws (dry-run skips MUTATION, not validation): Missing expected rejection.

=== Results: 678 passed, 18 failed ===
```
10 of 11 new tests fail (as expected — this is the real bug). The one that passes
("control: --dry-run preview without --target...") is deliberate: it proves the harness
*discriminates* rather than failing regardless of what the code does.

**After the full fix (including the security round):**
```
--target on the full upgrade path (issue #257):
  ✓ #257: --dry-run preview for the full path shows the PINNED target, not doctor.latest_version
  ✓ #257 control: --dry-run preview without --target still shows doctor.latest_version (unchanged default)
  ✓ #257 (the money test): --target on a cross-minor upgrade is honored -- checkout uses the pinned tag, not doctor.latest_version
  ✓ #257 control: without --target, the full upgrade path still checks out doctor.latest_version (unchanged default)
  ✓ #257: --target without a leading 'v' is normalized before checkout (matches the vX.Y.Z tag convention)
  ✓ #257: a --target that is not a known release tag is refused BEFORE any mutation (no snapshot taken)
  ✓ #257: a --target that IS a known release tag (mockTargetExists:true) proceeds normally
  ✓ #257: --target older than current_version is refused -- the full upgrade path only moves forward
  ✓ #257: --target equal to current_version is refused (not a forward upgrade)
  ✓ #257: an unparseable --target is refused with a clear message rather than reaching git with a bad ref
  ✓ #257 SECURITY: a --target shell-metacharacter payload is refused AND never reaches a shell (marker file must not exist)
  ✓ #257: trailing garbage after a valid-looking vX.Y.Z prefix is refused, not silently truncated and accepted
  ✓ #257: --target with a leading zero (v03.12.0) is normalized to the canonical v3.12.0, not passed through with the zero preserved
  ✓ #257: --dry-run with an invalid --target still throws (dry-run skips MUTATION, not validation)

=== Results: 692 passed, 7 failed ===
```
(The remaining failures are the pre-existing, host-load-dependent `OCP_LOCAL_TOOLS` `ltBoot`
integration cluster — same names every run, present identically before this PR touched anything,
tracked as #248. `server.mjs` is untouched by this PR.)

**Coverage honesty, stated explicitly:** the real (non-`mockExec`) post-flight version check and
`writeSnapshot`'s `toVersion` field share the exact same `upgradeTarget` local variable as the
checkout command and the new `result.target` field — both of the latter ARE exercised above — but
that real branch is not independently exercised by an automated test, for the same reason nothing
else in `runFullUpgrade`'s real (non-mock) branch is tested anywhere in this file.

## Mutation table (original round, re-verified against the current code shape)

| # | Mutation | Named test(s) caught | Restore method |
|---|---|---|---|
| A | Checkout reverted to `doctor.latest_version` (via the now-`execArgv` call site) | `#257 (the money test): ...`, `#257: --target without a leading 'v' is normalized ...`, `#257: --target with a leading zero ...` | `cp` from backup, `shasum -a 256` verified identical |
| B | Neutered the "not newer than current" guard | `#257: --target older than current_version is refused ...`, `#257: --target equal to current_version is refused ...`, `#257: --dry-run with an invalid --target still throws ...` | `cp` from backup, `shasum -a 256` verified identical |
| C | Neutered the tag-existence guard | `#257: a --target that is not a known release tag is refused BEFORE any mutation ...` | `cp` from backup, `shasum -a 256` verified identical |

See "Security review round" above for mutations D, E, F.

Each mutation: backed up the fixed file first (`shasum -a 256` confirmed identical to the working
copy before mutating), grepped for the exact anchor string and confirmed it was found before
editing (so a silently-unapplied mutation could never read as "not caught"), ran `npm test` and
confirmed the named test(s) failed with the expected message, then restored via `cp` from the
backup (never `git checkout --`) and re-confirmed `shasum -a 256` byte-identity before moving to
the next mutation. All mutations run serially against a clean baseline established beforehand.

## CI / full suite

Full `npm test` green apart from the pre-existing `OCP_LOCAL_TOOLS` `ltBoot` cluster (#248,
host-load-dependent, unrelated to this PR — `server.mjs` untouched). Final run: 692 passed, 7
failed, all 7 in that named cluster.

## Files changed

- `scripts/upgrade.mjs` — the fix (`resolveUpgradeTarget`, `execArgv`, wiring into
  `runUpgrade`'s dry-run preview and `runFullUpgrade`'s real execution path)
- `test-features.mjs` — fourteen new regression tests

No `cli.js` citation is provided because this PR does not touch `server.mjs` and makes no
assertion about what Claude Code / `cli.js` does.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
