### PR TITLE
fix(restart-unit): verify macOS restart-target identity via launchctl print

### DIFF
--- a/scripts/lib/restart-unit.mjs
+++ b/scripts/lib/restart-unit.mjs
@@ -114,13 +114,42 @@
  * already uses — never treated as "confirmed foreign" (a false-confident answer) nor silently
  * skipped (which would defeat the point of the check).
  *
- * Deliberately NOT covered by this fix (same "minimum reviewable unit" posture as defect 2 in the
- * THIRD review above): macOS. `/proc/<pid>/cmdline` doesn't exist there, and the darwin branch
- * below still returns `kind: "launchd"` for any confirmed listener without identifying the actual
- * process at all. That gap was originally reported as issue #233 defect 2; #233 itself is now
- * CLOSED (split per Iron Rule 11 into its own dedicated review) and the live tracker for this
- * specific work is issue #239 — extending identity verification to macOS is #239's job, not this
- * one's.
+ * At the time #237 landed, macOS was deliberately NOT covered (same "minimum reviewable unit"
+ * posture as defect 2 in the THIRD review above): `/proc/<pid>/cmdline` doesn't exist there, and
+ * the darwin branch used to return `kind: "launchd"` for any confirmed listener without
+ * identifying the actual process at all. That gap was originally reported as issue #233 defect 2;
+ * #233 itself was CLOSED (split per Iron Rule 11 into its own dedicated review) and tracked
+ * onward as issue #239.
+ *
+ * issue #239 (this fix): extends identity verification to macOS. The core asymmetry Linux and
+ * macOS have to work around is structural, not incidental — Linux has a pid -> cgroup -> unit-name
+ * REVERSE lookup (`/proc/<pid>/cgroup`), so resolution walks from "here's the pid holding the
+ * port" to "here's what unit that is". launchd has no equivalent (there is no
+ * `/proc/<pid>/launchd-label` file), so resolution has to run the OTHER direction: ask launchd
+ * what pid it believes owns the ONE label this repo manages (`dev.ocp.proxy`, hardcoded — there's
+ * no multi-label ambiguity to resolve the way Linux has system-vs-user scope) via `launchctl print
+ * gui/<uid>/dev.ocp.proxy`, and compare that pid against the pid `lsof`/`netstat` found actually
+ * holding the port. A mismatch — or the label not being registered, or registered but not
+ * currently running — means the port's holder is not verified to be `dev.ocp.proxy`: the macOS
+ * analogue of Linux's `no-unit`, via the same terminal `kind` (not a fourth, platform-only state).
+ *
+ * `classifyLaunchdJob` does that pid-and-argv extraction (verified live against the production
+ * host — see its own comment for the exact `launchctl print` output shapes, both registered and
+ * "Could not find service"). `classifyLaunchdArgv` then applies the SAME "does this argv invoke
+ * server.mjs" predicate `classifyCmdlineOwner` uses on Linux (factored out as `findServerMjsArg`
+ * below and called by both) to the job's own argv — mirroring #237's identity check, not
+ * reinventing a third notion of "is this OCP": a hand-edited or compromised plist could register
+ * the SAME label against a different program, and pid-matching alone would not catch that. A
+ * confirmed pid match whose argv does NOT invoke server.mjs resolves to the same `foreign-process`
+ * kind #237 introduced for Linux, reusing that terminal state and its refusal in `planRestart`
+ * rather than adding a platform-specific twin.
+ *
+ * `probe.launchdPrintOutput === undefined` (as opposed to `null`) means the caller never attempted
+ * this probe — same legacy/back-compat convention `probe.cmdlineContent` uses on the Linux side:
+ * skip the check, preserve pre-#239 behavior, rather than newly refuse restarts that were "safe"
+ * before this field existed. `planRestart`'s `no-unit` and `foreign-process` refusal messages are
+ * platform-branched (`owner.platform === "darwin"`) since the Linux wording names `systemd`,
+ * `/proc/<pid>/cgroup`, and `/proc/<pid>/cmdline` — none of which exist on macOS.
  */
 
 // Anything accepted as a restart target must look like a real systemd unit name.
@@ -194,6 +223,16 @@ export function classifySsListener(ssOutput) {
     state: "unknown", pid: null,
     reason: `${pids.size} distinct PIDs (${[...pids].sort().join(", ")}) are listening on this port (dual-stack / SO_REUSEPORT) — cannot determine which one to restart`,
   };
+}
+
+// Shared identity predicate (issue #239): does this argv actually invoke server.mjs? Used by
+// BOTH platforms' "is this OCP" checks — classifyCmdlineOwner below (Linux, argv sourced from
+// /proc/<pid>/cmdline, NUL-separated) and classifyLaunchdArgv further down (macOS, argv sourced
+// from `launchctl print`'s "arguments = { ... }" block, one token per line) — so "what counts as
+// OCP" cannot silently drift into two different definitions across platforms. Mirrors
+// scripts/doctor.mjs's own #230 fingerprintSystemdUnit / parsePlistCandidates serverArg check.
+function findServerMjsArg(argv) {
+  return argv.find(a => a === "server.mjs" || a.endsWith("/server.mjs"));
 }
 
 // --- macOS: classify `lsof -nP -iTCP:<port> -sTCP:LISTEN` output --- (same three states as ss)
@@ -337,6 +376,72 @@ export function parseCgroupUnit(cgroupContent) {
   return { state: "no-unit", scope: null, unit: null, reason: "no cgroup line yielded a recognizable systemd unit" };
 }
 
+// --- macOS: classify `launchctl print gui/<uid>/dev.ocp.proxy` output --- (issue #239)
+//
+// Linux has a pid -> cgroup -> unit-name REVERSE lookup (/proc/<pid>/cgroup), so parseCgroupUnit
+// above walks from "here's the pid holding the port" to "here's what unit that is". macOS/launchd
+// has no equivalent (there is no /proc/<pid>/launchd-label file), and this repo manages exactly
+// ONE label (dev.ocp.proxy, hardcoded — no multi-label ambiguity to resolve the way Linux has
+// system-vs-user scope), so this runs the OTHER direction: ask launchd what pid IT believes owns
+// the label, for resolveOwningUnit to compare against the pid lsof/netstat found actually holding
+// the port.
+//
+// Verified live against the production host (read-only `launchctl print`, never mutated):
+//   registered + running:  exit 0, a "pid = <N>" line, and an "arguments = { ... }" block with one
+//                          argv token per line (no shell-splitting ambiguity — the same guarantee
+//                          NUL-separation gives /proc/<pid>/cmdline on Linux, via a different
+//                          mechanism: launchctl's own line-per-token rendering). Example, captured
+//                          live against the real dev.ocp.proxy job on this host:
+//                            pid = 55416
+//                            arguments = {
+//                                /opt/homebrew/Cellar/node/26.5.0/bin/node
+//                                /Users/taodeng/ocp/server.mjs
+//                            }
+//   label not registered:  nonzero exit (113 observed on this host — Apple does not document
+//                          launchctl's exit codes, so this is NOT asserted on anywhere in this
+//                          codebase, matching this file's standing posture of trusting the MESSAGE
+//                          over an undocumented exit code), EMPTY stdout, stderr:
+//                            Bad request.
+//                            Could not find service "<label>" in domain for user gui: <uid>
+//                          — the gather layer (scripts/upgrade.mjs's
+//                          mapLaunchctlPrintFailureToProbeValue) turns that SPECIFIC, expected
+//                          failure into "" (this function's own not-registered sentinel), matching
+//                          the same "the tool ran and told us something meaningful, but execSync
+//                          still threw on the nonzero exit" shape lsof's own "nothing matched"
+//                          case already has (defect 1 / PR #240).
+//
+// Returns one of four states — same "unknown must never be treated as safe-to-guess" posture as
+// every other classifier in this file:
+//   "unknown"          printOutput === null — the probe didn't run, or failed some way OTHER than
+//                      the specific "not registered" signature above
+//   "not-registered"   printOutput is a non-null string that trims to empty — the gather layer's
+//                      sentinel for launchctl's "Could not find service" failure
+//   "not-running"      printOutput is non-empty but no "pid = <N>" line was found — the label IS
+//                      registered but has no live process right now (e.g. a mid-restart window);
+//                      NOT proof the port's current holder is this job
+//   "running"          a "pid = <N>" line was found; pid and argv (parsed from the
+//                      "arguments = { ... }" block) are both returned for the caller to verify
+//                      against the actual port-holding pid and against server.mjs identity
+export function classifyLaunchdJob(printOutput) {
+  if (printOutput == null) {
+    return {
+      state: "unknown", pid: null, argv: null,
+      reason: "launchctl print did not run (missing tool, probe failed, or a failure other than \"not registered\")",
+    };
+  }
+  const text = String(printOutput);
+  if (!text.trim()) {
+    return { state: "not-registered", pid: null, argv: null, reason: null };
+  }
+  const pidMatch = text.match(/^\s*pid\s*=\s*(\d+)\s*$/m);
+  if (!pidMatch) {
+    return { state: "not-running", pid: null, argv: null, reason: null };
+  }
+  const argsBlock = text.match(/\barguments\s*=\s*\{([^}]*)\}/);
+  const argv = argsBlock ? argsBlock[1].split("\n").map(s => s.trim()).filter(Boolean) : [];
+  return { state: "running", pid: pidMatch[1], argv, reason: null };
+}
+
 // --- Linux: classify /proc/<pid>/cmdline content as OCP's own server.mjs, or a foreign process ---
 // (issue #237)
 //
