### PR TITLE
fix(test): ltFreePort callers retry on a fresh port after EADDRINUSE

### DIFF
--- a/test-features.mjs
+++ b/test-features.mjs
@@ -1217,6 +1217,100 @@ async function ltFreePort() {
   await new Promise(r => srv.close(r));
   return p;
 }
+// #219: ltFreePort()'s bind-then-close-then-return-the-number is a textbook TOCTOU — the port
+// is unowned between our close() and the child's own listen(), and anything (a sibling
+// ltFreePort() in this same process, a concurrent suite process, or an unrelated outbound
+// connection) can take it in that window. Closing the window entirely would mean the CHILD
+// binds :0 itself and reports the port it actually got — but the banner's port comes from the
+// configured value, not `server.address().port` (server.mjs:3638), so that fix lives in
+// server.mjs and is out of scope here (test-infra only; no cli.js citation would apply to it
+// either way, and out-of-scope server.mjs changes are exactly what this repo's governance
+// exists to prevent). That leaves narrowing the window's IMPACT: detect a collision and retry
+// with a FRESH port rather than reusing the one that just lost the race.
+//
+// A collided child is silent, not crashed: server.mjs installs a process-wide
+// `uncaughtException` handler that logs and swallows (server.mjs:3553), so a failed
+// `server.listen()` never reaches "listening on", never exits, and never closes on its own —
+// it just hangs until something kills it. The only signal is on stderr, written by that
+// handler's `logEvent("error", "uncaught_exception", {...})`
+// (server.mjs:862-869 -> console.error(JSON.stringify({level:"error", event:"uncaught_exception",
+// error: "listen EADDRINUSE: ..."}))). LT_EADDRINUSE_RE below is that exact shape.
+//
+// The probe window (LT_COLLISION_PROBE_MS) only has to catch the DEFINITIVE collision
+// signature, not decide whether a slow-but-healthy boot will eventually succeed. On any other
+// signal (success, a non-collision exit, or the probe window simply elapsing) this returns
+// immediately and lets the caller's own existing ltWait(...) call — already present in every
+// test body — do the rest, unchanged: a slow-but-uncollided boot is not retried here. This is
+// NOT a claim of being unaffected by #248's contention -- ltBootFresh's own probe is itself a
+// wait, so under heavy contention this function's total worst-case time does grow (bounded by
+// LT_COLLISION_PROBE_MS x maxAttempts). What it IS orthogonal to is #248's actual fix: this
+// function doesn't touch ltWait's ceiling/backoff logic, which is shared by every caller in the
+// file and is #248's territory. The two changes are independent even though both, separately,
+// make ltBoot-based tests take longer to fail under contention.
+//
+// maxAttempts=3, each with a FRESH port (never the one that just collided): the issue measured
+// 7/300 (~2.3%) on Linux CI at 4-way concurrency. Treating attempts as independent draws,
+// P(all 3 collide) ~= 0.023^3 ~= 1.2e-5 -- roughly a 2000x reduction in the residual failure
+// rate for the same host conditions that produced 7/300.
+const LT_EADDRINUSE_RE = /"event":"uncaught_exception"[^\n]*EADDRINUSE/;
+// Generous, not tight: reaching server.listen() at all needs the same startup work (module
+// load, sqlite open, etc.) that a successful boot needs, so under host contention the collision
+// signature can be just as slow to appear as "listening on" is. A too-short probe doesn't cause
+// a false positive, only a false NEGATIVE — it falls through to "not (yet) collided" and hands
+// back to the caller's own wait, which is safe but forfeits the retry; too short was observed
+// directly while validating this fix: an earlier 5000ms probe made the deterministic regression
+// test below fail (the outer wait timed out with the EADDRINUSE line already present in stderr
+// by the time the failure was reported — the probe had simply given up before noticing it).
+// 20000ms was re-tested and passed reliably, repeatedly, under the same host/load conditions
+// that made 5000ms fail -- but re-running the suite later, alongside heavier ambient contention
+// from other concurrent sessions on the same dev host (multiple full `npm test` runs from
+// unrelated agent worktrees observed via `ps` while validating this fix), 20000ms ALSO proved
+// too short (closeMs~54s, still open). test.yml runs this on an isolated ubuntu-latest runner
+// with nothing else scheduled on it (see that workflow's own comment), so CI is not exposed to
+// this class of contention -- the risk is specific to a shared dev host running several agent
+// sessions at once, which is exactly the scenario #248 and #219 both exist because of. Set
+// generously enough to absorb that, since the cost of a slow PASS here is just wall-clock time,
+// not correctness: the end-to-end total this test can take is bounded by LT_COLLISION_PROBE_MS
+// (this attempt's probe) plus whatever the retry's own boot needs, which is a separate, explicit
+// ceiling at the call site below — not this constant.
+const LT_COLLISION_PROBE_MS = 45000;
+// onPort(port, attempt), if given, runs after the port is drawn but before the child spawns —
+// test-only instrumentation (this whole function is test-side, not server.mjs, so there's no
+// "production hook" concern here) that lets a dedicated regression test occupy the exact port
+// just handed back and DETERMINISTICALLY reproduce the race window instead of waiting on rare
+// natural timing. See "ltBootFresh recovers from a forced port collision" below.
+async function ltBootFresh(env, dir, nodeArgs = [], maxAttempts = 3, onPort = null) {
+  let last = null;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const port = await ltFreePort();
+    if (onPort) await onPort(port, attempt);
+    const result = ltBoot({ ...env, CLAUDE_PROXY_PORT: String(port) }, dir, nodeArgs);
+    const { buf } = result;
+    // Every terminal signal ends the probe promptly, not just a clean exit: buf.exit stays null
+    // on a SIGKILL/SIGTERM death (Node reports code=null there), so buf.exit != null alone would
+    // miss it and burn the full LT_COLLISION_PROBE_MS on a child that already died. buf.closed
+    // (fires on 'close', after any exit/signal) and buf.spawnErr (fires on 'error', e.g. ENOENT)
+    // catch those. This also means an attempt's own buf.spawnErr is populated BEFORE this
+    // function returns, so a caller doesn't need its own late-attached listener to see it.
+    await ltWait(() =>
+      buf.out.includes("listening on") || buf.exit != null || buf.closed || buf.spawnErr ||
+      LT_EADDRINUSE_RE.test(buf.err),
+      LT_COLLISION_PROBE_MS);
+    last = { ...result, port };
+    if (!LT_EADDRINUSE_RE.test(buf.err)) return last; // success, a different failure, or just still booting
+    if (process.env.LT_DEBUG) console.warn(`    [ltBootFresh] port ${port} collided (EADDRINUSE), retry ${attempt}/${maxAttempts}`);
+    result.child.kill("SIGKILL"); // this attempt is dead on a bad port; free it before redrawing
+    // Same gap as ltTest's between-test drain and bootOnce's sequential-boot fix (#248):
+    // kill() only SENDS the signal, 'close' (and _ltActiveBoots's decrement) fires
+    // asynchronously after. Without waiting here, the NEXT attempt's ltBoot() call — a couple
+    // lines up, next loop iteration — could overlap this collided child's still-in-flight
+    // teardown, pushing _ltActiveBoots above 1 even though only one attempt is ever meant to be
+    // "live" at a time. Caught by the #248 peak-concurrency regression test once this test
+    // (added by #219) joined that same ltTest queue.
+    await ltWait(() => buf.closed, 5000);
+  }
+  return last; // attempts exhausted — hand back the last (still-collided) attempt for the caller to diagnose
+}
 async function ltPost(port, body) {
   try {
     await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
@@ -1273,11 +1367,46 @@ function ltTest(name, fn) {
 
 console.log("\nOCP_LOCAL_TOOLS integration (boot server.mjs):");
 
+// #219 regression: the natural race is rare by construction (the issue measured 7/300 on Linux
+// CI) -- too rare to gate a mutation on. This forces it deterministically: occupy the EXACT
+// port ltFreePort() just handed back, in the same window a sibling process would exploit, so
+// the first real server.mjs child hits a genuine EADDRINUSE (not a simulated one) and
+// ltBootFresh's retry path is exercised end to end against real processes and a real socket
+// collision -- port drawn for real, child spawned for real, collision forced for real, retry
+// for real, success for real. Wrapped in ltTest (#248), same as every other test in this block
+// spawning a real server.mjs child -- this one is no exception, and being unwrapped would both
+// let it race the others and put it back outside #248's peak-concurrency guarantee.
+ltTest("integration: ltBootFresh recovers from a forced port collision by retrying on a fresh port (#219)", async () => {
+  if (!LT_POSIX) return;
+  const dir = ltMkdir(); const fake = ltFake(dir);
+  let blocker = null;
+  const { child, buf, port } = await ltBootFresh({ CLAUDE_BIN: fake }, dir, [], 3, async (p, attempt) => {
+    if (attempt === 1) {
+      blocker = _ltNetServer();
+      await new Promise(r => blocker.listen(p, "127.0.0.1", r));
+    }
+  });
+  try {
+    // A generous explicit ceiling: this attempt already paid the LT_COLLISION_PROBE_MS cost for
+    // the forced first-attempt collision before ever reaching this line, and the retry's own
+    // boot still has to do the full startup work under whatever host contention is present.
+    assert.ok(await ltWait(() => buf.out.includes("listening on") || buf.exit != null, 45000),
+      `expected the retry to recover onto a fresh port after the forced collision — ${ltDiag(buf)}`);
+    assert.ok(buf.out.includes("listening on"),
+      `boot must ultimately succeed after the forced first-attempt collision — ${ltDiag(buf)}`);
+    assert.ok(blocker && blocker.address() && blocker.address().port !== port,
+      `the recovered boot must be on a DIFFERENT port than the one that was deliberately occupied`);
+  } finally {
+    child.kill("SIGKILL");
+    if (blocker) await new Promise(r => blocker.close(r));
+    _ltRmRetry(dir);
+  }
+});
+
 ltTest("integration: OCP_LOCAL_TOOLS=1 → the -p spawn receives the POSITIVE wrapper (kills the no-op mutation)", async () => {
   if (!LT_POSIX) return; // sh fake — skip on Windows CI
   const dir = ltMkdir(); const cap = join(dir, "sp.txt"); const fake = ltFake(dir);
-  const port = await ltFreePort();
-  const { child, buf } = ltBoot({ OCP_LOCAL_TOOLS: "1", CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port), SP_CAPTURE: cap }, dir);
+  const { child, buf, port } = await ltBootFresh({ OCP_LOCAL_TOOLS: "1", CLAUDE_BIN: fake, SP_CAPTURE: cap }, dir);
   try {
     assert.ok(await ltWait(() => buf.out.includes("listening on") || buf.exit != null), `server did not start: ${buf.err.slice(0,200)}`);
     await ltPost(port, { model: "sonnet", messages: [{ role: "user", content: "hi" }] });
@@ -1291,8 +1420,7 @@ ltTest("integration: OCP_LOCAL_TOOLS=1 → the -p spawn receives the POSITIVE wr
 ltTest("integration: flag OFF → the -p spawn receives the EXACT negative wrapper (default path byte-for-byte)", async () => {
   if (!LT_POSIX) return;
   const dir = ltMkdir(); const cap = join(dir, "sp.txt"); const fake = ltFake(dir);
-  const port = await ltFreePort();
-  const { child, buf } = ltBoot({ CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port), SP_CAPTURE: cap }, dir); // OCP_LOCAL_TOOLS unset
+  const { child, buf, port } = await ltBootFresh({ CLAUDE_BIN: fake, SP_CAPTURE: cap }, dir); // OCP_LOCAL_TOOLS unset
   try {
     assert.ok(await ltWait(() => buf.out.includes("listening on") || buf.exit != null), `server did not start: ${buf.err.slice(0,200)}`);
     await ltPost(port, { model: "sonnet", messages: [{ role: "user", content: "hi" }] });
@@ -1313,8 +1441,7 @@ ltTest("integration: boot gate REFUSES each unsafe config (multi / non-loopback 
   ];
   try {
     for (const c of cases) {
-      const port = await ltFreePort();
-      const { child, buf } = ltBoot({ OCP_LOCAL_TOOLS: "1", CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port), ...c.env }, dir);
+      const { child, buf } = await ltBootFresh({ OCP_LOCAL_TOOLS: "1", CLAUDE_BIN: fake, ...c.env }, dir);
       try {
         // Wait for `closed`, not `exit`: the assertion below reads buf.err, and stderr is only
         // guaranteed drained at 'close'. This is the ordering #203 was filed for.
@@ -1336,8 +1463,7 @@ ltTest("integration: boot gate REFUSES each unsafe config (multi / non-loopback 
 ltTest("integration: safe single-user config BOOTS past the gate and announces local tools", async () => {
   if (!LT_POSIX) return;
   const dir = ltMkdir(); const fake = ltFake(dir);
-  const port = await ltFreePort();
-  const { child, buf } = ltBoot({ OCP_LOCAL_TOOLS: "1", CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port) }, dir); // loopback + none
+  const { child, buf } = await ltBootFresh({ OCP_LOCAL_TOOLS: "1", CLAUDE_BIN: fake }, dir); // loopback + none
   try {
     // Same race as #199, one line over: "Local tools: ON" (server.mjs:3640) is written 12
     // console.log calls after "listening on" (:3627) — 10 of them in this env, since the
@@ -1367,8 +1493,7 @@ ltTest("integration: TUI mode → flag is announced INERT (not 'ON'), boot not r
   const dir = ltMkdir(); const fake = ltFake(dir);
   // Non-loopback would normally trip the local-tools gate; under TUI the flag is inert so the
   // gate must NOT fire on its behalf. Use loopback here to isolate TUI's own guards from ours.
-  const port = await ltFreePort();
-  const { child, buf } = ltBoot({ OCP_LOCAL_TOOLS: "1", CLAUDE_TUI_MODE: "true", CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port) }, dir);
+  const { child, buf } = await ltBootFresh({ OCP_LOCAL_TOOLS: "1", CLAUDE_TUI_MODE: "true", CLAUDE_BIN: fake }, dir);
   try {
     // Wait for the line actually under assertion, not for a proxy signal. "listening on" and the
     // inert-flag warning are written independently, so gating on the former and then asserting
@@ -1389,8 +1514,8 @@ ltTest("integration: toggling OCP_LOCAL_TOOLS invalidates the standard response 
   if (!LT_POSIX) return;
   const dir = ltMkdir(); const fake = ltFake(dir); const counter = join(dir, "spawns.txt");
   const req = { model: "sonnet", messages: [{ role: "user", content: "epoch-probe" }] };
-  const bootOnce = async (env, port) => {
-    const { child, buf } = ltBoot({ CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port), CLAUDE_CACHE_TTL: "60000", SP_COUNTER: counter, ...env }, dir);
+  const bootOnce = async (env) => {
+    const { child, buf, port } = await ltBootFresh({ CLAUDE_BIN: fake, CLAUDE_CACHE_TTL: "60000", SP_COUNTER: counter, ...env }, dir);
     try {
       assert.ok(await ltWait(() => buf.out.includes("listening on")), `did not start: ${buf.err.slice(0,160)}`);
       _ltWrite(counter, "0"); // reset AFTER boot so boot-time spawns (if any) don't count
@@ -1407,8 +1532,8 @@ ltTest("integration: toggling OCP_LOCAL_TOOLS invalidates the standard response 
     }
   };
   try {
-    const off = await bootOnce({}, await ltFreePort());                       // caches "OK" under epoch(negative)
-    const on = await bootOnce({ OCP_LOCAL_TOOLS: "1" }, await ltFreePort());  // same DB, epoch(positive) → must MISS → re-spawn
+    const off = await bootOnce({});                       // caches "OK" under epoch(negative)
+    const on = await bootOnce({ OCP_LOCAL_TOOLS: "1" });  // same DB, epoch(positive) → must MISS → re-spawn
     assert.equal(off, 1, "first request (cache empty) must spawn claude");
     assert.equal(on, 1, "after toggling the flag the identical request must NOT be served from the old cache (epoch differs → re-spawn)");
   } finally { _ltRmRetry(dir); }
@@ -1468,16 +1593,19 @@ ltTest("integration: a synchronous pre-spawn throw must not leak stats.activeReq
   // Hard gate: if this ever stops fitting, fail loudly rather than regress to an E2BIG skip.
   assert.ok(bytes <= LT_MAX_ARG_STRLEN,
     `env entry ${bytes}B exceeds MAX_ARG_STRLEN ${LT_MAX_ARG_STRLEN}B — lower LT_STACK`);
-  const port = await ltFreePort();
   const dir = ltMkdir(); const fake = ltFake(dir);
-  const { child, buf } = ltBoot({
-    CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port), CLAUDE_ALLOWED_TOOLS: entry,
+  const { child, buf, port } = await ltBootFresh({
+    CLAUDE_BIN: fake, CLAUDE_ALLOWED_TOOLS: entry,
   }, dir, [`--stack-size=${LT_STACK}`]);
-  let spawnErr = null;
-  child.on("error", e => { spawnErr = e; });
+  // Read buf.spawnErr directly rather than attaching a fresh child.on("error", ...) listener
+  // here: ltBootFresh's internal wait can already resolve on the collision-probe path before
+  // control returns to this line, and Node does not replay an 'error' event to a listener
+  // attached after it already fired. ltBoot() attaches its own listener at spawn time
+  // (test-features.mjs, inside ltBoot), so buf.spawnErr is populated promptly regardless of
+  // when this test itself gets a chance to look at it.
   try {
-    const up = await ltWait(() => buf.out.includes("listening on") || spawnErr, 20000);
-    assert.ok(up && !spawnErr, `did not start: ${spawnErr ? spawnErr.message : buf.err.slice(0, 300)}`);
+    const up = await ltWait(() => buf.out.includes("listening on") || buf.spawnErr, 20000);
+    assert.ok(up && !buf.spawnErr, `did not start: ${buf.spawnErr ? buf.spawnErr.message : buf.err.slice(0, 300)}`);
     const req = { model: "haiku", messages: [{ role: "user", content: "leak-probe" }] };
     const res = [];
     for (let i = 0; i < 3; i++) res.push(await ltPostStatus(port, req));
@@ -1521,8 +1649,7 @@ console.log("\nCache key resolves the model alias (#194):");
 ltTest("integration: an alias and its canonical target share ONE cache slot (normal path)", async () => {
   if (!LT_POSIX) return;
   const dir = ltMkdir(); const fake = ltFake(dir); const counter = join(dir, "spawns.txt");
-  const port = await ltFreePort();
-  const { child, buf } = ltBoot({ CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port), CLAUDE_CACHE_TTL: "60000", SP_COUNTER: counter }, dir);
+  const { child, buf, port } = await ltBootFresh({ CLAUDE_BIN: fake, CLAUDE_CACHE_TTL: "60000", SP_COUNTER: counter }, dir);
   try {
     assert.ok(await ltWait(() => buf.out.includes("listening on")), `did not start: ${buf.err.slice(0, 200)}`);
     _ltWrite(counter, "0");
@@ -1539,8 +1666,7 @@ ltTest("integration: an alias and its canonical target share ONE cache slot (nor
 ltTest("integration: an alias and its canonical target share ONE cache slot (STRUCTURED path)", async () => {
   if (!LT_POSIX) return;
   const dir = ltMkdir(); const fake = ltFakeJson(dir); const counter = join(dir, "spawns.txt");
-  const port = await ltFreePort();
-  const { child, buf } = ltBoot({ CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port), CLAUDE_CACHE_TTL: "60000", SP_COUNTER: counter }, dir);
+  const { child, buf, port } = await ltBootFresh({ CLAUDE_BIN: fake, CLAUDE_CACHE_TTL: "60000", SP_COUNTER: counter }, dir);
   try {
     assert.ok(await ltWait(() => buf.out.includes("listening on")), `did not start: ${buf.err.slice(0, 200)}`);
     _ltWrite(counter, "0");
@@ -1561,8 +1687,7 @@ ltTest("integration: an alias and its canonical target share ONE cache slot (STR
 ltTest("integration: a legacyAlias shares ONE cache slot with its canonical target", async () => {
   if (!LT_POSIX) return;
   const dir = ltMkdir(); const fake = ltFake(dir); const counter = join(dir, "spawns.txt");
-  const port = await ltFreePort();
-  const { child, buf } = ltBoot({ CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port), CLAUDE_CACHE_TTL: "60000", SP_COUNTER: counter }, dir);
+  const { child, buf, port } = await ltBootFresh({ CLAUDE_BIN: fake, CLAUDE_CACHE_TTL: "60000", SP_COUNTER: counter }, dir);
   try {
     assert.ok(await ltWait(() => buf.out.includes("listening on")), `did not start: ${buf.err.slice(0, 200)}`);
     _ltWrite(counter, "0");
@@ -1581,8 +1706,8 @@ ltTest("integration: a config change invalidates the STRUCTURED cache too (close
   const dir = ltMkdir(); const fake = ltFakeJson(dir); const counter = join(dir, "spawns.txt");
   const rf = { type: "json_schema", json_schema: { name: "probe", schema: LT_SCHEMA } };
   const req = { model: "sonnet", messages: [{ role: "user", content: "structured-epoch-probe" }], response_format: rf };
-  const bootOnce = async (env, port) => {
-    const { child, buf } = ltBoot({ CLAUDE_BIN: fake, CLAUDE_PROXY_PORT: String(port), CLAUDE_CACHE_TTL: "60000", SP_COUNTER: counter, ...env }, dir);
+  const bootOnce = async (env) => {
+    const { child, buf, port } = await ltBootFresh({ CLAUDE_BIN: fake, CLAUDE_CACHE_TTL: "60000", SP_COUNTER: counter, ...env }, dir);
     try {
       assert.ok(await ltWait(() => buf.out.includes("listening on")), `did not start: ${buf.err.slice(0, 200)}`);
       _ltWrite(counter, "0");
@@ -1599,8 +1724,8 @@ ltTest("integration: a config change invalidates the STRUCTURED cache too (close
     }
   };
   try {
-    const off = await bootOnce({}, await ltFreePort());                        // caches under epoch(negative wrapper)
-    const on = await bootOnce({ OCP_LOCAL_TOOLS: "1" }, await ltFreePort());   // same DB, epoch differs → must re-spawn
+    const off = await bootOnce({});                        // caches under epoch(negative wrapper)
+    const on = await bootOnce({ OCP_LOCAL_TOOLS: "1" });   // same DB, epoch differs → must re-spawn
     assert.equal(off, 1, "first structured request (cache empty) must spawn claude");
     assert.equal(on, 1, "structured cache must honor CONFIG_EPOCH — before #194 it omitted the epoch entirely and served the stale answer");
   } finally { _ltRmRetry(dir); }


### PR DESCRIPTION
## Summary

Closes #219 ("ltFreePort has a bind-then-close race") by narrowing the race's *impact* rather than closing the window itself, scoped entirely to `test-features.mjs`. No production code touched.

## Why not the issue's own "preferred" fix

The issue's own text proposes removing the window entirely: have the child bind `:0` itself and report the port it actually got from the banner line `ltBoot` already waits for. The issue's own follow-up comment already checked this and found it doesn't work as written — `server.mjs`'s banner is built from the *configured* `PORT` value, not `server.address().port` (`server.mjs:3638`), so with `CLAUDE_PROXY_PORT=0` the banner reports `:0`, which the harness can't parse. The real fix for that is a one-line change inside `server.mjs`'s `server.listen()` callback — which makes it a `server.mjs` change, gated by this repo's `ALIGNMENT.md` (a `cli.js` citation or an explicit Rule-2 argument, plus a fresh-context reviewer opening `cli.js` at the cited lines). That's out of scope for this PR; per the hard constraints on this work, `server.mjs` is not touched here. If someone wants to pursue it, it's a separate, `server.mjs`-governed PR.

## What this PR does

Added `ltBootFresh()`, wrapping the existing `ltFreePort()` + `ltBoot()` pairing with detection + retry:

- A collided child does not crash — `server.mjs`'s process-wide `uncaughtException` handler (`server.mjs:3553`) logs a failed `listen()` and swallows it rather than exiting, so a collided child never prints `"listening on"`, never exits, and never closes on its own. The only signal is the `logEvent` JSON on stderr (`server.mjs:862-869`): `"event":"uncaught_exception"` paired with `EADDRINUSE` in the same line. `ltBootFresh` watches for exactly that shape.
- On any other outcome (success, an unrelated failure, or the probe window just elapsing) it returns immediately and defers to the caller's own existing `ltWait(...)` call, unchanged. This is **not** a claim of full independence from #248's contention (ltBootFresh's own probe is itself a wait, so its total worst-case time does grow under the same contention #248 describes) — what's actually independent is that this PR does not touch `ltWait`'s own shared ceiling/backoff logic, which every caller in the file uses and which is #248's fix target (a separate PR, per Iron Rule 11; this branch does not include it).
- On a detected collision, it kills the dead child and retries on a **fresh** port (never the one that just lost the race) — the mechanism the issue's "why 'just retry' is the weaker fix" section already anticipated as the fallback if the window can't be closed outright.
- `maxAttempts = 3`. Treating attempts as independent draws at the issue's own measured 7/300 (~2.3%) rate: `0.023^3 ≈ 1.2e-5` — roughly a 2000x reduction in the residual failure rate under the same conditions that produced 7/300.

Every `ltFreePort()` + `ltBoot()` pairing that existed in the affected block before this change (13, confirmed by `grep` before editing) now goes through `ltBootFresh()` — 11 call sites after the two `bootOnce()` helpers collapsed their paired off/on draws into one call site apiece; a 12th `ltBootFresh()` call site is the new deterministic regression test below. `ltFreePort()` itself is unchanged and still used directly by the `"#224: scripts/upgrade.mjs --resolve-restart"` test (search `test-features.mjs` for `const freePort = await ltFreePort()`; not citing a line number here since it has already drifted twice during this PR's own edits), which only needs a plausibly-free port *number* to probe against and never binds it — the race doesn't apply there.

## Deterministic regression test

The natural race is too rare (2.3%) to gate a mutation test on reliably. Added `"integration: ltBootFresh recovers from a forced port collision by retrying on a fresh port (#219)"`, which forces the exact mechanism instead of hoping to observe it: a test-only `onPort(port, attempt)` hook on `ltBootFresh` (this function is entirely test-side, in `test-features.mjs` — none of the "no production hook" concern that would apply to instrumenting `server.mjs` applies here) occupies the *exact* port `ltFreePort()` just handed back, in the same window a sibling process would otherwise exploit. The real `server.mjs` child then hits a genuine `EADDRINUSE` — not a simulated one — and the retry path runs end-to-end for real: real port draw, real spawn, real collision, real retry, real success on a different port.

## Rate characterization

**Local synthetic reproduction found the natural race too rare to observe on this host.** A same-process `bind(0)`-then-delayed-bind probe, calibrated against 10 measured real spawn-to-`"listening on"` latencies of this exact `server.mjs`/fake-claude shape (185-441ms), run across up to 4 concurrent OS processes × 15 workers (2184 combined trials), reproduced **zero** EADDRINUSE collisions. This is not a contradiction of the issue's 7/300 — that number was measured on a resource-constrained `ubuntu-latest` runner (2-4 vCPUs); this work was done on a 10-core machine with real ambient contention from other concurrent agent sessions, which is a different enough scheduler-pressure profile that the same synthetic load doesn't reproduce comparably rare timing.

**CI-based measurement (apples-to-apples with the issue's own methodology):** triggered this repo's own `.github/workflows/flake-hunt.yml` (already built for #203's reproduction — concurrent real `npm test` runs on `ubuntu-latest`) against both `origin/main` at `d2ea5a7` (unmodified `ltFreePort`, "before") and this branch ("after"), classifying failures by the stderr `EADDRINUSE` signature specifically (not generic "did not start", which would conflate with #248 — unmodified on this branch by design).

**Results (real, downloaded artifacts, not summarized secondhand):**

| arm | ref checked out | runner | rounds x concurrency | trials | completed | clean | EADDRINUSE-signature failures |
|---|---|---|---|---|---|---|---|
| before | `d2ea5a7` (`origin/main`, unmodified `ltFreePort`) | ubuntu-latest, 4 vCPU | 30 x 4 | 120 | 120 | 118 | **2 / 120 (1.67%)** |
| after | `d1ba89e` (this branch's core fix — the retry mechanism itself; three subsequent commits on top add test-robustness only, described below, and were not re-measured on CI given time budget) | ubuntu-latest, 4 vCPU | 30 x 4 | 120 | 120 | 120 | **0 / 120 (0%; rule-of-three upper 95% bound ≈ 2.5%)** |

Both arms recorded via `env.txt`: `ref` is the literal `git rev-parse HEAD` inside the job (not just the dispatch input — verified directly, since `gh run view --json headBranch` reports the *dispatch* branch context and is not informative about what `actions/checkout@v4`'s `ref:` input actually checked out). Classification is by the `EADDRINUSE` stderr signature specifically (`grep -l EADDRINUSE`), not generic "did not start", to avoid conflating with #248. The two "before" failures: `r22c2.log` (`integration: toggling OCP_LOCAL_TOOLS invalidates the standard response cache (epoch fold)`) and `r9c3.log` (`integration: an alias and its canonical target share ONE cache slot (STRUCTURED path)`) — different tests, confirming (as the issue itself noted) the victim is whichever test draws the colliding port, not a specific assertion. 120 trials is smaller than the issue's 300 (kept to a size that fits comfortably under `flake-hunt.yml`'s 50-minute job timeout); stated as 120, not rounded up or extrapolated.

## Changes after independent review

An independent reviewer (fresh context, per Iron Rule 10) checked this PR and requested changes. All addressed in the commit now on this branch (the CI rate measurement above ran against the commit *before* these — the core retry mechanism is unchanged by them, see the table's "after" row note):

1. `ltBootFresh`'s internal wait now also terminates promptly on `buf.spawnErr`/`buf.closed`, not only a clean `buf.exit != null` — `buf.exit` stays `null` on a signal death, so the original condition could burn the full probe window on an attempt that had already died.
2. The pre-existing "synchronous pre-spawn throw" test's own `child.on("error", ...)` listener (attached *after* `ltBootFresh` already returned) could miss an error that fired during `ltBootFresh`'s internal wait — Node does not replay `'error'` to a listener attached after the fact. Switched it to read `buf.spawnErr` directly, which `ltBoot()` populates via its own listener at spawn time regardless of when the caller looks.
3. `LT_COLLISION_PROBE_MS` raised 5000 → 20000 → 45000 (and the deterministic test's own outer ceiling to match), based on directly observed failures at each prior value under real, increasing ambient contention from other concurrent sessions on this shared dev host (confirmed via `ps` — this is not synthetic). `test.yml`'s CI runner is isolated (nothing else scheduled on the VM), so this class of contention doesn't reach it; the cost of a generous local ceiling is wall-clock time on a slow pass, not correctness.
4. Corrected two inaccurate comments: an overstated "orthogonal to #248" claim (reworded above), and a timing comment that asserted a specific latency this session never actually measured (rewritten to state only what was directly observed).
5. Simplified `_ltQueue`-style bookkeeping is not used here (that's PR #264's pattern) — not applicable to this PR.

**Known limitation, flagged by review, not fixed here:** three pre-existing fixed `600ms` settle-sleeps in the alias/cache-slot tests in this same block (unrelated to the port race — they wait to confirm a would-be *second* spawn does *not* happen) could in principle mask a real caching regression under severe host contention if `600ms` isn't long enough. Left as a follow-up rather than changed without equivalent mutation verification under time pressure.

## Mutation table

Each mutation: anchor existence asserted (`grep -c` == 1) before mutating; a byte-identical `cp` backup of the fixed file taken beforehand and its sha256 recorded; restored via `cp` (never `git checkout --`) and the restored file's sha256 re-verified to match. Re-run against the post-review code (not just the original), since the wait condition changed.

| # | mutation | anchor asserted | named failure | restore verified |
|---|---|---|---|---|
| 1 | Disable the retry: `if (true \|\| !LT_EADDRINUSE_RE.test(buf.err)) return last;` — always returns after attempt 1 | yes | `integration: ltBootFresh recovers from a forced port collision by retrying on a fresh port (#219)`: hangs on the deliberately-occupied port (still open at report time) | sha256 match, 705/0 after |
| 2 | Hoist the port draw out of the retry loop — every attempt reuses the SAME (still-occupied) port | yes | same named test: exhausts all 3 attempts on the blocked port | sha256 match, 705/0 after |

## CI

- `.github/workflows/test.yml` runs `npm test` on an isolated `ubuntu-latest` runner — unaffected on the happy path.
- `.github/workflows/alignment.yml` does not trigger for this PR (path filter excludes `test-features.mjs`).
- No port literal introduced — `test-features.mjs` is explicitly exempt from the port-literal SPOT job.

## Test plan

- [x] `npm test` green, serial, before and after (705 passed — 704 existing + 1 new deterministic regression test)
- [x] Mutation table above, both restores byte-verified
- [x] CI-based rate measurement via `flake-hunt.yml`, before vs. after, trial counts stated
- [x] Independent reviewer (fresh context) reviewed; findings addressed above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gbqUZ8HfBZpjjbzQ85oH8
