### PR TITLE
fix(ocp): distinguish "the command could not run" from "the request failed" in curl call sites

### DIFF
--- a/ocp
+++ b/ocp
@@ -71,6 +71,51 @@ _pyfail() {
   return 1
 }
 
+# Issue #261 (the pattern #256/#258 partially addressed): a call site that folds curl's own
+# stderr into the captured response body via `2>&1` — `data=$(_curl ... 2>&1) || { echo "proxy
+# unreachable"; exit 1; }` — cannot tell "curl itself never ran" (a local shell/exec fault —
+# curl missing from $PATH, or a bash builtin error firing before curl was ever invoked, e.g. the
+# `set -u` "unbound variable" that used to fire inside `_curl` itself, per #256) apart from
+# "curl ran and the request genuinely failed" (network down, proxy not listening, non-2xx).
+# Both produce a nonzero exit from the `$(...)`, so both got the SAME "proxy unreachable" text —
+# exactly how #256 hid: the shell died three lines before curl would have run, and the reader
+# was pointed at a healthy service instead of the actual fault.
+#
+# `_curl_or_die` never merges the two streams: the wrapped command's own stderr is captured to a
+# private temp file (never /dev/null — discarding it would just trade one misdiagnosis for a
+# silent one), and the exit status plus that captured text decide which message fires. Exit 127
+# is bash's own reserved "command not found" code (curl itself never produces it); the text
+# "command not found" in the captured stderr is bash's own diagnostic vocabulary, never curl's —
+# either signal means the shell failed to even start the command, not that it ran and failed.
+#
+# Usage: `data=$(_curl_or_die "<network-failure label>" _curl -sf ... "$url") || exit 1` — the
+# first argument after the label is the command to run (`_curl` for authenticated call sites,
+# plain `curl` for the one unauthenticated one), so this stays a drop-in replacement for the old
+# `<cmd> ... 2>&1) || { echo "Error: <label>"; exit 1; }` shape at each site, byte-identical on
+# the success path and on a genuine network failure (same label text), and message text goes to
+# stderr (matching the sibling display commands' own stderr convention, PR #252 round 1 fix 3 —
+# these three call sites were the ones that review explicitly left untouched).
+_curl_or_die() {
+  local network_label="$1"; shift
+  local errfile out status err
+  errfile=$(mktemp "${TMPDIR:-/tmp}/ocp-curlerr.XXXXXX" 2>/dev/null) || errfile="${TMPDIR:-/tmp}/.ocp-curlerr.$$"
+  out=$("$@" 2>"$errfile")
+  status=$?
+  err=$(cat "$errfile" 2>/dev/null)
+  rm -f "$errfile"
+  if [[ $status -ne 0 ]]; then
+    if [[ $status -eq 127 ]] || [[ "$err" == *"command not found"* ]]; then
+      echo "Error: could not run curl (${err:-exit status $status}) — this is a local shell/environment fault, not a proxy problem" >&2
+    else
+      echo "Error: $network_label" >&2
+      [[ -n "$err" ]] && echo "$err" >&2
+    fi
+    return 1
+  fi
+  printf '%s' "$out"
+  return 0
+}
+
 _bar() {
   local pct=$1 width=20
   local filled=$(( pct * width / 100 ))
@@ -100,7 +145,7 @@ EOF
 cmd_usage() {
   if [[ "${1:-}" == "--by-key" ]]; then
     local data
-    data=$(_curl -sf --max-time 15 "$PROXY/api/usage" 2>&1) || { echo "Error: proxy unreachable or usage API not available"; exit 1; }
+    data=$(_curl_or_die "proxy unreachable or usage API not available" _curl -sf --max-time 15 "$PROXY/api/usage") || exit 1
     echo "$data" | python3 -c "
 import sys, json
 d = json.loads(sys.stdin.read())
@@ -121,7 +166,7 @@ else:
   fi
 
   local data
-  data=$(curl -sf --max-time 15 "$PROXY/usage" 2>&1) || { echo "Error: proxy unreachable"; exit 1; }
+  data=$(_curl_or_die "proxy unreachable" curl -sf --max-time 15 "$PROXY/usage") || exit 1
 
   echo "$data" | python3 -c "
 import sys, json
@@ -337,9 +382,9 @@ cmd_keys() {
     add)
       if [[ -z "${2:-}" ]]; then echo "Usage: ocp keys add <name>"; return 1; fi
       local result
-      result=$(_curl -sf --max-time 5 -X POST "$PROXY/api/keys" \
+      result=$(_curl_or_die "proxy unreachable or unauthorized" _curl -sf --max-time 5 -X POST "$PROXY/api/keys" \
         -H "Content-Type: application/json" \
-        -d "{\"name\": \"$2\"}" 2>&1) || { echo "Error: proxy unreachable or unauthorized"; exit 1; }
+        -d "{\"name\": \"$2\"}") || exit 1
       # Issue #242: this is the highest-stakes of the nine `_pyfail` sites — the formatted view
       # below is the ONLY place the newly created key is ever shown ("you won't see it again").
       # A silent death here (python3 missing/broken) would mean the key was created (the POST

--- a/ocp
+++ b/ocp
@@ -84,9 +84,32 @@ _pyfail() {
 # `_curl_or_die` never merges the two streams: the wrapped command's own stderr is captured to a
 # private temp file (never /dev/null — discarding it would just trade one misdiagnosis for a
 # silent one), and the exit status plus that captured text decide which message fires. Exit 127
-# is bash's own reserved "command not found" code (curl itself never produces it); the text
-# "command not found" in the captured stderr is bash's own diagnostic vocabulary, never curl's —
-# either signal means the shell failed to even start the command, not that it ran and failed.
+# is bash's own reserved "command not found" code (curl itself never produces it); exit 126 is
+# bash's own "found, but not executable" code (permission denied, ENOEXEC, a broken interpreter
+# line — this repo has its own history of exactly that shape, a corrupted `claude` native
+# binary). Independent review round 1: curl present but `chmod 000` reproduced exit 126 landing
+# in the "proxy unreachable" branch — the exact headline this issue exists to kill. Both codes,
+# plus "Permission denied"/"bad interpreter" in the captured stderr, now route to the could-not-
+# run branch. (The original text match for "command not found" alongside the 127 check was
+# dropped per the same review: bash's exit 127 already carries the full signal unconditionally,
+# and unlike this issue's own #263 sibling — which inspects a subcommand DISPATCHER's combined
+# stdout+stderr and genuinely needed the text arm removed to avoid a false positive — curl's own
+# stderr can't organically contain that phrase, so the arm was redundant, not merely benign.)
+#
+# Independent review round 1 (security, LOW-MEDIUM): the original mktemp fallback
+# (`errfile="${TMPDIR:-/tmp}/.ocp-curlerr.$$"`, used only if `mktemp` itself failed) created its
+# file via plain shell redirection, not `mktemp` — world-readable (0644 under a standard 022
+# umask, vs. `mktemp`'s 0600) at a PID-predictable path under a typically-shared `/tmp`, and a
+# plain `>` redirect FOLLOWS a pre-existing symlink at that path rather than refusing, so a
+# symlink planted in advance at the predictable name gets its target truncated. The content
+# curl's own stderr carries is normally harmless ("command not found" never echoes the request's
+# own arguments), but under `bash -x` tracing an expanded `Authorization: Bearer <admin key>`
+# would reach stderr and could land in that 0644 file. Fixed by making a `mktemp` failure fatal
+# instead of falling back to a predictable path at all: `mktemp` is a POSIX utility present on
+# every host this repo targets, so losing the ability to run `_curl_or_die` on a hypothetical
+# host without it is an acceptable trade for removing the vulnerable fallback outright. mktemp's
+# own stderr is left unredirected (never `2>/dev/null` — see this file's own #261 lesson) so a
+# genuine `mktemp` failure (e.g. a full or unwritable $TMPDIR) is visible, not swallowed.
 #
 # Usage: `data=$(_curl_or_die "<network-failure label>" _curl -sf ... "$url") || exit 1` — the
 # first argument after the label is the command to run (`_curl` for authenticated call sites,
@@ -98,13 +121,16 @@ _pyfail() {
 _curl_or_die() {
   local network_label="$1"; shift
   local errfile out status err
-  errfile=$(mktemp "${TMPDIR:-/tmp}/ocp-curlerr.XXXXXX" 2>/dev/null) || errfile="${TMPDIR:-/tmp}/.ocp-curlerr.$$"
+  errfile=$(mktemp "${TMPDIR:-/tmp}/ocp-curlerr.XXXXXX") || {
+    echo "Error: could not create a secure temp file to capture curl's diagnostic output (mktemp failed, see error above) — cannot safely determine why the request failed" >&2
+    return 1
+  }
   out=$("$@" 2>"$errfile")
   status=$?
   err=$(cat "$errfile" 2>/dev/null)
   rm -f "$errfile"
   if [[ $status -ne 0 ]]; then
-    if [[ $status -eq 127 ]] || [[ "$err" == *"command not found"* ]]; then
+    if [[ $status -eq 127 ]] || [[ $status -eq 126 ]] || [[ "$err" == *"Permission denied"* ]] || [[ "$err" == *"bad interpreter"* ]]; then
       echo "Error: could not run curl (${err:-exit status $status}) — this is a local shell/environment fault, not a proxy problem" >&2
     else
       echo "Error: $network_label" >&2

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -9913,6 +9913,15 @@ function _bwHarnessRun({
   // latter is a substring of the former). Purely additive: an empty array (the default)
   // leaves every existing call site's curl stub byte-identical to before this issue.
   curlResponses = [],
+  // Issue #261: simulates "curl is not on $PATH at all" the same way pythonAbsent (below)
+  // simulates a missing python3 — a stub that always exits 127 (bash's own reserved "command
+  // not found" code, never one curl itself produces), placed first on $PATH so it shadows any
+  // real curl the harness's own /usr/bin:/bin fallback would otherwise resolve to. The
+  // realistic, environment-only-controlled stand-in for "the command could not run", as
+  // distinct from "the command ran and the request failed" (the existing curlResponses/
+  // curlHealthExit/default-refusal arms, all of which still require curl to have started).
+  // Default false leaves the curl stub's behavior byte-identical to before this issue.
+  curlAbsent = false,
   // Issue #242 test-setup note (NOT a fix for a #242/#241 defect — a separate, pre-existing,
   // previously-undiscovered one, found incidentally while adding these tests, out of scope for
   // both PRs and left for its own issue): `_curl()`'s `curl "${_AUTH_ARGS[@]}" "$@"` references
@@ -10077,12 +10086,30 @@ function _bwHarnessRun({
     // Issue #242: curlResponses (see its own doc comment above) adds arbitrary fixture arms,
     // checked BEFORE "/health" and the default refusal, for the nine display commands' own
     // curl calls (/api/usage, /usage, /logs, /v1/models, /sessions, /api/keys, /settings).
+    //
+    // Issue #261: curlAbsent simulates "curl is not on $PATH" the SAME way pythonAbsent already
+    // simulates "python3 is not on $PATH" a few lines below (see that stub's own comment: "a
+    // real executable file that always reports command-not-found's own exit code ... rather
+    // than trying to strip PATH of every directory that might contain a real" copy). Simply
+    // omitting the bin/curl file does NOT achieve this: this harness's $PATH is
+    // `${bin}:/usr/bin:/bin` (needed so python3/cat/sed/mktemp resolve to the real system
+    // copies), and /usr/bin/curl is a real, present binary on this repo's own macOS dev hosts
+    // (and on plenty of Linux bases) — omitting only the harness's own stub would silently fall
+    // through to that REAL curl, which would then make a REAL (if pointless, PROXY is
+    // "http://127.0.0.1:1") network attempt and fail for a genuinely-different reason than the
+    // one this option exists to simulate. The stub below always wins the PATH lookup (bin/ is
+    // first) and, when curlAbsent is true, unconditionally exits 127 — bash's own reserved
+    // "command not found" code, which curl itself never produces — without attempting any
+    // network I/O, before curlResponseFiles/curlHealthExit are even consulted.
     const curlResponseFiles = curlResponses.map((r, i) => {
       const p = join(root, `curl-resp-${i}.json`);
       testWriteFile(p, r.body ?? "");
       return { match: r.match, exit: r.exit ?? 0, path: p };
     });
-    mkStub("curl", [
+    mkStub("curl", curlAbsent ? [
+      `echo "FAKE-CURL-ABSENT-CALL $*" >> "${logPath}"`,
+      `exit 127`,
+    ].join("\n") : [
       `echo "FAKE-CURL-CALL $*" >> "${logPath}"`,
       `case "$*" in`,
       ...curlResponseFiles.flatMap((r) => [
@@ -10618,6 +10645,78 @@ test("#242 fix-3 cmd_keys revoke: 'Error: proxy unreachable or unauthorized' goe
   assert.notEqual(r.status, 0);
   assert.ok(r.stderr.includes("Error: proxy unreachable or unauthorized"), `expected the message on stderr, got: ${JSON.stringify(r.stderr)}`);
   assert.equal(r.stdout, "", `stdout must stay clean; got: ${JSON.stringify(r.stdout)}`);
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Issue #261 (the pattern #256/#258 partially addressed, and #242's own review left the three
+// sites below untouched — see the "fix 3" note above): `cmd_usage --by-key`, `cmd_usage`
+// (main), and `cmd_keys add` are the three remaining call sites that fold curl's own stderr
+// into the captured response body via `2>&1` and then attribute ANY nonzero exit — a genuine
+// network failure OR a hard shell-level failure before curl ever ran (the exact #256 shape) —
+// to the identical "proxy unreachable" text. `curl` missing from $PATH (bash's own reserved
+// exit 127, "command not found" — a code and message curl itself never produces) is the
+// realistic, environment-only-controlled stand-in used here for "the command could not run",
+// generalizing #256's own repro (an `unbound variable` inside `_curl` itself, now fixed by
+// #258) to the CLASS of bug rather than that one instance. Each site gets a money test (curl
+// absent — must NOT say "proxy unreachable", must name curl) and a control test (curl present,
+// proxy genuinely unreachable — must still say "proxy unreachable", proving the fix does not
+// just delete the diagnosis). A fourth test checks the stream: these three sites previously
+// printed to stdout, unlike every sibling site #242's own "fix 3" already moved to stderr —
+// fixing that parity gap is in scope here because this PR rewrites these exact lines anyway.
+console.log("\nocp _curl call sites distinguish 'the command could not run' from 'the request failed' (#261):");
+
+test("#261 cmd_usage --by-key: curl missing from $PATH must be reported as a local fault, not 'proxy unreachable' (generalizes #256's exact repro)", () => {
+  const r = _bwHarnessRun({ args: ["usage", "--by-key"], adminKey: "test-admin-key-marker", curlAbsent: true });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(!r.stderr.includes("proxy unreachable") && !r.stdout.includes("proxy unreachable"),
+    `must NOT misattribute a missing curl binary to the proxy — this is exactly how #256 hid the real cause; stderr=${JSON.stringify(r.stderr)} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(/curl/i.test(r.stderr), `expected the message to name curl/the local command failure, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#261 control: cmd_usage --by-key with curl present but the proxy genuinely unreachable still says so", () => {
+  const r = _bwHarnessRun({ args: ["usage", "--by-key"], adminKey: "test-admin-key-marker" });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(r.stderr.includes("proxy unreachable or usage API not available"),
+    `a GENUINE network failure must still be reported as such (proves the fix does not just delete the diagnosis), got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#261 cmd_usage (main): curl missing from $PATH must be reported as a local fault, not 'proxy unreachable'", () => {
+  const r = _bwHarnessRun({ args: ["usage"], curlAbsent: true });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(!r.stderr.includes("proxy unreachable") && !r.stdout.includes("proxy unreachable"),
+    `must NOT misattribute a missing curl binary to the proxy; stderr=${JSON.stringify(r.stderr)} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(/curl/i.test(r.stderr), `expected the message to name curl/the local command failure, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#261 control: cmd_usage (main) with curl present but the proxy genuinely unreachable still says so", () => {
+  const r = _bwHarnessRun({ args: ["usage"] });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(r.stderr.includes("Error: proxy unreachable"),
+    `a GENUINE network failure must still be reported as such, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#261 cmd_keys add: curl missing from $PATH must be reported as a local fault, not 'proxy unreachable or unauthorized'", () => {
+  const r = _bwHarnessRun({ args: ["keys", "add", "laptop-marker"], adminKey: "test-admin-key-marker", curlAbsent: true });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(!r.stderr.includes("proxy unreachable") && !r.stdout.includes("proxy unreachable"),
+    `must NOT misattribute a missing curl binary to the proxy/auth layer; stderr=${JSON.stringify(r.stderr)} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(/curl/i.test(r.stderr), `expected the message to name curl/the local command failure, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#261 control: cmd_keys add with curl present but the proxy genuinely unreachable still says so", () => {
+  const r = _bwHarnessRun({ args: ["keys", "add", "laptop-marker"], adminKey: "test-admin-key-marker" });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(r.stderr.includes("proxy unreachable or unauthorized"),
+    `a GENUINE network failure must still be reported as such, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#261 stream parity: cmd_usage/cmd_keys-add 'proxy unreachable' guards now write to stderr, stdout stays empty (matches the #242 fix-3 sibling sites)", () => {
+  const byKey = _bwHarnessRun({ args: ["usage", "--by-key"], adminKey: "test-admin-key-marker" });
+  assert.equal(byKey.stdout, "", `cmd_usage --by-key: stdout must stay clean of the error text; got: ${JSON.stringify(byKey.stdout)}`);
+  const main = _bwHarnessRun({ args: ["usage"] });
+  assert.equal(main.stdout, "", `cmd_usage (main): stdout must stay clean; got: ${JSON.stringify(main.stdout)}`);
+  const keysAdd = _bwHarnessRun({ args: ["keys", "add", "laptop-marker"], adminKey: "test-admin-key-marker" });
+  assert.equal(keysAdd.stdout, "", `cmd_keys add: stdout must stay clean; got: ${JSON.stringify(keysAdd.stdout)}`);
 });
 
 console.log("\nRestart-unit resolution (issue #233 defect 1) — macOS lsof exit-code handling:");

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -9922,6 +9922,23 @@ function _bwHarnessRun({
   // curlHealthExit/default-refusal arms, all of which still require curl to have started).
   // Default false leaves the curl stub's behavior byte-identical to before this issue.
   curlAbsent = false,
+  // Independent review round 1 (fold-in B): reproduces "curl is present on $PATH but not
+  // executable" (the reviewer's own repro: `chmod 000` a real curl -> exit 126 + "Permission
+  // denied"). Uses the same echo-and-exit shadow-stub technique as curlAbsent, not a literal
+  // chmod-644 file -- verified directly that bash's own PATH search does not stop at a
+  // non-executable candidate and report 126, it SKIPS it and keeps searching later PATH
+  // entries, so a chmod-based stub here would silently fall through to the real, executable
+  // /usr/bin/curl this harness's own fallback provides for python3/cat/sed/mktemp (caught by
+  // running a first attempt built that way, not assumed). See the stub's own comment below for
+  // the exact repro that surfaced this.
+  curlNotExecutable = false,
+  // Independent review round 1 (fold-in A): shadows the real `mktemp` on $PATH with a stub that
+  // always fails, to prove `_curl_or_die` now treats a `mktemp` failure as FATAL (an honest
+  // error) rather than falling back to the predictable, world-readable, symlink-following path
+  // the review flagged as a security issue. Same shadow-stub technique as
+  // curlAbsent/openclawAbsent/pythonAbsent. Default false leaves the real system `mktemp`
+  // (resolved via the harness's own /usr/bin:/bin fallback) untouched.
+  mktempFails = false,
   // Issue #242 test-setup note (NOT a fix for a #242/#241 defect — a separate, pre-existing,
   // previously-undiscovered one, found incidentally while adding these tests, out of scope for
   // both PRs and left for its own issue): `_curl()`'s `curl "${_AUTH_ARGS[@]}" "$@"` references
@@ -10101,32 +10118,66 @@ function _bwHarnessRun({
     // first) and, when curlAbsent is true, unconditionally exits 127 — bash's own reserved
     // "command not found" code, which curl itself never produces — without attempting any
     // network I/O, before curlResponseFiles/curlHealthExit are even consulted.
-    const curlResponseFiles = curlResponses.map((r, i) => {
-      const p = join(root, `curl-resp-${i}.json`);
-      testWriteFile(p, r.body ?? "");
-      return { match: r.match, exit: r.exit ?? 0, path: p };
-    });
-    mkStub("curl", curlAbsent ? [
-      `echo "FAKE-CURL-ABSENT-CALL $*" >> "${logPath}"`,
-      `exit 127`,
-    ].join("\n") : [
-      `echo "FAKE-CURL-CALL $*" >> "${logPath}"`,
-      `case "$*" in`,
-      ...curlResponseFiles.flatMap((r) => [
-        `  *${JSON.stringify(r.match)}*)`,
-        `    cat ${JSON.stringify(r.path)}`,
-        `    exit ${r.exit}`,
+    // Independent review round 1 (fold-in B): curlNotExecutable simulates "curl found on $PATH
+    // but not executable" (the reviewer's own repro: `chmod 000` a real curl -> exit 126 +
+    // "Permission denied"). A literal chmod-644 stub does NOT reliably reproduce this inside
+    // this harness: verified directly (env -i PATH="<stub-dir>:/usr/bin:/bin" bash -c 'curl
+    // --version') that bash's PATH search does not stop at a non-executable candidate and
+    // report 126 -- it SKIPS it and keeps searching later PATH entries, silently falling
+    // through to the real, executable /usr/bin/curl this harness's own fallback provides for
+    // python3/cat/sed/mktemp. (A first attempt at this option used chmod 0644 and the "money"
+    // test failed with the REAL curl's own network error instead of the intended 126 -- caught
+    // by running it, not assumed.) Using the same echo-and-exit shadow-stub technique as
+    // curlAbsent/openclawFailExit instead: portable, and does not depend on what a given host's
+    // /usr/bin:/bin happens to contain.
+    if (curlNotExecutable) {
+      mkStub("curl", [
+        `echo "FAKE-CURL-NOT-EXECUTABLE-CALL $*" >> "${logPath}"`,
+        `echo "bash: $0: Permission denied" >&2`,
+        `exit 126`,
+      ].join("\n"));
+    } else {
+      const curlResponseFiles = curlResponses.map((r, i) => {
+        const p = join(root, `curl-resp-${i}.json`);
+        testWriteFile(p, r.body ?? "");
+        return { match: r.match, exit: r.exit ?? 0, path: p };
+      });
+      mkStub("curl", curlAbsent ? [
+        `echo "FAKE-CURL-ABSENT-CALL $*" >> "${logPath}"`,
+        `exit 127`,
+      ].join("\n") : [
+        `echo "FAKE-CURL-CALL $*" >> "${logPath}"`,
+        `case "$*" in`,
+        ...curlResponseFiles.flatMap((r) => [
+          `  *${JSON.stringify(r.match)}*)`,
+          `    cat ${JSON.stringify(r.path)}`,
+          `    exit ${r.exit}`,
+          `    ;;`,
+        ]),
+        `  *"/health"*)`,
+        `    exit ${curlHealthExit}`,
         `    ;;`,
-      ]),
-      `  *"/health"*)`,
-      `    exit ${curlHealthExit}`,
-      `    ;;`,
-      `  *)`,
-      `    echo "FAKE-CURL: refusing unhandled invocation: $*" >&2`,
-      `    exit 94`,
-      `    ;;`,
-      `esac`,
-    ].join("\n"));
+        `  *)`,
+        `    echo "FAKE-CURL: refusing unhandled invocation: $*" >&2`,
+        `    exit 94`,
+        `    ;;`,
+        `esac`,
+      ].join("\n"));
+    }
+
+    // Independent review round 1 (fold-in A): mktempFails shadows the real `mktemp` (normally
+    // resolved via this harness's own /usr/bin:/bin fallback) with a stub that always fails, so
+    // `_curl_or_die`'s mktemp call fails too -- proving the fix treats that as FATAL rather than
+    // falling back to the predictable, world-readable, symlink-following path the review
+    // flagged. Prints its own stderr line (like a real `mktemp` failure would) rather than
+    // silently exiting, since #261's own lesson is "never discard stderr".
+    if (mktempFails) {
+      mkStub("mktemp", [
+        `echo "FAKE-MKTEMP-FAIL-CALL $*" >> "${logPath}"`,
+        `echo "mktemp: FAKE failure injected by test harness (mktempFails)" >&2`,
+        `exit 1`,
+      ].join("\n"));
+    }
 
     // Simulates issue #236's exact repro ("stubbed absent": a real executable file that always
     // reports command-not-found's own exit code) rather than trying to strip PATH of every
@@ -10717,6 +10768,37 @@ test("#261 stream parity: cmd_usage/cmd_keys-add 'proxy unreachable' guards now 
   assert.equal(main.stdout, "", `cmd_usage (main): stdout must stay clean; got: ${JSON.stringify(main.stdout)}`);
   const keysAdd = _bwHarnessRun({ args: ["keys", "add", "laptop-marker"], adminKey: "test-admin-key-marker" });
   assert.equal(keysAdd.stdout, "", `cmd_keys add: stdout must stay clean; got: ${JSON.stringify(keysAdd.stdout)}`);
+});
+
+// ── Independent review round 1: two fold-ins ──────────────────────────────────────────────────
+console.log("\nocp _curl_or_die: independent review round 1 fold-ins (exit 126, mktemp security):");
+
+test("#261 fold-in B (independent review round 1): curl present but NOT EXECUTABLE (exit 126) is reported as a local fault, not 'proxy unreachable'", () => {
+  // Reviewer's own repro: `chmod 000` a real curl -> exit 126 -> "Error: proxy unreachable...",
+  // the exact headline this issue exists to kill, and this repo's own ENOEXEC footgun history
+  // (a corrupted `claude` native binary) makes this a real, not merely theoretical, scenario.
+  const r = _bwHarnessRun({ args: ["usage", "--by-key"], adminKey: "test-admin-key-marker", curlNotExecutable: true });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(!r.stderr.includes("proxy unreachable") && !r.stdout.includes("proxy unreachable"),
+    `must NOT misattribute a non-executable curl binary to the proxy; stderr=${JSON.stringify(r.stderr)} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(/curl/i.test(r.stderr), `expected the message to name curl/the local command failure, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#261 fold-in A (independent review round 1, security): a mktemp failure is FATAL, not a silent fallback to a predictable/world-readable/symlink-following temp path", () => {
+  // The original fallback (`errfile="$TMPDIR/.ocp-curlerr.$$"`, used only when mktemp itself
+  // failed) was 0644 at a PID-predictable path, and a plain `>` redirect follows a pre-existing
+  // symlink there instead of refusing -- the review demonstrated a symlink-planted-in-advance
+  // attack truncating a victim file. This test proves the fallback is gone entirely: a mktemp
+  // failure must now produce an honest error, and curl must never even be invoked (nothing safe
+  // exists yet to redirect its stderr into).
+  const r = _bwHarnessRun({ args: ["usage", "--by-key"], adminKey: "test-admin-key-marker", mktempFails: true });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(r.stderr.includes("could not create a secure temp file"),
+    `expected the explicit mktemp-failure message, got stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(_bwCalled(r.log, "FAKE-MKTEMP-FAIL-CALL"), `sanity check the mktemp-fails stub was actually reached; log=${JSON.stringify(r.log)}`);
+  assert.ok(!_bwCalled(r.log, "FAKE-CURL-CALL"),
+    `curl must never be invoked once mktemp has already failed -- there is nothing safe to ` +
+    `redirect its stderr into; log=${JSON.stringify(r.log)}`);
 });
 
 console.log("\nRestart-unit resolution (issue #233 defect 1) — macOS lsof exit-code handling:");


### PR DESCRIPTION
## Summary

Three `ocp` call sites (`cmd_usage --by-key`, `cmd_usage` main, `cmd_keys add`) fold curl's own stderr into the captured response body via `2>&1`, then attribute ANY nonzero exit — a genuine network failure, or a hard shell-level failure before curl ever ran — to the identical "proxy unreachable" text.

This is the general pattern behind how #256 hid: the shell died on an unbound variable three lines before curl would have run, and the operator was pointed at a healthy proxy instead of the real fault. PR #258 removed that one specific cause; the pattern itself remained, which is what #261 tracks (refs #242, refs #252 for the sibling `_pyfail`/stderr-stream precedent this borrows its shape from).

## Fix

Adds a shared `_curl_or_die` helper (next to `_pyfail`, near the top of `ocp`):

- Captures the wrapped command's own stderr to a private temp file — **never** `/dev/null`.
- Distinguishes "the command could not run" (exit 127, or `"command not found"` in the captured stderr — bash's own vocabulary, never curl's) from "the command ran and the request failed" (any other nonzero exit).
- Prints an accurate, separate message to **stderr** for each case (matching the sibling display commands' own convention from #252 review round 1 fix 3, which explicitly left these three sites untouched at the time).
- Drop-in at each call site: `data=$(_curl_or_die "<network-failure label>" _curl -sf ... "$url") || exit 1` — byte-identical wording and behavior on a genuine network failure.

## Test harness extension

`test-features.mjs`'s existing `_bwHarnessRun` ocp bash-CLI harness (#225 lineage) gets a `curlAbsent` option, using the **same technique `pythonAbsent` already uses** a few lines below: an always-`exit 127` stub that shadows the real binary on `$PATH`, not an omitted file. (Omitting the file alone doesn't work — this harness's own `/usr/bin:/bin` `$PATH` fallback, needed for python3/cat/sed/mktemp, resolves to a **real curl** on this repo's own macOS dev hosts. I hit this directly: an earlier version of this option just skipped writing the stub, and the "money" tests still failed after the fix because the real system curl actually ran and hit a real — but different — connection failure. Caught by running the tests, not assumed.)

Seven new tests:
- 3 money tests: curl **absent** → message must name curl, must NOT say "proxy unreachable".
- 3 control tests: curl **present**, proxy genuinely down → must still say "proxy unreachable" (proves the fix doesn't just delete the diagnosis).
- 1 stream-parity test: all three sites now write to stderr, stdout stays clean.

## Evidence — RED then GREEN

Baseline on `origin/main` (`8b1435d`): **773 passed, 0 failed**.

**RED** (corrected harness, pristine `ocp` swapped in via a checksum-verified `cp`, not `git checkout`): **773 passed, 7 failed** — all 7 new `#261` tests, e.g.:
```
✗ #261 cmd_usage --by-key: curl missing from $PATH must be reported as a local fault, not
  'proxy unreachable' (generalizes #256's exact repro): must NOT misattribute a missing curl
  binary to the proxy — this is exactly how #256 hid the real cause;
  stderr="" stdout="Error: proxy unreachable or usage API not available\n"
```

**GREEN** (fix applied, restored from a checksum-verified backup): **780 passed, 0 failed**.

## Mutation testing

Two guards inside `_curl_or_die`, each broken independently, restored via `cp` + `shasum -a 256` (never `git checkout`), anchor existence asserted via `grep -c` before mutating:

| Mutation | Change | Result | Killed by (named) |
|---|---|---|---|
| A | `if [[ $status -eq 127 ]] \|\| [[ "$err" == *"command not found"* ]]; then` → `if false; then` (neuters command-not-found detection) | 777 passed, 3 failed | `#261 cmd_usage --by-key: curl missing...`, `#261 cmd_usage (main): curl missing...`, `#261 cmd_keys add: curl missing...` |
| B | `echo "Error: $network_label" >&2` → `echo "Error: $network_label"` (drops stderr redirect) | 777 passed, 3 failed | `#261 control: cmd_usage --by-key with curl present but the proxy genuinely unreachable...`, `#261 control: cmd_usage (main)...`, `#261 control: cmd_keys add...` |

Note on mutation B: it did **not** trip the stream-parity test, for a more interesting reason than a weak assertion — every affected call site does `data=$(_curl_or_die ...) || exit 1`, so an un-redirected `echo` inside `_curl_or_die` gets captured into the discarded `$data` on failure and never reaches the terminal at all (rather than merely landing on the wrong stream). The message is genuinely silenced, not just misrouted. The 3 control tests (which check stderr content directly) caught this correctly; the stream-parity test's `stdout === ""` assertion stayed vacuously true. Both backups verified byte-identical to the pre-mutation file via `shasum -a 256` before and after restore.

## Full suite

`npm test`: **780 passed, 0 failed** (final, post-restore, pre-push).

## Scope

Does **not** touch `server.mjs`. No `cli.js` citation applies — this is `ocp` (the bash CLI wrapper), not the proxy itself; `ALIGNMENT.md`'s Rules govern `server.mjs`'s wire behavior, not this file.

No port literals added (verified via diff grep).

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gbqUZ8HfBZpjjbzQ85oH8