@@ -372,11 +477,38 @@ export function classifyCmdlineOwner(cmdlineContent) {
   if (argv.length === 0) {
     return { state: "unknown", reason: "empty /proc/<pid>/cmdline read" };
   }
-  const serverArg = argv.find(a => a === "server.mjs" || a.endsWith("/server.mjs"));
+  const serverArg = findServerMjsArg(argv);
   if (!serverArg) {
     return {
       state: "foreign",
       reason: `owning process's argv (${argv.join(" ")}) does not invoke server.mjs at all — this is not an OCP process`,
+    };
+  }
+  return { state: "ocp", reason: null };
+}
+
+// --- macOS: classify a launchd job's argv as OCP's own server.mjs, or a foreign process ---
+// (issue #239, mirroring classifyCmdlineOwner's #237 check)
+//
+// classifyLaunchdJob (above) answers "is a process running under the dev.ocp.proxy label, and
+// what pid/argv does launchd say it has" — it does NOT answer "does that argv actually invoke
+// server.mjs". A hand-edited or compromised plist could register the SAME label against a
+// DIFFERENT program; nothing about classifyLaunchdJob's own contract catches that — the same gap
+// classifyCmdlineOwner exists to close for a real-but-foreign systemd unit name (#237). Takes the
+// pre-parsed argv classifyLaunchdJob already extracted from the "arguments = { ... }" block (one
+// token per line — no separate probe or parse pass) and applies the EXACT SAME "does this argv
+// invoke server.mjs" predicate classifyCmdlineOwner uses on Linux (findServerMjsArg, this file's
+// top) — deliberately reusing that function rather than reimplementing the check, so "what counts
+// as OCP" cannot drift into a third definition across platforms.
+//
+// Returns the same two terminal states classifyCmdlineOwner uses: "ocp" / "foreign".
+export function classifyLaunchdArgv(argv) {
+  const list = Array.isArray(argv) ? argv : [];
+  const serverArg = findServerMjsArg(list);
+  if (!serverArg) {
+    return {
+      state: "foreign",
+      reason: `owning process's argv (${list.join(" ")}) does not invoke server.mjs at all — this is not an OCP process`,
     };
   }
   return { state: "ocp", reason: null };
@@ -414,16 +546,35 @@ export function classifyCmdlineOwner(cmdlineContent) {
  *                                  undefined — "undefined" only arises from a caller (or test)
  *                                  that hasn't been wired to this check, and must not newly
  *                                  refuse restarts that were safe before this field existed.
+ *   launchdPrintOutput  raw `launchctl print gui/<uid>/<expectedUnit>` stdout for the ONE label
+ *                   this repo manages (macOS only; issue #239). Same three-state convention as
+ *                   cmdlineContent above:
+ *                     a string     classified via classifyLaunchdJob (then, if "running",
+ *                                  classifyLaunchdArgv against its argv)
+ *                     null         the probe was ATTEMPTED and failed some way other than the
+ *                                  specific "not registered" signature — treated as "unknown"
+ *                     undefined    the caller never attempted this probe at all — the check is
+ *                                  SKIPPED entirely, preserving pre-#239 behavior. Legacy/
+ *                                  back-compat lane, same convention as cmdlineContent's: real
+ *                                  production use (scripts/upgrade.mjs's gather layer) always
+ *                                  populates this field one way or another; "undefined" only
+ *                                  arises from a caller (or test) not yet wired to this check.
  *
  * Returns { kind, platform, pid, unit, scope?, mismatched, reason? }, kind one of:
  *   "system-unit"      Linux, port owned by a system-scope systemd unit
  *   "user-unit"        Linux, port owned by a user-scope systemd unit
- *   "launchd"          macOS, port is held by a process (launchd is the only
- *                      restart mechanism this repo drives on macOS)
- *   "no-unit"          Linux, a PID holds the port but isn't in any systemd unit
- *                      (a bare `node server.mjs`, most likely)
- *   "foreign-process"  Linux, a real systemd unit owns the port but its process is CONFIRMED not
- *                      to be OCP's server.mjs (issue #237 — e.g. nginx.service)
+ *   "launchd"          macOS, port is held by a process CONFIRMED to be the dev.ocp.proxy launchd
+ *                      job (issue #239 — pid match against launchd's own bookkeeping, plus an
+ *                      argv check; see classifyLaunchdJob/classifyLaunchdArgv)
+ *   "no-unit"          a PID holds the port but isn't verified to be managed by any (systemd
+ *                      unit | the dev.ocp.proxy launchd job) — a bare `node server.mjs`, most
+ *                      likely, but on macOS also covers "label not registered", "label registered
+ *                      but not running", and "label running under a DIFFERENT pid than the one
+ *                      holding the port" — all collapse to this same terminal state rather than
+ *                      each getting its own platform-only kind
+ *   "foreign-process"  a real unit/job owns the port but its process is CONFIRMED not to be OCP's
+ *                      server.mjs (issue #237 on Linux — e.g. nginx.service; issue #239 on macOS —
+ *                      a launchd label whose registered argv doesn't invoke server.mjs)
  *   "not-listening"    the tool ran cleanly and found nothing bound to the port
  *   "unknown"          could not determine ownership (see `reason`) — must never
  *                       be treated as equivalent to "not-listening"
@@ -443,6 +594,41 @@ export function resolveOwningUnit(probe = {}) {
     if (listener.state === "not-listening") {
       return { kind: "not-listening", platform, pid: null, unit: null, mismatched: false };
     }
+
+    // issue #239: a confirmed listener is not proof it's dev.ocp.proxy — ask launchd what pid it
+    // believes owns the ONE label this repo manages and compare against the pid actually holding
+    // the port. probe.launchdPrintOutput === undefined means the caller never attempted this
+    // probe at all — same legacy/back-compat convention as probe.cmdlineContent on the Linux side
+    // (issue #237): skip the check, preserve pre-#239 behavior, instead of newly refusing
+    // restarts that were "safe" before this field existed.
+    if (probe.launchdPrintOutput === undefined) {
+      return { kind: "launchd", platform, pid: listener.pid, unit: expectedUnit || "dev.ocp.proxy", mismatched: false };
+    }
+    const job = classifyLaunchdJob(probe.launchdPrintOutput);
+    if (job.state === "unknown") {
+      return { kind: "unknown", platform, pid: listener.pid, unit: null, mismatched: false, reason: job.reason };
+    }
+    if (job.state !== "running" || String(job.pid) !== String(listener.pid)) {
+      // Not registered, registered-but-not-running, or registered with a DIFFERENT live pid — in
+      // every case the process holding the port is not verified to be dev.ocp.proxy. Collapses to
+      // the same "no-unit" terminal state Linux uses for "a pid holds the port but isn't in any
+      // (verified) unit" — deliberately not a fourth, macOS-only kind.
+      return { kind: "no-unit", platform, pid: listener.pid, unit: null, mismatched: false };
+    }
+
+    // issue #239 (mirroring #237): the label being registered and its pid matching the port's
+    // holder is still not proof that process actually runs server.mjs — a hand-edited or
+    // compromised plist could register the SAME label to launch a different program. Check the
+    // job's own argv (from the SAME `launchctl print` call above — no separate probe) exactly
+    // like classifyCmdlineOwner does for the Linux cgroup-resolved unit.
+    const argvResult = classifyLaunchdArgv(job.argv);
+    if (argvResult.state === "foreign") {
+      return {
+        kind: "foreign-process", platform, pid: listener.pid, unit: expectedUnit || "dev.ocp.proxy", mismatched: false,
+        reason: `"${expectedUnit || "dev.ocp.proxy"}" (launchd, pid ${job.pid}) owns the OCP port, but its process is not OCP's server.mjs — ${argvResult.reason}`,
+      };
+    }
+
     return { kind: "launchd", platform, pid: listener.pid, unit: expectedUnit || "dev.ocp.proxy", mismatched: false };
   }
 
@@ -550,8 +736,9 @@ export function planRestart(owner, opts = {}) {
   if (owner.kind === "unknown") {
     throw new Error(
       `restart aborted: could not determine what (if anything) owns the OCP port — ${owner.reason}. ` +
-      `Verify manually (\`ss -lptn\` / \`lsof -iTCP\` / \`cat /proc/<pid>/cgroup\`, with elevated ` +
-      `privileges if needed) before retrying. Guessing here is exactly issue #215's failure mode.`
+      `Verify manually (\`ss -lptn\` / \`lsof -iTCP\` / \`cat /proc/<pid>/cgroup\` on Linux, ` +
+      `\`launchctl print gui/$(id -u)/${opts.expectedUnit}\` on macOS, with elevated privileges if ` +
+      `needed) before retrying. Guessing here is exactly issue #215's failure mode.`
     );
   }
 
@@ -597,6 +784,22 @@ export function planRestart(owner, opts = {}) {
   }
 
   if (owner.kind === "no-unit") {
+    // issue #239: on macOS this state ALSO covers "label not registered", "label registered but
+    // not running", and "label running under a different pid than the port's holder" (all
+    // collapsed into the same terminal kind by resolveOwningUnit's darwin branch) — the Linux
+    // wording below names "systemd" and recommends a "/proc/<pid>/cgroup"-shaped remedy, neither
+    // of which exists on macOS, so the message is platform-branched rather than reused verbatim.
+    if (owner.platform === "darwin") {
+      throw new Error(
+        `restart aborted: PID ${owner.pid} holds the OCP port but is not confirmed to be managed ` +
+        `by the "${opts.expectedUnit}" launchd job (issue #239 — a confirmed listener alone is not ` +
+        `proof it's ours; launchd's own bookkeeping for that label either doesn't show it running, ` +
+        `or shows a DIFFERENT pid than the one actually holding the port). Restarting ` +
+        `"${opts.expectedUnit}" here would spawn a second, orphaned process that cannot bind the ` +
+        `port — exactly issue #215. Stop PID ${owner.pid} manually (or bring it under launchd as ` +
+        `"${opts.expectedUnit}") and re-run the upgrade.`
+      );
+    }
     throw new Error(
       `restart aborted: PID ${owner.pid} holds the OCP port but is not managed by any systemd unit ` +
       `(a bare "node server.mjs"?). Restarting "${opts.expectedUnit}" here would spawn a second, ` +
@@ -605,25 +808,32 @@ export function planRestart(owner, opts = {}) {
     );
   }
 
-  // issue #237: a real, well-formed systemd unit is not proof it's OCP's own. Unlike
-  // `mismatched` (a NAME comparison against the hard-coded expectedUnit, which only ever warns —
-  // see the warnings.push at the top of this function), this is a POSITIVE confirmation from the
-  // owning process's own /proc/<pid>/cmdline that it is definitely not server.mjs. This is the
-  // safety inverse of #215: #215 restarted the wrong thing because the resolver guessed at an
-  // identity it had no basis for; this restarts the wrong thing because the resolver correctly
-  // identifies a real unit that simply isn't ours — bouncing an unrelated production service
-  // (nginx.service, say) is outside OCP's legitimate blast radius regardless of root/sudo
-  // authorization, so this refuses unconditionally, before any of the system-unit/user-unit
-  // machinery below ever runs.
+  // issue #237 (Linux) / issue #239 (macOS): a real, well-formed unit/job name is not proof it's
+  // OCP's own. Unlike `mismatched` (a NAME comparison against the hard-coded expectedUnit, which
+  // only ever warns — see the warnings.push at the top of this function), this is a POSITIVE
+  // confirmation from the owning process's own argv (read from /proc/<pid>/cmdline on Linux, from
+  // `launchctl print`'s "arguments = { ... }" block on macOS — see classifyCmdlineOwner /
+  // classifyLaunchdArgv) that it is definitely not server.mjs. This is the safety inverse of #215:
+  // #215 restarted the wrong thing because the resolver guessed at an identity it had no basis
+  // for; this restarts the wrong thing because the resolver correctly identifies a real unit/job
+  // that simply isn't ours — bouncing an unrelated production service (nginx.service, or a
+  // relabeled non-OCP launchd job) is outside OCP's legitimate blast radius regardless of
+  // root/sudo authorization, so this refuses unconditionally, before any of the
+  // system-unit/user-unit/launchd machinery below ever runs.
   if (owner.kind === "foreign-process") {
-    // owner.reason (built by resolveOwningUnit) already names the unit, its scope, and the
-    // cmdline evidence — no need to re-preface it with another "the OCP port is owned by X" here.
+    // owner.reason (built by resolveOwningUnit) already names the unit/job, its scope, and the
+    // argv evidence — no need to re-preface it with another "the OCP port is owned by X" here.
+    // The verification commands are platform-branched: /proc/<pid>/cmdline and `ss` don't exist
+    // on macOS, and lsof/launchctl don't exist on Linux.
+    const verifyCmd = owner.platform === "darwin"
+      ? `\`lsof -nP -iTCP:<port> -sTCP:LISTEN\` / \`launchctl print gui/$(id -u)/${opts.expectedUnit}\``
+      : `\`ss -lptn\` / \`cat /proc/${owner.pid}/cmdline\``;
     throw new Error(
       `restart aborted: ${owner.reason}. Restarting an unrelated service this tooling does not ` +
       `manage is outside OCP's legitimate blast radius — refusing rather than repeating issue ` +
-      `#215's failure mode in the opposite direction (see issue #237). Verify what's actually ` +
-      `bound to this port (\`ss -lptn\` / \`cat /proc/${owner.pid}/cmdline\`) and either free the ` +
-      `port for OCP or point CLAUDE_PROXY_PORT elsewhere.`
+      `#215's failure mode in the opposite direction (see issue #237 / #239). Verify what's ` +
+      `actually bound to this port (${verifyCmd}) and either free the port for OCP or point ` +
+      `CLAUDE_PROXY_PORT elsewhere.`
     );
   }
 

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -17,7 +17,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { existsSync, copyFileSync } from "node:fs";
 import { writeSnapshot, listSnapshots, readSnapshot, gcSnapshots } from "./lib/snapshot.mjs";
-import { resolveOwningUnit, planRestart, classifySsListener } from "./lib/restart-unit.mjs";
+import { resolveOwningUnit, planRestart, classifySsListener, classifyLsofListener } from "./lib/restart-unit.mjs";
 import { DEFAULT_PORT } from "../lib/constants.mjs";
 
 // Default command runner for restart-unit gathering/probing: real execSync, string in,
@@ -104,6 +104,26 @@ function mapLsofFailureToProbeValue(err, run, port) {
   if (listening === true) return { lsofOutput: null, netstatConfirmsListener: true };
   if (listening === false) return { lsofOutput: "" };
   return { lsofOutput: null, netstatProbeFailed: true };
+}
+
+// issue #239: `launchctl print gui/<uid>/<label>` signals "label not registered" via a NONZERO
+// exit (113 observed on this host; Apple does not document launchctl's exit codes, so this is NOT
+// asserted on — matching this file's existing lsof-failure posture above, see
+// mapLsofFailureToProbeValue) with EMPTY stdout and a stderr message:
+//   Bad request.
+//   Could not find service "<label>" in domain for user gui: <uid>
+// — verified live against a deliberately nonexistent label on this host. That specific, expected
+// failure maps to `""` (classifyLaunchdJob's own "not-registered" sentinel — same convention
+// mapLsofFailureToProbeValue uses for lsof's own "nothing matched" signature above); anything else
+// (permission failure, launchctl itself missing, a differently-worded failure) maps to `null`
+// ("unknown" — genuinely couldn't tell), never silently treated the same as "not registered".
+function mapLaunchctlPrintFailureToProbeValue(err) {
+  const stdout = err && err.stdout != null ? String(err.stdout) : "";
+  const stderr = err && err.stderr != null ? String(err.stderr) : "";
+  if (stdout.trim() === "" && /Could not find service/i.test(stderr)) {
+    return { launchdPrintOutput: "" };
+  }
+  return { launchdPrintOutput: null };
 }
 
 // Resolve which unit actually owns the OCP port and build a restart plan for it, instead
@@ -193,6 +213,24 @@ function resolveRestartPlan({ opts, port, isRollback = false, fromCommit = null 
           if (mapped.netstatConfirmsListener) probe.netstatConfirmsListener = true;
           if (mapped.netstatProbeFailed) probe.netstatProbeFailed = true;
         }
+      }
+
+      // issue #239: a confirmed listener alone is not proof it's dev.ocp.proxy — gather launchd's
+      // own bookkeeping for the ONE label this repo manages, keyed off nothing but the label
+      // itself (unlike Linux, launchd has no pid -> label reverse lookup, so this doesn't need
+      // listener.pid the way the cgroup/cmdline reads below do). resolveOwningUnit
+      // (scripts/lib/restart-unit.mjs) uses this to verify the port's actual holder before ever
+      // treating a confirmed listener as a restart candidate — see classifyLaunchdJob /
+      // classifyLaunchdArgv for the pure classification half. Only probed once a listener is
+      // actually confirmed (same "don't shell out for nothing" posture the Linux branch below
+      // already takes for its own cgroup/cmdline reads).
+      const macListener = classifyLsofListener(probe.lsofOutput, {
+        netstatConfirmsListener: !!probe.netstatConfirmsListener,
+        netstatProbeFailed: !!probe.netstatProbeFailed,
+      });
+      if (macListener.state === "listening") {
+        try { probe.launchdPrintOutput = run(`launchctl print gui/$(id -u)/${expectedUnit}`); }
+        catch (err) { probe.launchdPrintOutput = mapLaunchctlPrintFailureToProbeValue(err).launchdPrintOutput; }
       }
     } else {
       try { probe.ssOutput = run(`ss -lptn "sport = :${port}"`); } catch { probe.ssOutput = null; }

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -8182,7 +8182,7 @@ test("LOW-2 (real shell, verified mechanism): ocp's doctor-check-surfacing block
 // and asserts on return values or thrown messages — never on scripts/
 // upgrade.mjs's or scripts/lib/restart-unit.mjs's source text.
 // ═══════════════════════════════════════════════════════════════════════════
-import { resolveOwningUnit, planRestart, classifySsListener, classifyLsofListener, parseCgroupUnit, classifyCmdlineOwner } from "./scripts/lib/restart-unit.mjs";
+import { resolveOwningUnit, planRestart, classifySsListener, classifyLsofListener, parseCgroupUnit, classifyCmdlineOwner, classifyLaunchdJob, classifyLaunchdArgv } from "./scripts/lib/restart-unit.mjs";
 
 console.log("\nRestart-unit resolution (issue #215) — classifiers:");
 
@@ -8367,6 +8367,95 @@ test("classifyCmdlineOwner: empty-string cmdline read is also 'unknown', not 'fo
   assert.equal(classifyCmdlineOwner("").state, "unknown");
 });
 
+console.log("\nRestart-unit resolution (issue #239) — classifyLaunchdJob:");
+
+// issue #239: macOS has no /proc/<pid>/cgroup reverse lookup, so ownership resolution runs the
+// OTHER direction from Linux — ask launchd what pid IT believes owns the ONE label this repo
+// manages, via `launchctl print gui/<uid>/dev.ocp.proxy`. classifyLaunchdJob is the pure
+// classifier for that command's raw stdout, mirroring parseCgroupUnit's role on the Linux side.
+// Fixture shapes below are taken from a live capture against the real dev.ocp.proxy job (see this
+// function's own comment in scripts/lib/restart-unit.mjs) and from the live "Could not find
+// service" probe against a deliberately nonexistent label.
+
+const LAUNCHCTL_PRINT_LIVE_SAMPLE =
+  "gui/501/dev.ocp.proxy = {\n" +
+  "\tactive count = 1\n" +
+  "\tpath = /Users/tester/Library/LaunchAgents/dev.ocp.proxy.plist\n" +
+  "\ttype = LaunchAgent\n" +
+  "\tstate = running\n\n" +
+  "\tprogram = /opt/homebrew/Cellar/node/26.5.0/bin/node\n" +
+  "\targuments = {\n" +
+  "\t\t/opt/homebrew/Cellar/node/26.5.0/bin/node\n" +
+  "\t\t/Users/tester/ocp/server.mjs\n" +
+  "\t}\n\n" +
+  "\tdomain = gui/501 [100018]\n" +
+  "\tpid = 55416\n" +
+  "\tlast exit code = (never exited)\n" +
+  "}";
+
+test("classifyLaunchdJob: full live-shaped capture (registered + running) → running, correct pid and argv", () => {
+  const result = classifyLaunchdJob(LAUNCHCTL_PRINT_LIVE_SAMPLE);
+  assert.equal(result.state, "running");
+  assert.equal(result.pid, "55416");
+  assert.deepEqual(result.argv, ["/opt/homebrew/Cellar/node/26.5.0/bin/node", "/Users/tester/ocp/server.mjs"]);
+});
+
+test("classifyLaunchdJob: not-registered — the gather layer's sentinel for launchctl's \"Could not find service\" failure is an EMPTY string, not null", () => {
+  // scripts/upgrade.mjs's mapLaunchctlPrintFailureToProbeValue turns the live "Could not find
+  // service ..." nonzero-exit failure into "" — this function's job is just to classify that
+  // sentinel correctly, not to talk to launchctl itself.
+  assert.deepEqual(classifyLaunchdJob(""), { state: "not-registered", pid: null, argv: null, reason: null });
+  assert.equal(classifyLaunchdJob("   \n").state, "not-registered", "whitespace-only output must also count as empty");
+});
+
+test("classifyLaunchdJob: registered but NOT running — no \"pid = \" line anywhere in a non-empty blob → not-running", () => {
+  const blob = "gui/501/dev.ocp.proxy = {\n\tstate = not running\n\tpath = /Users/tester/Library/LaunchAgents/dev.ocp.proxy.plist\n}";
+  const result = classifyLaunchdJob(blob);
+  assert.equal(result.state, "not-running");
+  assert.equal(result.pid, null);
+});
+
+test("classifyLaunchdJob: printOutput === null (probe didn't run / failed some other way) → unknown, never a false 'not-registered'", () => {
+  // Same "unknown must never be treated as safe-to-guess" posture as every other classifier in
+  // this file: null means genuinely couldn't tell, distinct from "" (a string, positively
+  // confirmed empty by the gather layer's specific "Could not find service" mapping).
+  const result = classifyLaunchdJob(null);
+  assert.equal(result.state, "unknown");
+  assert.notEqual(result.state, "not-registered");
+  assert.ok(result.reason);
+});
+
+console.log("\nRestart-unit resolution (issue #239) — classifyLaunchdArgv:");
+
+// issue #239 (mirroring #237): classifyLaunchdJob answers "is a process running under the label,
+// and what pid/argv does launchd say it has" — never "does that argv actually invoke server.mjs".
+// classifyLaunchdArgv closes that gap using the EXACT SAME predicate classifyCmdlineOwner uses on
+// Linux (findServerMjsArg) — reused, not reimplemented.
+
+test("classifyLaunchdArgv: argv invokes server.mjs directly → ocp", () => {
+  assert.deepEqual(classifyLaunchdArgv(["node", "server.mjs"]), { state: "ocp", reason: null });
+});
+
+test("classifyLaunchdArgv: argv invokes an absolute path ending in /server.mjs → ocp", () => {
+  assert.deepEqual(classifyLaunchdArgv(["/opt/homebrew/bin/node", "/Users/tester/ocp/server.mjs"]), { state: "ocp", reason: null });
+});
+
+test("classifyLaunchdArgv: a hand-edited/hijacked label running a DIFFERENT program → foreign, names the argv in the reason", () => {
+  // The macOS analogue of #237's nginx scenario: the dev.ocp.proxy LABEL is registered and
+  // running, its pid matches the port's holder, but its ProgramArguments were changed (by hand,
+  // or by a compromised installer) to launch something that isn't server.mjs at all.
+  const result = classifyLaunchdArgv(["/usr/bin/python3", "/opt/some-other-daemon/main.py"]);
+  assert.equal(result.state, "foreign");
+  assert.ok(result.reason.includes("does not invoke server.mjs"));
+  assert.ok(result.reason.includes("main.py"), `reason should name the actual argv; got: ${result.reason}`);
+});
+
+test("classifyLaunchdArgv: empty or non-array argv → foreign, never throws", () => {
+  assert.equal(classifyLaunchdArgv([]).state, "foreign");
+  assert.equal(classifyLaunchdArgv(null).state, "foreign");
+  assert.equal(classifyLaunchdArgv(undefined).state, "foreign");
+});
+
 console.log("\nRestart-unit resolution (issue #237) — resolveOwningUnit + planRestart refuse a FOREIGN process holding the port:");
 
 test("resolveOwningUnit: a real systemd unit (nginx.service) whose process is confirmed NOT server.mjs resolves to 'foreign-process', not 'system-unit'", () => {
@@ -8491,6 +8580,144 @@ test("HIGH-1: resolveOwningUnit — root-owned listener seen by a non-root updat
 
 test("resolveOwningUnit: macOS — tool didn't run (null lsofOutput) → unknown, not not-listening", () => {
   assert.equal(resolveOwningUnit({ platform: "darwin", lsofOutput: null }).kind, "unknown");
+});
+
+test("resolveOwningUnit: launchdPrintOutput ABSENT (undefined, not null) preserves pre-#239 behavior — backward compatible for callers not wired to the new check", () => {
+  // Mirrors the Linux-side "cmdlineContent ABSENT" test below (issue #237's own back-compat
+  // guarantee) — the SAME test right above this one ("macOS launchd — port held, resolves to the
+  // known label") already exercises this implicitly (it never sets launchdPrintOutput at all),
+  // but this test names the guarantee explicitly and would fail loudly if a future change made
+  // the field required rather than optional.
+  const owner = resolveOwningUnit({
+    platform: "darwin",
+    expectedUnit: "dev.ocp.proxy",
+    lsofOutput: `COMMAND   PID  USER   FD   TYPE DEVICE SIZE/OFF NODE NAME\nnode    12345 opc   23u  IPv6 0x1234      0t0  TCP *:3456 (LISTEN)`,
+    // launchdPrintOutput deliberately omitted — undefined, not null.
+  });
+  assert.equal(owner.kind, "launchd");
+  assert.equal(owner.pid, "12345");
+});
+
+console.log("\nRestart-unit resolution (issue #239) — resolveOwningUnit darwin composition (launchd identity verification):");
+
+test("#239: resolveOwningUnit — launchd job registered, running, matching pid, argv invokes server.mjs → launchd", () => {
+  const owner = resolveOwningUnit({
+    platform: "darwin",
+    expectedUnit: "dev.ocp.proxy",
+    lsofOutput: `COMMAND   PID  USER   FD   TYPE DEVICE SIZE/OFF NODE NAME\nnode    55416 tester 23u  IPv6 0x1234      0t0  TCP *:3456 (LISTEN)`,
+    launchdPrintOutput: LAUNCHCTL_PRINT_LIVE_SAMPLE,
+  });
+  assert.equal(owner.kind, "launchd");
+  assert.equal(owner.pid, "55416");
+  assert.equal(owner.unit, "dev.ocp.proxy");
+});
+
+test("#239: resolveOwningUnit — label NOT REGISTERED (launchdPrintOutput \"\") but a PID still holds the port → no-unit", () => {
+  // The literal issue #239 scenario: cmd_restart's nohup fallback bootout'd the launchd job
+  // successfully but a subsequent bootstrap failed, leaving a bare `node server.mjs` holding the
+  // port with dev.ocp.proxy no longer registered with launchd at all.
+  const owner = resolveOwningUnit({
+    platform: "darwin",
+    expectedUnit: "dev.ocp.proxy",
+    lsofOutput: `COMMAND   PID  USER   FD   TYPE DEVICE SIZE/OFF NODE NAME\nnode    55416 tester 23u  IPv6 0x1234      0t0  TCP *:3456 (LISTEN)`,
+    launchdPrintOutput: "",
+  });
+  assert.equal(owner.kind, "no-unit");
+  assert.equal(owner.pid, "55416");
+});
+
+test("#239: resolveOwningUnit — label registered but NOT RUNNING (no \"pid = \" line) → no-unit", () => {
+  const notRunningBlob = "gui/501/dev.ocp.proxy = {\n\tstate = not running\n\tpath = /Users/tester/Library/LaunchAgents/dev.ocp.proxy.plist\n}";
+  const owner = resolveOwningUnit({
+    platform: "darwin",
+    expectedUnit: "dev.ocp.proxy",
+    lsofOutput: `COMMAND   PID  USER   FD   TYPE DEVICE SIZE/OFF NODE NAME\nnode    55416 tester 23u  IPv6 0x1234      0t0  TCP *:3456 (LISTEN)`,
+    launchdPrintOutput: notRunningBlob,
+  });
+  assert.equal(owner.kind, "no-unit");
+});
+
+test("#239: resolveOwningUnit — launchd reports a DIFFERENT pid than the one holding the port → no-unit, not a false 'launchd'", () => {
+  // launchd says dev.ocp.proxy is running as pid 55416; lsof says the port is actually held by
+  // pid 99999. Neither probe is wrong on its own — the mismatch itself is the signal that the
+  // port's holder is not verified to be dev.ocp.proxy.
+  const owner = resolveOwningUnit({
+    platform: "darwin",
+    expectedUnit: "dev.ocp.proxy",
+    lsofOutput: `COMMAND   PID  USER   FD   TYPE DEVICE SIZE/OFF NODE NAME\nnode    99999 tester 23u  IPv6 0x1234      0t0  TCP *:3456 (LISTEN)`,
+    launchdPrintOutput: LAUNCHCTL_PRINT_LIVE_SAMPLE, // pid = 55416 inside this fixture
+  });
+  assert.equal(owner.kind, "no-unit");
+  assert.equal(owner.pid, "99999", "owner.pid must reflect the ACTUAL port holder (lsof), not launchd's belief");
+});
+
+test("#239: resolveOwningUnit — pid matches, but the job's own argv does NOT invoke server.mjs → foreign-process, not launchd", () => {
+  // A hijacked/hand-edited dev.ocp.proxy plist: the label is registered, running, and its pid
+  // genuinely matches the port's holder — but that process isn't server.mjs at all. This is the
+  // macOS analogue of #237's nginx.service scenario, and resolves to the SAME terminal kind.
+  const hijackedBlob =
+    "gui/501/dev.ocp.proxy = {\n\tstate = running\n\tprogram = /usr/bin/python3\n\t" +
+    "arguments = {\n\t\t/usr/bin/python3\n\t\t/opt/some-other-daemon/main.py\n\t}\n\tpid = 55416\n}";
+  const owner = resolveOwningUnit({
+    platform: "darwin",
+    expectedUnit: "dev.ocp.proxy",
+    lsofOutput: `COMMAND   PID  USER   FD   TYPE DEVICE SIZE/OFF NODE NAME\npython3 55416 tester 23u  IPv6 0x1234      0t0  TCP *:3456 (LISTEN)`,
+    launchdPrintOutput: hijackedBlob,
+  });
+  assert.equal(owner.kind, "foreign-process");
+  assert.ok(owner.reason.includes("main.py"), `reason should name the actual argv; got: ${owner.reason}`);
+  assert.ok(owner.reason.includes("not OCP's server.mjs"));
+});
+
+test("#239: resolveOwningUnit — launchctl print probe genuinely failed (launchdPrintOutput null) → unknown, never a false 'no-unit'", () => {
+  // Same "unknown must never be treated as safe-to-guess" posture as every other probe-failure
+  // case in this file: a genuine probe failure (permission error, launchctl itself missing) must
+  // not collapse into the SAME confident answer a positively-confirmed "not registered" gets.
+  const owner = resolveOwningUnit({
+    platform: "darwin",
+    expectedUnit: "dev.ocp.proxy",
+    lsofOutput: `COMMAND   PID  USER   FD   TYPE DEVICE SIZE/OFF NODE NAME\nnode    55416 tester 23u  IPv6 0x1234      0t0  TCP *:3456 (LISTEN)`,
+    launchdPrintOutput: null,
+  });
+  assert.equal(owner.kind, "unknown");
+  assert.notEqual(owner.kind, "no-unit");
+  assert.ok(owner.reason);
+});
+
+console.log("\nRestart-unit resolution (issue #239) — planRestart darwin-specific refusal wording:");
+
+test("#239: planRestart — darwin no-unit refusal says \"launchd\", NOT \"systemd\" (issue #239's own explicit ask)", () => {
+  const owner = { kind: "no-unit", platform: "darwin", pid: "55416", unit: null, mismatched: false };
+  assert.throws(
+    () => planRestart(owner, { expectedUnit: "dev.ocp.proxy" }),
+    /PID 55416.*launchd job.*issue #239/s
+  );
+  // Control: the wording must actually differ from the Linux message, not just additionally
+  // mention launchd — "systemd" must not appear anywhere in the darwin refusal.
+  try {
+    planRestart(owner, { expectedUnit: "dev.ocp.proxy" });
+    assert.fail("must throw");
+  } catch (e) {
+    assert.ok(!/systemd/.test(e.message), `darwin no-unit message must not mention systemd; got: ${e.message}`);
+  }
+});
+
+test("#239: planRestart — darwin foreign-process refusal names lsof/launchctl, never ss or /proc", () => {
+  const owner = {
+    kind: "foreign-process", platform: "darwin", pid: "55416", unit: "dev.ocp.proxy", mismatched: false,
+    reason: `"dev.ocp.proxy" (launchd, pid 55416) owns the OCP port, but its process is not OCP's server.mjs — owning process's argv (/usr/bin/python3 /opt/some-other-daemon/main.py) does not invoke server.mjs at all — this is not an OCP process`,
+  };
+  assert.throws(
+    () => planRestart(owner, { expectedUnit: "dev.ocp.proxy" }),
+    /lsof -nP -iTCP.*launchctl print gui/s
+  );
+  try {
+    planRestart(owner, { expectedUnit: "dev.ocp.proxy" });
+    assert.fail("must throw");
+  } catch (e) {
+    assert.ok(!/\bss -lptn\b/.test(e.message) && !/\/proc\//.test(e.message),
+      `darwin foreign-process message must not reference Linux-only tools/paths; got: ${e.message}`);
+  }
 });
 
 console.log("\nRestart-unit resolution (issue #215) — planRestart (refusals + MED-4/MED-7):");
@@ -8757,6 +8984,17 @@ function makeFakeRun(handlers) {
   };
 }
 
+// issue #239: `launchctl print` output for a registered, RUNNING dev.ocp.proxy job whose argv
+// invokes server.mjs and whose pid matches the lsof fixtures' pid (12345) used throughout this
+// section — the "everything matches, restart proceeds" fixture, reused across the macOS
+// gather-layer tests below exactly the way the Linux `cat /proc/<pid>/cmdline` fixture strings
+// ("/usr/bin/node\0/opt/ocp/server.mjs\0") are reused for the equivalent Linux tests. Shape
+// verified live against the real dev.ocp.proxy job on a real host (see scripts/lib/restart-
+// unit.mjs's classifyLaunchdJob comment for the captured output this mirrors).
+const LAUNCHCTL_PRINT_RUNNING_OCP_12345 =
+  "gui/501/dev.ocp.proxy = {\n\tstate = running\n\tprogram = /opt/homebrew/bin/node\n\t" +
+  "arguments = {\n\t\t/opt/homebrew/bin/node\n\t\t/Users/tester/ocp/server.mjs\n\t}\n\tpid = 12345\n}";
+
 test("MED-6: injected runner — Linux path calls `ss`, not `lsof` (platform branches are not swapped)", async () => {
   // This is the literal mutation the review re-derived undetected against the first version:
   // swapping which command each platform calls. A fake run that only understands `ss` and
@@ -8783,6 +9021,11 @@ test("MED-6: injected runner — Linux path calls `ss`, not `lsof` (platform bra
 test("MED-6: injected runner — macOS path calls `lsof`, not `ss`", async () => {
   const run = makeFakeRun({
     "lsof -nP": `COMMAND   PID  USER   FD   TYPE DEVICE SIZE/OFF NODE NAME\nnode    12345 opc   23u  IPv6 0x1234      0t0  TCP *:3456 (LISTEN)`,
+    // issue #239: resolveOwningUnit now also gathers launchd's own bookkeeping for the resolved
+    // pid — this fixture's scenario is the legitimate case (matching pid, argv invokes
+    // server.mjs), not the #239 no-unit/foreign-process cases covered elsewhere, so this handler
+    // must be present or the test would newly (and wrongly) refuse as "unknown".
+    "launchctl print": LAUNCHCTL_PRINT_RUNNING_OCP_12345,
     "ss ": new Error("test: ss must not be called on macOS"),
   });
   const result = await runUpgrade({
@@ -8793,6 +9036,111 @@ test("MED-6: injected runner — macOS path calls `lsof`, not `ss`", async () =>
   const restartCmds = result.phases.filter(p => p.name === "restart").map(p => p.cmd);
   assert.equal(restartCmds.length, 2);
   assert.ok(restartCmds[0].includes("launchctl bootout"));
+});
+
+console.log("\nRestart-unit resolution (issue #239) — MED-6-style: injected runner drives the REAL macOS launchctl-print gather layer:");
+
+// Every #239 test above (resolveOwningUnit / classifyLaunchdJob / classifyLaunchdArgv / planRestart)
+// exercises the PURE functions in isolation. Per this repo's own documented lesson (independent
+// review of PR #221, finding MED-6 — see the console.log heading above): the IMPURE gather layer —
+// which command runs, with which flags, how a failure maps to a probe value — is exactly where
+// real defects have lived (a platform-branch swap, an exit-code mismapping, both survived mutation
+// undetected in earlier rounds). These tests drive scripts/upgrade.mjs's ACTUAL
+// `launchctl print gui/$(id -u)/dev.ocp.proxy` invocation via a fake command router, end to end
+// through runUpgrade — not just resolveOwningUnit/planRestart called directly.
+
+test("#239 MED-6: injected runner — launchctl print \"Could not find service\" (label not registered) refuses as no-unit end to end", async () => {
+  const launchctlNotRegisteredErr = Object.assign(
+    new Error("Command failed: launchctl print gui/501/dev.ocp.proxy"),
+    { status: 113, stdout: "", stderr: 'Bad request.\nCould not find service "dev.ocp.proxy" in domain for user gui: 501\n' }
+  );
+  const run = makeFakeRun({
+    "lsof -nP": `COMMAND   PID  USER   FD   TYPE DEVICE SIZE/OFF NODE NAME\nnode    55416 tester 23u  IPv6 0x1234      0t0  TCP *:3456 (LISTEN)`,
+    "launchctl print": launchctlNotRegisteredErr,
+  });
+  await assert.rejects(async () => {
+    await runUpgrade({
+      yes: true, dryRun: false, mockExec: true,
+      mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" }, current_version: "v3.10.0", latest_version: "v3.14.0" },
+      mockPlatform: "darwin", run,
+    });
+  }, /PID 55416.*launchd job.*issue #239/s);
+});
+
+test("#239 MED-6: injected runner — a genuine launchctl failure (missing tool, no \"Could not find service\" text) maps to unknown, refuses — not silently treated as not-registered", async () => {
+  const launchctlMissingErr = Object.assign(
+    new Error("Command failed: launchctl print gui/501/dev.ocp.proxy"),
+    { status: 127, stdout: "", stderr: "/bin/sh: launchctl: command not found" }
+  );
+  const run = makeFakeRun({
+    "lsof -nP": `COMMAND   PID  USER   FD   TYPE DEVICE SIZE/OFF NODE NAME\nnode    55416 tester 23u  IPv6 0x1234      0t0  TCP *:3456 (LISTEN)`,
+    "launchctl print": launchctlMissingErr,
+  });
+  await assert.rejects(async () => {
+    await runUpgrade({
+      yes: true, dryRun: false, mockExec: true,
+      mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" }, current_version: "v3.10.0", latest_version: "v3.14.0" },
+      mockPlatform: "darwin", run,
+    });
+  }, /could not determine what.*owns the OCP port.*launchctl print did not run/s);
+});
+
+test("#239 MED-6: injected runner — launchd reports a pid mismatch end to end (real listener, real print output, wrong pid inside it) refuses as no-unit", async () => {
+  const run = makeFakeRun({
+    "lsof -nP": `COMMAND   PID  USER   FD   TYPE DEVICE SIZE/OFF NODE NAME\nnode    99999 tester 23u  IPv6 0x1234      0t0  TCP *:3456 (LISTEN)`,
+    "launchctl print": LAUNCHCTL_PRINT_RUNNING_OCP_12345, // pid = 12345 inside this fixture, not 99999
+  });
+  await assert.rejects(async () => {
+    await runUpgrade({
+      yes: true, dryRun: false, mockExec: true,
+      mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" }, current_version: "v3.10.0", latest_version: "v3.14.0" },
+      mockPlatform: "darwin", run,
+    });
+  }, /PID 99999.*launchd job/s);
+});
+
+test("#239 MED-6: injected runner — a real listener whose launchd job argv does NOT invoke server.mjs refuses as foreign-process end to end, even for rollback", async () => {
+  const hijackedBlob =
+    "gui/501/dev.ocp.proxy = {\n\tstate = running\n\tprogram = /usr/bin/python3\n\t" +
+    "arguments = {\n\t\t/usr/bin/python3\n\t\t/opt/some-other-daemon/main.py\n\t}\n\tpid = 12345\n}";
+  const run = makeFakeRun({
+    "lsof -nP": `COMMAND   PID  USER   FD   TYPE DEVICE SIZE/OFF NODE NAME\npython3 12345 tester 23u  IPv6 0x1234      0t0  TCP *:3456 (LISTEN)`,
+    "launchctl print": hijackedBlob,
+  });
+  await assert.rejects(async () => {
+    await runUpgrade({
+      rollback: true, yes: true, mockExec: true,
+      mockPlatform: "darwin", run,
+      mockSnapshots: [{ name: "upgrade-snapshot-2026-05-11T08:30:00Z", path: "/tmp/snap-x" }],
+      mockSnapshotMeta: { fromCommit: "abc1234", fromVersion: "v3.10.0", toVersion: "v3.14.0", path: "/tmp/snap-x" },
+    });
+  }, /not OCP's server\.mjs.*main\.py/s);
+});
+
+test("#239 MED-6: injected runner — launchctl print is only invoked once a listener is actually confirmed (not shelled out to for nothing)", async () => {
+  // Mirrors the Linux gather layer's own "don't shell out for nothing" posture (cgroup/cmdline
+  // are only read once ss confirms a listener). Uses an explicit call COUNTER rather than only
+  // asserting on the final error text — a "launchctl print" call whose result is discarded (the
+  // gather layer's own catch swallows any thrown error into `null` silently) would otherwise
+  // never surface in the final message at all, letting an accidental "always probe" regression
+  // pass this test vacuously even though it shells out unnecessarily on every darwin restart
+  // resolution, listening or not.
+  let launchctlPrintCalls = 0;
+  const run = makeFakeRun({
+    "launchctl print": () => { launchctlPrintCalls++; return LAUNCHCTL_PRINT_RUNNING_OCP_12345; },
+    "lsof -nP": "",
+  });
+  let caught = null;
+  try {
+    await runUpgrade({
+      yes: true, dryRun: false, mockExec: true,
+      mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" }, current_version: "v3.10.0", latest_version: "v3.14.0" },
+      mockPlatform: "darwin", run,
+    });
+  } catch (e) { caught = e; }
+  assert.ok(caught, "upgrade must refuse when nothing is listening");
+  assert.ok(/nothing is currently listening/.test(caught.message), `expected the not-listening refusal; got: ${caught.message}`);
+  assert.equal(launchctlPrintCalls, 0, "launchctl print must never be invoked when nothing is listening");
 });
 
 test("MED-6: injected runner — ss tool missing (throws) maps to 'unknown', aborts loudly, never silently proceeds", async () => {
@@ -9905,6 +10253,8 @@ test("issue #233 defect 1: lsof is invoked at its absolute path (/usr/sbin/lsof)
   // test would fail with a refusal instead of a successful restart plan.
   const run = makeFakeRun({
     "/usr/sbin/lsof -nP -iTCP:": `COMMAND   PID  USER   FD   TYPE DEVICE SIZE/OFF NODE NAME\nnode    12345 opc   23u  IPv6 0x1234      0t0  TCP *:3456 (LISTEN)`,
+    // issue #239: see the "macOS path calls lsof" test above for why this handler is required now.
+    "launchctl print": LAUNCHCTL_PRINT_RUNNING_OCP_12345,
   });
   const result = await runUpgrade({
     yes: true, dryRun: false, mockExec: true,


### PR DESCRIPTION
## Summary

`resolveOwningUnit`'s darwin branch (`scripts/lib/restart-unit.mjs`) returned `kind: "launchd"`
for **any** confirmed listener on the OCP port, without ever checking whether the process holding
it was actually the `dev.ocp.proxy` launchd job. Linux has an analogous refusal (`kind: "no-unit"`,
via `/proc/<pid>/cgroup`) for exactly this shape; macOS had none. This PR closes that gap.

Split out of #233 (defect 2) per Iron Rule 11 — see the design write-up in #239 itself, which this
PR follows (verified against today's code before implementing, not trusted blindly, since the
surrounding module changed several times since the issue was filed).

**Does not touch `server.mjs`.** ALIGNMENT.md's `cli.js`-citation requirement governs the Class A
`cli.js`-mirror surface (`server.mjs`); `scripts/lib/restart-unit.mjs` and `scripts/upgrade.mjs`
are OCP-internal service-restart tooling, entirely outside that surface — no `cli.js` citation
applies to this change.

## Design reasoning (macOS has no `/proc`)

Linux walks `pid -> /proc/<pid>/cgroup -> unit name` — a reverse lookup. `launchd` has no
`pid -> label` equivalent (no `/proc/<pid>/launchd-label`), and this repo manages exactly ONE
label (`dev.ocp.proxy`, hardcoded — no multi-label ambiguity the way Linux has system/user scope),
so resolution has to run the OTHER direction: ask launchd what pid **it** believes owns the label,
and compare that against the pid `lsof`/`netstat` found actually holding the port.

Verified live, read-only, against the real `dev.ocp.proxy` job on this host before writing any
code:

```
$ launchctl list | grep ocp
55416	0	dev.ocp.proxy

$ launchctl print gui/501/dev.ocp.proxy
gui/501/dev.ocp.proxy = {
	...
	program = /opt/homebrew/Cellar/node/26.5.0/bin/node
	arguments = {
		/opt/homebrew/Cellar/node/26.5.0/bin/node
		/Users/taodeng/ocp/server.mjs
	}
	...
	pid = 55416
	...
}
```

And against a deliberately nonexistent label (proving the "not registered" signature, read-only,
never mutated):

```
$ launchctl print gui/501/dev.ocp.proxy.NONEXISTENT-TEST-LABEL
Bad request.
Could not find service "dev.ocp.proxy.NONEXISTENT-TEST-LABEL" in domain for user gui: 501
$ echo $?
113
```

`launchctl`'s exit codes are undocumented by Apple, so **113 is not asserted on anywhere** — the
same posture this file already takes for `lsof`'s own exit-code ambiguity (PR #240). The **message
text** (`Could not find service`) is what the gather layer keys on to distinguish "not registered"
from a genuine tool failure.

Command-choice tradeoff (`launchctl print` vs `launchctl list`): `print` targets the exact label
and gives an explicit, message-based "not found" signal; `list`'s bare table gives no such signal
(absence has to be inferred) and would need a second command to get a live/not-running distinction
`print`'s own `pid =` line already gives directly. `print` was chosen for both reasons.

**New pure classifiers** (`scripts/lib/restart-unit.mjs`, mirroring the file's existing shape):

- `classifyLaunchdJob(printOutput)` — mirrors `parseCgroupUnit`'s role. States:
  `unknown` (probe failed) / `not-registered` (empty string, the gather layer's sentinel for
  "Could not find service") / `not-running` (registered, no `pid =` line) / `running` (pid + argv,
  parsed from the `arguments = { ... }` block — one token per line, the same
  no-shell-split-ambiguity guarantee NUL-separation gives `/proc/<pid>/cmdline` on Linux, just via
  launchd's own line-per-token rendering instead).
- `classifyLaunchdArgv(argv)` — mirrors `classifyCmdlineOwner`'s #237 identity check. A pid match
  alone isn't proof the process is `server.mjs` (a hand-edited plist could register the same label
  against a different program), so this checks the job's own argv using the **exact same**
  `findServerMjsArg` predicate `classifyCmdlineOwner` already uses on Linux — factored out and
  reused, not reimplemented, so "what counts as OCP" cannot drift into a third definition per
  platform (the explicit ask for this PR).

**`resolveOwningUnit`'s darwin branch**: not-registered / not-running / pid-mismatch all collapse
into the **same** `no-unit` kind Linux already uses (no fourth, macOS-only state); a pid match with
foreign argv resolves to the **same** `foreign-process` kind PR #251 introduced for Linux's #237
fix, reused rather than duplicated.

**Fail-closed invariant** (stated explicitly in a comment in `restart-unit.mjs`): an unreadable or
ambiguous probe maps to `unknown -> refuse`, never to a confident "ours" or "foreign" answer.
`probe.launchdPrintOutput` follows the exact `undefined`-vs-`null` convention PR #251 established
for `probe.cmdlineContent` — `undefined` (caller never attempted the probe) preserves pre-#239
behavior for callers not yet wired to it; `null` (attempted, failed) is `unknown` and refuses. This
distinction is load-bearing (see mutation 6 below) and is the same bug class this codebase has been
burned by before.

`planRestart`'s `no-unit` and `foreign-process` refusal messages are now platform-branched — the
existing wording named `systemd` and `/proc/<pid>/cgroup`/`/proc/<pid>/cmdline`, none of which
exist on macOS.

**Builds on, does not duplicate**: PR #240 (`mapLsofFailureToProbeValue` /
`netstatHasListenerOnPort`, reused unchanged) and PR #251 (`classifyCmdlineOwner` /
`foreign-process` kind, mirrored here).

## Failing-then-passing test (both runs shown)

The exact same assertion (verbatim, the new regression test added by this PR) run against
`scripts/lib/restart-unit.mjs` at `main@d2ea5a7` (pre-fix) and against this branch (post-fix):

**Against `main@d2ea5a7` (FAILS):**
```
AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+ actual - expected

+ 'launchd'
- 'no-unit'
    at .../assert_test.mjs:17:8
exit code: 1
```

**Against this fix (PASSES):**
```
PASS against ./restart-unit-AFTER.mjs: owner.kind === "no-unit" ({"kind":"no-unit","platform":"darwin","pid":"55416","unit":null,"mismatched":false})
exit code: 0
```

Scenario: a bare `node server.mjs` holds the OCP port; `dev.ocp.proxy` is NOT registered with
launchd at all (the exact shape issue #239 describes — `cmd_restart`'s nohup fallback bootout'd
successfully but a subsequent bootstrap failed). Pre-fix: `resolveOwningUnit` reports `"launchd"`
and the caller would bootout/bootstrap blindly, racing a second `server.mjs` against the
already-held port (`KeepAlive => true`, verified live — a respawn loop, not a clean orphan).
Post-fix: `resolveOwningUnit` reports `"no-unit"` and `planRestart` refuses.

## Test suite

Baseline (`main@d2ea5a7`, clean run before any change): **695 passed, 9 failed** — all 9 failures
in the documented `OCP_LOCAL_TOOLS`/`ltBoot` flaky cluster (issue #248), confirmed via three
repeated runs to vary in count/membership independent of this change.

This branch, full suite, three repeated runs, serially: **718-719 passed, 7-8 failed** every time
— the *only* failures across all three runs were `OCP_LOCAL_TOOLS`/`ltBoot` integration tests
(never a restart-unit test). 22 new tests added (verified via
`git diff origin/main...HEAD -- test-features.mjs | grep -c '^+test('`); 2 pre-existing darwin gather-layer tests
(`MED-6: injected runner — macOS path calls lsof, not ss` and `issue #233 defect 1: lsof is
invoked at its absolute path`) updated with the new required `launchctl print` fixture, since this
PR's gather layer now shells out to it once a listener is confirmed — both were re-verified to
fail without the new fixture and pass with it.

## Mutation table

Every new guard mutated, named test(s) shown to fail, restored from a **file backup** (`cp`,
verified byte-identical via `shasum -a 256` — never `git checkout --`), suite reconfirmed green.
Anchor string existence asserted (via Python) before every mutation, so a silently-unapplied
mutation could never read as "not caught."

| # | Guard mutated | File | Named test(s) that failed |
|---|---|---|---|
| 1 | `resolveOwningUnit` darwin: `job.state !== "running" \|\| pid mismatch` check neutralized (`if (false)`) | restart-unit.mjs | `#239: resolveOwningUnit — label NOT REGISTERED...`, `...NOT RUNNING...`, `...DIFFERENT pid...`, `#239 MED-6: injected runner — launchctl print "Could not find service"...`, `#239 MED-6: injected runner — launchd reports a pid mismatch...` (5 tests) |
| 2 | `resolveOwningUnit` darwin: `argvResult.state === "foreign"` check neutralized | restart-unit.mjs | `#239: resolveOwningUnit — pid matches, but the job's own argv does NOT invoke server.mjs...`, `#239 MED-6: injected runner — a real listener whose launchd job argv does NOT invoke server.mjs...` (2 tests) |
| 3 | `classifyLaunchdJob`'s empty-string (`not-registered`) detection neutralized | restart-unit.mjs | `classifyLaunchdJob: not-registered — the gather layer's sentinel...` |
| 4 | Shared `findServerMjsArg` predicate mutated to always match | restart-unit.mjs | 9 tests across **both** #237 (Linux) and #239 (macOS) suites, incl. `classifyCmdlineOwner: nginx's real cmdline...`, `classifyLaunchdArgv: a hand-edited/hijacked label...`, `resolveOwningUnit: a real systemd unit (nginx.service)...`, `#237: upgrade full path — a FOREIGN systemd unit...` — proof the shared predicate genuinely protects both platforms, not a divergent third notion |
| 5 | `planRestart`'s `owner.platform === "darwin"` branch (no-unit message) neutralized | restart-unit.mjs | `#239: planRestart — darwin no-unit refusal says "launchd", NOT "systemd"...`, plus 2 MED-6 injected-runner tests whose regex expects the darwin wording |
| 6 | `probe.launchdPrintOutput === undefined` widened to `== null` (swallows genuine failures into the back-compat lane — the exact bug class this file was burned by before) | restart-unit.mjs | `#239: resolveOwningUnit — launchctl print probe genuinely failed... -> unknown, never a false 'no-unit'`, `#239 MED-6: injected runner — a genuine launchctl failure...` |
| 7 | `mapLaunchctlPrintFailureToProbeValue`'s `Could not find service` message match neutralized | upgrade.mjs | `#239 MED-6: injected runner — launchctl print "Could not find service"...` |
| 8 | Gather layer's "only probe once listening" gate removed (`if (true)`) | upgrade.mjs | `#239 MED-6: injected runner — launchctl print is only invoked once a listener is actually confirmed...` (test strengthened with an explicit call-counter after the first pass showed the original message-only assertion couldn't actually detect this class of regression — the swallowing `catch` hid it) |

## CI coverage — explicit statement

This is **darwin-only** runtime behavior; CI runs `ubuntu-latest`, so the `platform === "darwin"`
branch in `resolveOwningUnit`/the gather layer's `if (platform === "darwin")` block **never
executes on CI**. Nothing in this PR changes that.

What **is** genuinely CI-enforced: every new function (`classifyLaunchdJob`, `classifyLaunchdArgv`,
`mapLaunchctlPrintFailureToProbeValue`) is pure or fed **injected command OUTPUT** shaped exactly
like the real `launchctl`/`lsof`/`netstat` text captured live on this host above — the same pattern
`classifyLsofListener`/`classifySsListener`/`classifyCmdlineOwner` already use, and the reason that
pattern exists in this file. CI runs these against Linux Node, but the functions never call
`process.platform` or shell out themselves — they only classify strings — so CI does exercise the
real logic paths, just never the real macOS command invocations. The macOS-specific pieces CI
cannot verify: the actual shell command strings (`launchctl print gui/$(id -u)/...`), and that
`launchctl`'s real output matches the shapes these fixtures assume — those were verified live,
read-only, against the production host (command transcripts above), not by CI.

## Hard constraints honored

- `server.mjs` untouched (stated above and in the commit body).
- No port literals introduced in `scripts/lib/restart-unit.mjs` or `scripts/upgrade.mjs` (verified
  via `grep -E '3456|3478'` against the diff — zero hits).
- No destructive commands run against the production `dev.ocp.proxy` job on this host — only
  read-only `launchctl print` / `launchctl list` / `ps` / `lsof` (transcripts above).
- Mutation restores used file-backup `cp` + `shasum -a 256` verification exclusively, never
  `git checkout --`.
- `Closes #239` appears exactly once in the commit; every other issue reference (#215, #221, #233,
  #234, #237, #240, #248, #251) uses neutral wording — verified via
  `git log -1 --format=%B | grep -inE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+'`, which
  matches only `Closes #239`.

## Independent review (Iron Rule 10)

A fresh-context reviewer subagent (no prior visibility into this implementation) reviewed the
full diff, read AGENTS.md/CLAUDE.md/ALIGNMENT.md first, confirmed `server.mjs` is untouched,
independently re-ran the full test suite twice, independently re-derived and re-verified mutation
#6 from scratch (own backup, own `shasum -a 256` restore-verification), and grepped the commit/PR
text for closing-keyword footguns against other issue numbers. Verdict: **APPROVE**. One nitpick
caught and corrected: the original draft claimed "24 new tests" where the actual count (verified
via `git diff origin/main...HEAD -- test-features.mjs | grep -c '^+test('`) is 22 — fixed above.

Closes #239
