### PR TITLE
fix(restart-unit): compare working directory before trusting a resolved server.mjs process

### DIFF
--- a/scripts/lib/restart-unit.mjs
+++ b/scripts/lib/restart-unit.mjs
@@ -150,6 +150,33 @@
  * before this field existed. `planRestart`'s `no-unit` and `foreign-process` refusal messages are
  * platform-branched (`owner.platform === "darwin"`) since the Linux wording names `systemd`,
  * `/proc/<pid>/cgroup`, and `/proc/<pid>/cmdline` — none of which exist on macOS.
+ *
+ * A FIFTH independent review (issue #254, split from #237 by review of PR #251) found that #237's
+ * own fix, while it fully closes the reported "wholly foreign service" vulnerability, leaves one
+ * narrower case open: classifyCmdlineOwner confirms a process invokes A server.mjs, never that it
+ * invokes THIS installation's server.mjs. A second, unrelated Node application whose entrypoint
+ * happens to be named (or symlinked to) server.mjs — or, more realistically on this fleet, a
+ * second OCP checkout (a dev tree sitting next to a production install) — still passes
+ * classifyCmdlineOwner's "ocp" verdict and gets treated as a legitimate restart candidate.
+ *
+ * Fix: classifyWorkingTree compares the resolved process's ACTUAL working directory
+ * (`readlink /proc/<pid>/cwd`, gathered in the same probe pass as cmdline/cgroup — no separate
+ * resolution round-trip) against the working tree scripts/upgrade.mjs is itself running from
+ * (opts.ocpDir or its script-relative default). Unlike doctor.mjs's own #230 workingTree (derived
+ * from static argv TEXT, since it inspects unit definitions that may not even be running — and
+ * unreliable for a bare relative "server.mjs" argv, a real production unit shape on this fleet
+ * today), `/proc/<pid>/cwd` reflects the kernel's own canonical resolution of a LIVE pid's cwd,
+ * independent of whatever argv happened to spell out.
+ *
+ * Deliberately a WARNING, not a refusal (see classifyWorkingTree's own comment for the full
+ * rationale): unlike #237's argv check, whose false-positive rate is close to zero (real argv
+ * genuinely lacking "server.mjs" is unambiguous), a working-tree mismatch is comparatively weaker
+ * evidence — `/proc/<pid>/cwd` requires ptrace-level visibility (stricter than cmdlineContent's),
+ * so "unknown" is a routine outcome, not an edge case, on a non-root updater against a root-owned
+ * unit. A false "different install" verdict here would refuse a healthy production restart, which
+ * this fleet cannot afford — a stricter posture than #237 took for the CONFIRMED-foreign case.
+ * Scope: Linux only, mirroring #237/#239's own platform split — macOS has no direct pid-to-cwd
+ * read this module can lean on without its own separate design pass, and is left for a follow-up.
  */
 
 // Anything accepted as a restart target must look like a real systemd unit name.
@@ -487,6 +514,83 @@ export function classifyCmdlineOwner(cmdlineContent) {
   return { state: "ocp", reason: null };
 }
 
+// --- Linux: compare the port-holding process's ACTUAL working directory against the working
+// tree the specific installation running `ocp update`/`ocp restart` is itself rooted in --- (issue
+// #254 — the residual gap independent review of PR #251 flagged and asked to be filed rather than
+// silently dropped)
+//
+// classifyCmdlineOwner (#237, above) answers "does this process invoke A server.mjs at all" — it
+// does not, and was never meant to, answer "is it THIS installation's server.mjs". A second,
+// unrelated Node application whose own entrypoint happens to be named (or symlinked to)
+// server.mjs — or, far more realistically on this fleet, a second OCP checkout (a dev tree sitting
+// next to a production install) — passes classifyCmdlineOwner's "ocp" verdict exactly the same way
+// the real production process does; nothing about that check can tell them apart.
+//
+// doctor.mjs's own #230 fingerprintSystemdUnit/parsePlistCandidates derive a "workingTree" by
+// slicing argv's own server.mjs path apart (`serverArg === "server.mjs" ? "" : serverArg.slice(0,
+// -"/server.mjs".length)`). That is a STATIC-TEXT signal computed over a unit DEFINITION that may
+// not even be running, and it is unreliable by construction for a bare relative "server.mjs" argv
+// — workingTree resolves to "", not to a real, comparable directory. This fleet runs production
+// units of EXACTLY that shape today (WorkingDirectory=<tree>, ExecStart=node server.mjs); keying a
+// comparison off argv text would read every one of them as an unresolvable mismatch regardless of
+// whether the tree is actually the same — wrong by construction, not a corner case.
+//
+// This module's context is different and stronger: resolveOwningUnit only ever reaches this check
+// once `ss` has already confirmed a LIVE pid. A live pid's actual working directory is legible
+// straight from the kernel: `/proc/<pid>/cwd` is a symlink whose target the kernel resolves and
+// stores as a real (canonical, no "..", no unresolved intermediate symlink) absolute path,
+// entirely independent of whatever argv happened to spell out (relative or absolute) — so this
+// does NOT inherit doctor.mjs's bare-relative-argv blind spot.
+//
+// What this honestly CANNOT decide:
+//   - `/proc/<pid>/cwd` requires ptrace-level visibility (same uid, or CAP_SYS_PTRACE) — a
+//     STRICTER requirement than /proc/<pid>/cmdline, which is world-readable on a default
+//     hidepid=0/1 host. A non-root `ocp update` against a root-owned SYSTEM unit — a supported,
+//     already-documented shape elsewhere in this file — will routinely have cmdlineContent succeed
+//     while THIS read is denied. Denied means "unknown", never "confirmed different tree" — same
+//     "unknown must never be treated as safe-to-guess" posture as every other classifier here.
+//   - it reflects the process's CURRENT cwd, not provably "the directory server.mjs was loaded
+//     from" — a process that calls `process.chdir()` after startup would defeat this. OCP's own
+//     server.mjs does not (verified: no `process.chdir` call anywhere in server.mjs); an adversary
+//     willing to both fork a lookalike server.mjs-named entrypoint AND chdir it to match is the
+//     same out-of-scope threat model #237's own review already named ("spoofing argv is a
+//     non-issue for the threat model this addresses — misconfiguration, not an adversary
+//     controlling process identity").
+//   - unlike classifyCmdlineOwner (near-zero false-positive rate: real argv genuinely not
+//     containing "server.mjs" is unambiguous), a working-tree MISMATCH is comparatively weaker
+//     evidence on its own. A false "different install" verdict here would block a healthy
+//     production restart — unlike #237's classifyCmdlineOwner, this is NOT safe to treat as an
+//     unconditional refusal. See planRestart: a confirmed mismatch WARNS (matching doctor.mjs's
+//     own #230 MED-7 posture — "two legitimate, separate installs ... must NOT have one nominated
+//     over the other", extended here from "which unit to disable" to "whether to trust a
+//     restart"), it does not refuse.
+//
+// Returns one of three states:
+//   "match"     the observed cwd equals the expected working tree
+//   "mismatch"  both sides are known and they differ — a confident, positive "this may not be THIS
+//               installation" signal, not proof (see the honest limits above)
+//   "unknown"   either side could not be determined — never conflated with "mismatch"
+export function classifyWorkingTree(cwdTarget, expectedWorkingTree) {
+  const expected = expectedWorkingTree == null ? "" : String(expectedWorkingTree).trim();
+  if (!expected) {
+    return { state: "unknown", reason: "no expected working tree was provided to compare against" };
+  }
+  if (cwdTarget == null) {
+    return { state: "unknown", reason: "could not read /proc/<pid>/cwd (permission denied, or the process exited between probes)" };
+  }
+  const observed = String(cwdTarget).trim();
+  if (!observed) {
+    return { state: "unknown", reason: "empty /proc/<pid>/cwd read" };
+  }
+  if (observed === expected) {
+    return { state: "match", reason: null };
+  }
+  return {
+    state: "mismatch",
+    reason: `owning process's working directory (${observed}) does not match this installation's own working tree (${expected}) — this may be a different OCP checkout (or an unrelated process) rather than this installation`,
+  };
+}
+
 // --- macOS: classify a launchd job's argv as OCP's own server.mjs, or a foreign process ---
 // (issue #239, mirroring classifyCmdlineOwner's #237 check)
 //
@@ -546,6 +650,21 @@ export function classifyLaunchdArgv(argv) {
  *                                  undefined — "undefined" only arises from a caller (or test)
  *                                  that hasn't been wired to this check, and must not newly
  *                                  refuse restarts that were safe before this field existed.
+ *   cwdTarget      raw `readlink /proc/<pid>/cwd` output for the resolved PID (Linux only; issue
+ *                   #254). Only consulted once cmdlineContent has already classified as "ocp" —
+ *                   comparing working trees is meaningless for an already-unknown/foreign process.
+ *                   Same three-state convention as cmdlineContent:
+ *                     a string     classified via classifyWorkingTree against expectedWorkingTree
+ *                     null         the probe was ATTEMPTED and failed to read (commonly a
+ *                                  permission gap — /proc/<pid>/cwd needs ptrace-level visibility,
+ *                                  stricter than cmdlineContent's) — treated as "unknown"
+ *                     undefined    the caller never attempted this probe at all — the check is
+ *                                  SKIPPED entirely, preserving pre-#254 behavior. Legacy/back-
+ *                                  compat lane, same convention as cmdlineContent's.
+ *   expectedWorkingTree  the working tree THIS installation (the one running `ocp update`/
+ *                   `ocp restart`) is itself rooted in — scripts/upgrade.mjs derives this from
+ *                   opts.ocpDir (realpath'd where possible), the same default every other ocpDir
+ *                   use in that file already falls back to.
  *   launchdPrintOutput  raw `launchctl print gui/<uid>/<expectedUnit>` stdout for the ONE label
  *                   this repo manages (macOS only; issue #239). Same three-state convention as
  *                   cmdlineContent above:
@@ -654,6 +773,7 @@ export function resolveOwningUnit(probe = {}) {
   // all (skip the check, preserve pre-#237 behavior for callers not yet wired to it); a string or
   // null means it WAS attempted, and gets classified/treated-as-unknown respectively. See
   // classifyCmdlineOwner's own comment for the full three-state rationale.
+  let workingTreeResult = null;
   if (probe.cmdlineContent !== undefined) {
     const cmdlineResult = classifyCmdlineOwner(probe.cmdlineContent);
     if (cmdlineResult.state === "unknown") {
@@ -668,6 +788,14 @@ export function resolveOwningUnit(probe = {}) {
         reason: `"${cgroupResult.unit}" (${cgroupResult.scope}-scope) owns the OCP port, but its process is not OCP's server.mjs — ${cmdlineResult.reason}`,
       };
     }
+    // cmdlineResult.state === "ocp": confirmed to invoke A server.mjs. issue #254: that is not
+    // proof it's THIS installation's server.mjs — compare working trees, but only when the caller
+    // actually attempted this probe (probe.cwdTarget === undefined preserves pre-#254 behavior for
+    // callers/tests not yet wired to it, same legacy lane every other probe field in this file
+    // already uses).
+    if (probe.cwdTarget !== undefined) {
+      workingTreeResult = classifyWorkingTree(probe.cwdTarget, probe.expectedWorkingTree);
+    }
   }
 
   const mismatched = !!expectedUnit && cgroupResult.unit !== expectedUnit;
@@ -678,6 +806,13 @@ export function resolveOwningUnit(probe = {}) {
     unit: cgroupResult.unit,
     scope: cgroupResult.scope,
     mismatched,
+    // issue #254: a POSITIVE confirmation the resolved process's cwd differs from this
+    // installation's own working tree. Deliberately NOT folded into `mismatched` (a unit-NAME
+    // comparison) or `kind` (this never becomes "foreign-process" — see classifyWorkingTree's own
+    // comment for why an unconditional refusal is not safe here). "unknown"/no-probe both leave
+    // this false, same as every other classifier's "never treat unknown as confirmed" posture.
+    workingTreeMismatch: workingTreeResult?.state === "mismatch",
+    workingTreeReason: workingTreeResult?.state === "mismatch" ? workingTreeResult.reason : undefined,
   };
 }
 
@@ -730,6 +865,24 @@ export function planRestart(owner, opts = {}) {
       `[restart] WARNING: the OCP port is actually served by "${owner.unit}" (${owner.kind}), ` +
       `not the expected "${opts.expectedUnit}". Restarting "${owner.unit}" instead of the expected ` +
       `unit — see issue #215 (a hard-coded restart target left an orphan when the real owner differed).`
+    );
+  }
+
+  // issue #254: a confirmed "invokes server.mjs" verdict (classifyCmdlineOwner) is not proof it's
+  // THIS installation's server.mjs — see classifyWorkingTree's own comment for what the
+  // /proc/<pid>/cwd comparison can and cannot decide. Deliberately a WARNING, not a refusal: unlike
+  // the foreign-process check below (near-zero false-positive rate), a working-tree mismatch is
+  // weaker evidence — a false "different install" verdict here would refuse a healthy production
+  // restart, which this fleet cannot afford (matches doctor.mjs's own #230 MED-7 posture: two
+  // differing working trees are two legitimate, separate installs, and this codebase does not
+  // nominate one over the other without a human deciding).
+  if (owner.workingTreeMismatch) {
+    warnings.push(
+      `[restart] WARNING: ${owner.workingTreeReason} (issue #254). Proceeding anyway — a working-` +
+      `tree mismatch is not treated as confirmed-foreign the way issue #237's argv check is, ` +
+      `because refusing outright risks blocking a healthy production restart (this fleet runs a ` +
+      `relative "server.mjs" argv shape today, where only /proc/<pid>/cwd — not argv text — can ` +
+      `tell installs apart at all). Verify manually before trusting this restart if that matters here.`
     );
   }
 

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -15,7 +15,7 @@ import { runDoctor } from "./doctor.mjs";
 import { execSync, execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { existsSync, copyFileSync } from "node:fs";
+import { existsSync, copyFileSync, realpathSync } from "node:fs";
 import { writeSnapshot, listSnapshots, readSnapshot, gcSnapshots } from "./lib/snapshot.mjs";
 import { resolveOwningUnit, planRestart, classifySsListener, classifyLsofListener } from "./lib/restart-unit.mjs";
 import { DEFAULT_PORT } from "../lib/constants.mjs";
@@ -26,6 +26,17 @@ import { DEFAULT_PORT } from "../lib/constants.mjs";
 // refer to the exact same implementation.
 function execRun(cmd) {
   return execSync(cmd, { stdio: ["pipe", "pipe", "pipe"] }).toString();
+}
+
+// issue #254: the working tree THIS installation (the one this process is actually running from)
+// is rooted in — same opts.ocpDir-or-default fallback every other ocpDir use in this file already
+// takes (runFullUpgrade, runRollback). realpath'd where possible so a symlinked install dir
+// (~/ocp -> /data/ocp, say) compares correctly against /proc/<pid>/cwd's already-kernel-canonical
+// target; falls back to the raw path when realpath fails (doesn't exist yet, permission gap) —
+// this function must never throw, only degrade to the best answer it has.
+function resolveExpectedWorkingTree(opts) {
+  const ocpDir = opts.ocpDir || join(homedir(), "ocp");
+  try { return realpathSync(ocpDir); } catch { return ocpDir; }
 }
 
 // issue #233 defect 1: `lsof -nP -iTCP:<port> -sTCP:LISTEN` signals "nothing matched" via
@@ -242,6 +253,14 @@ function resolveRestartPlan({ opts, port, isRollback = false, fromCommit = null 
         // confirm the owning process is actually OCP's server.mjs before ever treating a resolved
         // unit as a restart candidate, instead of acting on a real-but-foreign unit name.
         try { probe.cmdlineContent = run(`cat /proc/${listener.pid}/cmdline`); } catch { probe.cmdlineContent = null; }
+        // issue #254: same gather step, same pid — read the process's actual working directory via
+        // the /proc/<pid>/cwd symlink (readlink resolves it to a kernel-canonical absolute path,
+        // regardless of whether argv itself spelled out a relative or absolute server.mjs). Paired
+        // with expectedWorkingTree (this installation's own tree) so resolveOwningUnit can tell a
+        // same-name, same-argv process apart from a DIFFERENT OCP checkout — see
+        // classifyWorkingTree's own comment in restart-unit.mjs for what this can and cannot decide.
+        try { probe.cwdTarget = run(`readlink /proc/${listener.pid}/cwd`); } catch { probe.cwdTarget = null; }
+        probe.expectedWorkingTree = resolveExpectedWorkingTree(opts);
       }
     }
     owner = resolveOwningUnit(probe);
@@ -938,7 +957,6 @@ async function runRollback(opts) {
 
 // CLI entrypoint — use fileURLToPath + realpath to handle symlinked install paths.
 import { fileURLToPath } from "node:url";
-import { realpathSync } from "node:fs";
 function _isMain() {
   if (!process.argv[1]) return false;
   try {

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -14,8 +14,9 @@
 import { runDoctor } from "./doctor.mjs";
 import { execSync, execFileSync } from "node:child_process";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { existsSync, copyFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { writeSnapshot, listSnapshots, readSnapshot, gcSnapshots } from "./lib/snapshot.mjs";
 import { resolveOwningUnit, planRestart, classifySsListener, classifyLsofListener } from "./lib/restart-unit.mjs";
 import { DEFAULT_PORT } from "../lib/constants.mjs";
@@ -29,13 +30,41 @@ function execRun(cmd) {
 }
 
 // issue #254: the working tree THIS installation (the one this process is actually running from)
-// is rooted in — same opts.ocpDir-or-default fallback every other ocpDir use in this file already
-// takes (runFullUpgrade, runRollback). realpath'd where possible so a symlinked install dir
+// is rooted in.
+//
+// Post-review correction: the first cut of this function defaulted to `opts.ocpDir ||
+// join(homedir(), "ocp")` — the SAME pattern runFullUpgrade/runRollback already use for their own
+// git-checkout/npm-install target. That default is silently wrong for THIS comparison specifically.
+// `opts.ocpDir` is dead in every real invocation: the `ocp` bash wrapper calls `node
+// "$script_dir/scripts/upgrade.mjs" ...` positionally (verified: grep the `ocp` script — no
+// `--ocp-dir` flag anywhere), and this file's own `_isMain()` argv parser never reads one either.
+// So in production the old default ALWAYS resolved to `~/ocp`, regardless of which tree is
+// actually running — which reproduces, in this new check, the exact class of bug it exists to
+// catch: it silently reports "match" when a DIFFERENT tree (say `~/ocp-dev`) manages production's
+// real `~/ocp` install (nothing about that scenario ever gets compared against the tree that's
+// actually acting), and it spuriously reports "mismatch" on every single restart on the
+// `/opt/ocp`-shaped hosts this fix was explicitly written to support (this file's own module
+// comment and the PR that introduced it both cite `/opt/ocp` as a real production shape) — because
+// the default never resolves to anything BUT `~/ocp`.
+//
+// Fix: default to the directory of THIS RUNNING FILE — the one fact this process can actually be
+// certain of — via `fileURLToPath(import.meta.url)`, exactly the same "trust the module's own URL
+// over any assumption about where it's installed" precedent `_isMain()` below already establishes
+// for symlinked install paths. `scripts/upgrade.mjs` always lives at `<ocpDir>/scripts/upgrade.mjs`
+// (setup.mjs never installs it anywhere else), so the OCP root is two `dirname()` calls up.
+// `opts.ocpDir` remains a valid EXPLICIT override (tests use it, and any future CLI flag could) —
+// only the no-override default changed. realpath'd where possible so a symlinked install dir
 // (~/ocp -> /data/ocp, say) compares correctly against /proc/<pid>/cwd's already-kernel-canonical
-// target; falls back to the raw path when realpath fails (doesn't exist yet, permission gap) —
-// this function must never throw, only degrade to the best answer it has.
+// target; this function must never throw, only degrade to the best answer it has.
 function resolveExpectedWorkingTree(opts) {
-  const ocpDir = opts.ocpDir || join(homedir(), "ocp");
+  let ocpDir = opts.ocpDir;
+  if (!ocpDir) {
+    try {
+      ocpDir = dirname(dirname(fileURLToPath(import.meta.url)));
+    } catch {
+      ocpDir = join(homedir(), "ocp"); // last-resort fallback if import.meta.url is ever unavailable
+    }
+  }
   try { return realpathSync(ocpDir); } catch { return ocpDir; }
 }
 
@@ -956,7 +985,6 @@ async function runRollback(opts) {
 }
 
 // CLI entrypoint — use fileURLToPath + realpath to handle symlinked install paths.
-import { fileURLToPath } from "node:url";
 function _isMain() {
   if (!process.argv[1]) return false;
   try {

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -8618,6 +8618,8 @@ test("classifyCmdlineOwner: empty-string cmdline read is also 'unknown', not 'fo
   assert.equal(classifyCmdlineOwner("").state, "unknown");
 });
 
+import { realpathSync } from "node:fs";
+
 console.log("\nRestart-unit resolution (issue #254) — classifyWorkingTree:");
 
 // issue #254: split from #237 per independent review of PR #251 — classifyCmdlineOwner confirms
@@ -9690,6 +9692,45 @@ test("#254: injected runner — REAL gather layer reads /proc/<pid>/cwd and warn
     result.phases.some(p => p.name === "restart-resolve" && p.note &&
       p.note.includes("/opt/other-ocp-install") && p.note.includes("/opt/ocp")),
     `expected the warning to name BOTH the observed and expected working tree; got ${JSON.stringify(result.phases)}`
+  );
+});
+
+test("#254: injected runner — default expectedWorkingTree derives from THIS RUNNING FILE's own location, not homedir() (post-review regression guard)", async () => {
+  // Independent review of an earlier revision of this fix found resolveExpectedWorkingTree's
+  // no-override default was opts.ocpDir || join(homedir(), "ocp") — the same pattern
+  // runFullUpgrade/runRollback use for their OWN git-checkout/npm-install target. That default is
+  // dead-wrong for THIS comparison specifically: opts.ocpDir is never populated by any real
+  // invocation (the `ocp` bash wrapper calls `node "$script_dir/scripts/upgrade.mjs" ...`
+  // positionally — no --ocp-dir flag exists anywhere, verified by reading the `ocp` script and this
+  // file's own _isMain() argv parser), so in production the old default ALWAYS resolved to ~/ocp
+  // regardless of which tree was actually running — reproducing, inside the new check itself, the
+  // exact "silently assumes the wrong tree" failure mode #254 exists to catch. Fixed to default to
+  // scripts/upgrade.mjs's own file location (fileURLToPath(import.meta.url), two dirnames up) —
+  // the one fact this process can be certain of, the same precedent this file's own _isMain()
+  // already establishes for symlinked install paths. This test drives the REAL default (no
+  // opts.ocpDir override at all) and confirms a cwd matching THIS repo's own root produces a
+  // match — not a spurious mismatch warning, which is what the old homedir()-based default would
+  // produce in this sandboxed test environment (whose real $HOME is essentially never this repo's
+  // checkout path).
+  const thisRepoRoot = realpathSync(_ltF2P(new URL(".", import.meta.url)).replace(/\/$/, ""));
+  const run = makeFakeRun({
+    "ss -lptn": `LISTEN 0 511 0.0.0.0:3456 0.0.0.0:* users:(("node",pid=900003,fd=19))`,
+    "cat /proc/900003/cgroup": "0::/system.slice/ocp.service\n",
+    "cat /proc/900003/cmdline": "/usr/bin/node\0server.mjs\0",
+    "readlink /proc/900003/cwd": `${thisRepoRoot}\n`, // SAME tree upgrade.mjs is actually running from
+    "sudo -n -l systemctl restart -- ocp.service": "systemctl restart -- ocp.service",
+  });
+  const result = await runUpgrade({
+    yes: true, dryRun: false, mockExec: true,
+    mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" }, current_version: "v3.10.0", latest_version: "v3.14.0" },
+    mockPlatform: "linux", mockIsRoot: true, run,
+    // Deliberately NO ocpDir override — that absence is the entire point of this test.
+  });
+  const restartCmds = result.phases.filter(p => p.name === "restart").map(p => p.cmd);
+  assert.ok(restartCmds.length > 0);
+  assert.ok(
+    !result.phases.some(p => p.name === "restart-resolve" && p.note && p.note.includes("does not match this installation's own working tree")),
+    `default expectedWorkingTree must resolve to THIS repo's own root, not homedir()/ocp; got phases=${JSON.stringify(result.phases)}`
   );
 });
 

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -8433,7 +8433,7 @@ test("LOW-2 (real shell, verified mechanism): ocp's doctor-check-surfacing block
 // and asserts on return values or thrown messages — never on scripts/
 // upgrade.mjs's or scripts/lib/restart-unit.mjs's source text.
 // ═══════════════════════════════════════════════════════════════════════════
-import { resolveOwningUnit, planRestart, classifySsListener, classifyLsofListener, parseCgroupUnit, classifyCmdlineOwner, classifyLaunchdJob, classifyLaunchdArgv } from "./scripts/lib/restart-unit.mjs";
+import { resolveOwningUnit, planRestart, classifySsListener, classifyLsofListener, parseCgroupUnit, classifyCmdlineOwner, classifyLaunchdJob, classifyLaunchdArgv, classifyWorkingTree } from "./scripts/lib/restart-unit.mjs";
 
 console.log("\nRestart-unit resolution (issue #215) — classifiers:");
 
@@ -8618,6 +8618,51 @@ test("classifyCmdlineOwner: empty-string cmdline read is also 'unknown', not 'fo
   assert.equal(classifyCmdlineOwner("").state, "unknown");
 });
 
+console.log("\nRestart-unit resolution (issue #254) — classifyWorkingTree:");
+
+// issue #254: split from #237 per independent review of PR #251 — classifyCmdlineOwner confirms
+// "this process invokes A server.mjs", never "THIS installation's server.mjs". classifyWorkingTree
+// closes that gap by comparing /proc/<pid>/cwd (kernel-canonical, independent of whatever argv
+// spelled out) against the working tree the caller itself is running from.
+
+test("classifyWorkingTree: observed cwd equals the expected tree → match", () => {
+  assert.deepEqual(classifyWorkingTree("/home/opc/ocp", "/home/opc/ocp"), { state: "match", reason: null });
+});
+
+test("classifyWorkingTree: observed cwd is a DIFFERENT tree → mismatch, names BOTH paths in the reason", () => {
+  const result = classifyWorkingTree("/home/other-user/ocp-dev", "/home/opc/ocp");
+  assert.equal(result.state, "mismatch");
+  assert.ok(result.reason.includes("/home/other-user/ocp-dev"));
+  assert.ok(result.reason.includes("/home/opc/ocp"));
+});
+
+test("classifyWorkingTree: readlink's real output carries a trailing newline — trimmed before comparing", () => {
+  // execSync's .toString() includes the shell command's trailing newline verbatim; a naive
+  // string compare would read a real match as a mismatch on every single call.
+  assert.equal(classifyWorkingTree("/home/opc/ocp\n", "/home/opc/ocp").state, "match");
+});
+
+test("classifyWorkingTree: cwdTarget null (probe attempted, failed to read) → unknown, never the false-confident 'mismatch'", () => {
+  // /proc/<pid>/cwd requires ptrace-level visibility — a STRICTER permission bar than
+  // /proc/<pid>/cmdline. A non-root updater against a root-owned system unit routinely has
+  // cmdlineContent succeed while this read is denied; that must never be read as "confirmed
+  // different tree", the same "unknown must never be treated as safe-to-guess" posture every other
+  // classifier in this file already takes.
+  const result = classifyWorkingTree(null, "/home/opc/ocp");
+  assert.equal(result.state, "unknown");
+  assert.notEqual(result.state, "mismatch");
+});
+
+test("classifyWorkingTree: empty-string cwdTarget read is also 'unknown', not 'mismatch'", () => {
+  assert.equal(classifyWorkingTree("", "/home/opc/ocp").state, "unknown");
+});
+
+test("classifyWorkingTree: no expected working tree provided → unknown (never guesses a comparison with nothing to compare against)", () => {
+  assert.equal(classifyWorkingTree("/home/opc/ocp", "").state, "unknown");
+  assert.equal(classifyWorkingTree("/home/opc/ocp", null).state, "unknown");
+  assert.equal(classifyWorkingTree("/home/opc/ocp", undefined).state, "unknown");
+});
+
 console.log("\nRestart-unit resolution (issue #239) — classifyLaunchdJob:");
 
 // issue #239: macOS has no /proc/<pid>/cgroup reverse lookup, so ownership resolution runs the
@@ -8765,6 +8810,122 @@ test("resolveOwningUnit: cmdlineContent ABSENT (undefined, not null) preserves p
   });
   assert.equal(owner.kind, "system-unit");
   assert.equal(owner.mismatched, true);
+});
+
+console.log("\nRestart-unit resolution (issue #254) — resolveOwningUnit + planRestart: working-tree comparison:");
+
+test("resolveOwningUnit: confirmed server.mjs process, MATCHING working tree → workingTreeMismatch false, no warning from planRestart", () => {
+  const owner = resolveOwningUnit({
+    platform: "linux",
+    expectedUnit: "ocp-proxy.service",
+    ssOutput: `LISTEN 0 511 127.0.0.1:3456 0.0.0.0:* users:(("node",pid=900010,fd=19))`,
+    cgroupContent: "0::/user.slice/user-1000.slice/user@1000.service/app.slice/ocp-proxy.service\n",
+    cmdlineContent: "/usr/bin/node\0/home/opc/ocp/server.mjs\0",
+    cwdTarget: "/home/opc/ocp\n",
+    expectedWorkingTree: "/home/opc/ocp",
+  });
+  assert.equal(owner.kind, "user-unit");
+  assert.equal(owner.workingTreeMismatch, false);
+  const plan = planRestart(owner, { expectedUnit: "ocp-proxy.service" });
+  assert.ok(!plan.warnings.some(w => w.includes("#254")), "a matching working tree must not produce a #254 warning");
+});
+
+test("resolveOwningUnit: confirmed server.mjs process, DIFFERENT working tree (a second OCP checkout) → workingTreeMismatch true, named in owner.reason-adjacent field", () => {
+  const owner = resolveOwningUnit({
+    platform: "linux",
+    expectedUnit: "ocp-proxy.service",
+    ssOutput: `LISTEN 0 511 127.0.0.1:3456 0.0.0.0:* users:(("node",pid=900011,fd=19))`,
+    cgroupContent: "0::/user.slice/user-1000.slice/user@1000.service/app.slice/ocp-proxy.service\n",
+    cmdlineContent: "/usr/bin/node\0/home/other-user/ocp-dev/server.mjs\0",
+    cwdTarget: "/home/other-user/ocp-dev\n",
+    expectedWorkingTree: "/home/opc/ocp",
+  });
+  assert.equal(owner.kind, "user-unit", "still a real, name-matching unit — this is NOT the foreign-process case");
+  assert.equal(owner.workingTreeMismatch, true);
+  assert.ok(owner.workingTreeReason.includes("/home/other-user/ocp-dev"));
+  assert.ok(owner.workingTreeReason.includes("/home/opc/ocp"));
+});
+
+test("resolveOwningUnit: BARE RELATIVE server.mjs argv (the real production unit shape) with the SAME cwd as expected → match, no false positive", () => {
+  // The central fleet risk this fix must not introduce: WorkingDirectory=<tree>,
+  // ExecStart=node server.mjs is a real production unit today. argv alone carries no path at all
+  // (doctor.mjs's own #230 workingTree derivation would resolve to "" here — unusable). Only
+  // /proc/<pid>/cwd tells this apart from a genuinely different install, and it must correctly
+  // recognize the common, legitimate case as a match.
+  const owner = resolveOwningUnit({
+    platform: "linux",
+    expectedUnit: "ocp-proxy.service",
+    ssOutput: `LISTEN 0 511 127.0.0.1:3456 0.0.0.0:* users:(("node",pid=900012,fd=19))`,
+    cgroupContent: "0::/user.slice/user-1000.slice/user@1000.service/app.slice/ocp-proxy.service\n",
+    cmdlineContent: "/usr/bin/node\0server.mjs\0",
+    cwdTarget: "/home/opc/ocp\n",
+    expectedWorkingTree: "/home/opc/ocp",
+  });
+  assert.equal(owner.workingTreeMismatch, false, "a relative argv resolving to the SAME cwd must never be flagged as a mismatch");
+});
+
+test("resolveOwningUnit: BARE RELATIVE server.mjs argv with a DIFFERENT cwd → mismatch IS caught (proves cwd succeeds where argv-text would be blind)", () => {
+  const owner = resolveOwningUnit({
+    platform: "linux",
+    expectedUnit: "ocp-proxy.service",
+    ssOutput: `LISTEN 0 511 127.0.0.1:3456 0.0.0.0:* users:(("node",pid=900013,fd=19))`,
+    cgroupContent: "0::/user.slice/user-1000.slice/user@1000.service/app.slice/ocp-proxy.service\n",
+    cmdlineContent: "/usr/bin/node\0server.mjs\0",
+    cwdTarget: "/opt/second-ocp-install\n",
+    expectedWorkingTree: "/home/opc/ocp",
+  });
+  assert.equal(owner.workingTreeMismatch, true);
+  assert.ok(owner.workingTreeReason.includes("/opt/second-ocp-install"));
+});
+
+test("resolveOwningUnit: cwdTarget null (probe attempted, permission denied) → workingTreeMismatch stays false — never a false-confident mismatch", () => {
+  const owner = resolveOwningUnit({
+    platform: "linux",
+    expectedUnit: "ocp-proxy.service",
+    ssOutput: `LISTEN 0 511 0.0.0.0:3456 0.0.0.0:* users:(("node",pid=900014,fd=19))`,
+    cgroupContent: "0::/system.slice/ocp.service\n",
+    cmdlineContent: "/usr/bin/node\0/opt/ocp/server.mjs\0",
+    cwdTarget: null,
+    expectedWorkingTree: "/opt/ocp",
+  });
+  assert.equal(owner.workingTreeMismatch, false);
+  const plan = planRestart(owner, { expectedUnit: "ocp-proxy.service", isRoot: true });
+  assert.ok(!plan.warnings.some(w => w.includes("#254")));
+});
+
+test("resolveOwningUnit: cwdTarget ABSENT (undefined, not null) preserves pre-#254 behavior — backward compatible for callers not wired to the new check", () => {
+  const owner = resolveOwningUnit({
+    platform: "linux",
+    expectedUnit: "ocp-proxy.service",
+    ssOutput: `LISTEN 0 511 0.0.0.0:3456 0.0.0.0:* users:(("node",pid=900015,fd=19))`,
+    cgroupContent: "0::/system.slice/ocp.service\n",
+    cmdlineContent: "/usr/bin/node\0/opt/ocp/server.mjs\0",
+    // cwdTarget/expectedWorkingTree deliberately omitted — mirrors every legacy caller that
+    // predates this check.
+  });
+  assert.equal(owner.workingTreeMismatch, false);
+});
+
+test("planRestart: a working-tree mismatch WARNS but still proceeds — never escalated to a refusal (a false mismatch must not block a healthy restart)", () => {
+  const owner = {
+    kind: "user-unit", platform: "linux", pid: "900011", unit: "ocp-proxy.service", scope: "user", mismatched: false,
+    workingTreeMismatch: true,
+    workingTreeReason: `owning process's working directory (/home/other-user/ocp-dev) does not match this installation's own working tree (/home/opc/ocp) — this may be a different OCP checkout (or an unrelated process) rather than this installation`,
+  };
+  const plan = planRestart(owner, { expectedUnit: "ocp-proxy.service" });
+  assert.equal(plan.cmds.length, 1, "must still construct a restart command — this is a warning, not a refusal");
+  assert.ok(plan.warnings.some(w => w.includes("#254") && w.includes("/home/other-user/ocp-dev") && w.includes("/home/opc/ocp")));
+});
+
+test("planRestart: a working-tree mismatch on a SYSTEM unit, root-authorized, still proceeds with a warning (not silently dropped, not refused)", () => {
+  const owner = {
+    kind: "system-unit", platform: "linux", pid: "900016", unit: "ocp.service", scope: "system", mismatched: false,
+    workingTreeMismatch: true,
+    workingTreeReason: `owning process's working directory (/opt/second-ocp-install) does not match this installation's own working tree (/home/opc/ocp) — this may be a different OCP checkout (or an unrelated process) rather than this installation`,
+  };
+  const plan = planRestart(owner, { expectedUnit: "ocp-proxy.service", isRoot: true });
+  assert.equal(plan.cmds[0].cmd, "systemctl restart -- ocp.service");
+  assert.ok(plan.warnings.some(w => w.includes("#254")));
 });
 
 console.log("\nRestart-unit resolution (issue #215) — resolveOwningUnit composition:");
@@ -9460,6 +9621,76 @@ test("#237: injected runner — REAL gather layer reads /proc/<pid>/cmdline and 
       mockPlatform: "linux", mockIsRoot: true, run,
     });
   }, /nginx\.service.*not OCP's server\.mjs/s);
+});
+
+console.log("\nRestart-unit resolution (issue #254) — working-tree comparison (residual gap left open by #237's own review):");
+
+// issue #254: split from #237 per independent review of PR #251. classifyCmdlineOwner (#237)
+// answers "does this process invoke A server.mjs at all" — it does NOT answer "is it THIS
+// installation's server.mjs". A second, unrelated Node app whose entrypoint happens to be named
+// server.mjs, or — far more realistically on this fleet — a second OCP checkout (a dev tree next
+// to a production install) passes classifyCmdlineOwner's "ocp" verdict exactly like the real
+// production process does. These two tests drive the fix end to end through the SAME runUpgrade()
+// path #237's own wiring tests use — one via mockOwnerProbe (bypasses scripts/upgrade.mjs's own
+// gather layer), one via a fake injected run() (drives the REAL `readlink /proc/<pid>/cwd`
+// invocation) — mirroring the two-test shape #237 itself used for exactly the same reason (review
+// finding MED-6: the impure gather layer is where real defects hide, so it needs its own coverage,
+// not just the pure functions in isolation).
+
+test("#254: upgrade full path — a process confirmed to invoke server.mjs but from a DIFFERENT working tree gets a loud warning, not silent trust", async () => {
+  const result = await runUpgrade({
+    yes: true, dryRun: false, mockExec: true,
+    mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" }, current_version: "v3.10.0", latest_version: "v3.14.0" },
+    mockPlatform: "linux",
+    mockOwnerProbe: {
+      ssOutput: `LISTEN 0 511 0.0.0.0:3456 0.0.0.0:* users:(("node",pid=900001,fd=19))`,
+      cgroupContent: "0::/user.slice/user-1000.slice/user@1000.service/app.slice/ocp-proxy.service\n",
+      // A REAL server.mjs — classifyCmdlineOwner alone confirms "ocp" — but rooted in a completely
+      // different checkout than this installation (opts.ocpDir below) is running from.
+      cmdlineContent: "/usr/bin/node\0/home/other-user/ocp-dev/server.mjs\0",
+      cwdTarget: "/home/other-user/ocp-dev\n", // readlink's real output carries a trailing newline
+      expectedWorkingTree: "/home/opc/ocp",
+    },
+    mockIsRoot: true,
+  });
+  const restartCmds = result.phases.filter(p => p.name === "restart").map(p => p.cmd);
+  // A working-tree mismatch WARNS — it does not refuse. See the fix's own design note: unlike
+  // #237's argv check (near-zero false-positive rate), a false "different install" verdict here
+  // would block a healthy production restart, which this fleet cannot afford (see the relative-argv
+  // production shape covered by the second test below).
+  assert.ok(restartCmds.length > 0, "a working-tree mismatch must not silently refuse the whole restart");
+  assert.ok(
+    result.phases.some(p => p.name === "restart-resolve" && p.note &&
+      p.note.includes("/home/other-user/ocp-dev") && p.note.includes("/home/opc/ocp")),
+    `expected a loud warning naming BOTH the observed and expected working tree; got phases=${JSON.stringify(result.phases)}`
+  );
+});
+
+test("#254: injected runner — REAL gather layer reads /proc/<pid>/cwd and warns on a working-tree mismatch end to end (not just the pure functions), even for a BARE RELATIVE server.mjs argv", async () => {
+  // The relative-argv shape (WorkingDirectory=<tree>, ExecStart=node server.mjs — argv carries no
+  // path at all) is a real production unit today. Any check keyed off argv TEXT for the tree
+  // (mirroring doctor.mjs's own #230 workingTree derivation) is blind here — the fix must use
+  // /proc/<pid>/cwd instead, which resolves the real cwd regardless of what argv spelled out.
+  const run = makeFakeRun({
+    "ss -lptn": `LISTEN 0 511 0.0.0.0:3456 0.0.0.0:* users:(("node",pid=900002,fd=19))`,
+    "cat /proc/900002/cgroup": "0::/system.slice/ocp.service\n",
+    "cat /proc/900002/cmdline": "/usr/bin/node\0server.mjs\0",
+    "readlink /proc/900002/cwd": "/opt/other-ocp-install\n",
+    "sudo -n -l systemctl restart -- ocp.service": "systemctl restart -- ocp.service",
+  });
+  const result = await runUpgrade({
+    yes: true, dryRun: false, mockExec: true,
+    mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" }, current_version: "v3.10.0", latest_version: "v3.14.0" },
+    mockPlatform: "linux", mockIsRoot: true, run,
+    ocpDir: "/opt/ocp",
+  });
+  const restartCmds = result.phases.filter(p => p.name === "restart").map(p => p.cmd);
+  assert.ok(restartCmds.length > 0, "must still restart — a working-tree mismatch warns, it does not refuse");
+  assert.ok(
+    result.phases.some(p => p.name === "restart-resolve" && p.note &&
+      p.note.includes("/opt/other-ocp-install") && p.note.includes("/opt/ocp")),
+    `expected the warning to name BOTH the observed and expected working tree; got ${JSON.stringify(result.phases)}`
+  );
 });
 
 test("MED-4 wiring: injected runner — sudo -n -l denies THIS specific command → refuses (not a generic sudo -n true probe)", async () => {


### PR DESCRIPTION
# Pull Request

## Summary

Closes #254 — the residual gap independent review of PR #251 asked to be filed rather than
silently dropped. #237's own fix (PR #251, `classifyCmdlineOwner`) confirms a port-owning process
invokes *A* `server.mjs` before treating its resolved unit as a restart candidate — it does not,
and per its own PR body was never meant to, confirm *WHICH* `server.mjs`. A second, unrelated Node
application whose entrypoint happens to be named (or symlinked to) `server.mjs`, or — more
realistically on this fleet — a second OCP checkout (a dev tree sitting next to a production
install), passes `classifyCmdlineOwner`'s `"ocp"` verdict exactly the same way the real production
process does; nothing about that check can tell them apart.

## Post-review correction (addressed in a follow-up commit on this branch)

An independent fresh-context review of the original commit found a real bug: `resolveExpectedWorkingTree`'s no-override default was `opts.ocpDir || join(homedir(), "ocp")` — the
same pattern this file's `runFullUpgrade`/`runRollback` already use for their own git-checkout/
npm-install target. That default is wrong for THIS specific comparison: `opts.ocpDir` is dead code
in every real invocation — verified independently by both the review and here: the `ocp` bash
wrapper invokes `node "$script_dir/scripts/upgrade.mjs" ...` positionally (no `--ocp-dir` flag
exists anywhere), and this file's own `_isMain()` argv parser never reads one either. So in
production the old default ALWAYS resolved to `~/ocp` regardless of which tree was actually
running — reproducing, inside the working-tree check itself, the exact class of failure the check
exists to catch: a false negative when a different checkout manages production's real `~/ocp`
install, and a false positive on every restart on a `/opt/ocp`-shaped host, the production shape
this fix was explicitly required to support.

Fixed to default to the directory of THIS RUNNING FILE instead, via
`fileURLToPath(import.meta.url)` (two `dirname()` calls up from `scripts/upgrade.mjs`'s own path)
— the one fact this process can actually be certain of, the same "trust the module's own URL"
precedent this file's own `_isMain()` already establishes for symlinked install paths.
`opts.ocpDir` remains a valid explicit override (tests use it); only the no-override default
changed. New regression test drives the REAL default (no `opts.ocpDir` override at all) and
confirms it resolves to this repo's own root rather than `homedir()/ocp`; verified this test
actually catches the reviewer-found bug by reverting the default to its pre-correction form,
confirming the test fails by name, and restoring from a file backup + `shasum -a 256`.

## Endpoint Class (REQUIRED)

- [x] **Not endpoint-touching.** `server.mjs` does not appear in this diff; no HTTP request handler
  is touched. This is a fix to the restart-resolution logic in `scripts/lib/restart-unit.mjs` and
  its gather layer in `scripts/upgrade.mjs` (the `ocp update` / `ocp restart` CLI path).

## Claude Code Alignment Evidence (REQUIRED)

N/A — not endpoint-touching. `server.mjs` is untouched, so no `cli.js:NNNN` citation applies
(`ALIGNMENT.md` Rule 5 governs `server.mjs` changes only). Confirmed by `git diff --stat`: only
`scripts/lib/restart-unit.mjs`, `scripts/upgrade.mjs`, and `test-features.mjs` changed.

## What can this check decide, honestly? (explicit per the issue's own ask)

**Can decide:** whether the port-owning process's *actual, current* working directory
(`readlink /proc/<pid>/cwd` — a kernel-canonicalized absolute path, resolved regardless of whether
`ExecStart`'s argv used a relative or absolute `server.mjs` path) matches the working tree *this
specific installation* (`opts.ocpDir` or its script-relative default) is running from. This is
strictly more reliable than the only alternative already in this codebase — `doctor.mjs`'s own
#230 `workingTree` (derived from static argv *text*) — because that signal resolves to `""` for a
bare relative `server.mjs` argv, which **is a real production unit shape on this fleet today**
(`WorkingDirectory=<tree>`, `ExecStart=node server.mjs`). A comparison keyed off argv text would
read every one of those hosts as an unresolvable mismatch regardless of whether the tree is
actually the same — wrong by construction. `/proc/<pid>/cwd` has no such blind spot.

**Cannot decide, and does not claim to:**
- **When permission is denied.** `/proc/<pid>/cwd` requires ptrace-level visibility (same uid, or
  `CAP_SYS_PTRACE`) — strictly stricter than `/proc/<pid>/cmdline`, which is world-readable on a
  default `hidepid=0/1` host. A non-root `ocp update` against a root-owned **system** unit — an
  already-supported, already-documented shape elsewhere in this file — will routinely have
  `cmdlineContent` succeed while this read is denied. Denied reads as `"unknown"`, never
  `"confirmed different tree"`.
- **Whether the process later `chdir()`'d.** `/proc/<pid>/cwd` is the process's *current* cwd, not
  provably "the directory `server.mjs` was loaded from." OCP's own `server.mjs` never calls
  `process.chdir()` (verified: zero hits). An adversary willing to both fork a lookalike
  `server.mjs`-named entrypoint *and* `chdir()` it to match is the same out-of-scope threat model
  #237's own review already named (misconfiguration, not an adversary controlling process
  identity).
- **Whether a mismatch is confidently "foreign."** Unlike `classifyCmdlineOwner`'s near-zero
  false-positive rate (real argv genuinely lacking `server.mjs` is unambiguous), a working-tree
  mismatch is comparatively weaker evidence, and "unknown" is routine (see the permission point
  above) rather than an edge case. **A false "different install" verdict here would refuse a
  healthy production restart** — this fleet cannot afford that. So this PR does **not** escalate a
  mismatch to a refusal: it WARNS. This matches `doctor.mjs`'s own #230 MED-7 posture — two
  differing working trees are two legitimate, separate installs, and this codebase does not
  nominate one as wrong without a human deciding.
- **macOS.** No `/proc` filesystem exists there. Extending this to macOS needs its own probe design
  (analogous to how #239 built `classifyLaunchdJob`/`classifyLaunchdArgv` as its own dedicated
  follow-up to #237) — deliberately out of scope here, mirroring the same Linux/macOS split #237
  and #239 already established.

## What changed

- `scripts/lib/restart-unit.mjs`: new pure classifier `classifyWorkingTree(cwdTarget,
  expectedWorkingTree)` — three states (`"match"` / `"mismatch"` / `"unknown"`), same "unknown must
  never be treated as safe-to-guess" posture every other classifier in this file already uses.
  `resolveOwningUnit` consults it only once `classifyCmdlineOwner` has already confirmed `"ocp"`
  (comparing working trees is meaningless for an already-unknown/foreign process), and only when
  the caller attempted the probe (`probe.cwdTarget !== undefined` — same legacy/back-compat lane
  every other probe field here uses). Result surfaces as `owner.workingTreeMismatch` /
  `owner.workingTreeReason`, deliberately **not** folded into `owner.kind` or `owner.mismatched`.
  `planRestart` appends a loud warning (not a refusal) when `owner.workingTreeMismatch` is true.
- `scripts/upgrade.mjs`: the Linux gather step now also reads `/proc/<pid>/cwd` in the same probe
  pass that already reads `cgroup`/`cmdline` (no separate resolution pass), and computes
  `expectedWorkingTree` from `opts.ocpDir` (realpath'd where possible, so a symlinked install
  directory compares correctly against `/proc/<pid>/cwd`'s already-canonical target) — the same
  `opts.ocpDir || join(homedir(), "ocp")` fallback every other `ocpDir` use in this file already
  takes.
- `test-features.mjs`: 17 new tests total (6 pure `classifyWorkingTree` unit tests, 8
  `resolveOwningUnit` + `planRestart` composition tests — including the bare-relative-argv
  production shape, both matching and mismatched cwd — 2 `runUpgrade()` end-to-end wiring tests,
  one via `mockOwnerProbe`, one via a real injected `run()` command router proving the actual
  gather layer, not just the pure functions, and 1 post-review regression guard proving the
  no-override default resolves from this file's own location rather than `homedir()`).

## Test evidence

**Before the fix** (unmodified `main` + the two `runUpgrade()`-level tests only — these use only
already-exported functions, so they run cleanly against unmodified `main` without any import
error; the classifier-level tests below require the new export and were added alongside the fix):

```
✗ #254: upgrade full path — a process confirmed to invoke server.mjs but from a DIFFERENT working tree gets a loud warning, not silent trust: expected a loud warning naming BOTH the observed and expected working tree; got phases=[...no working-tree warning present...]
✗ #254: injected runner — REAL gather layer reads /proc/<pid>/cwd and warns on a working-tree mismatch end to end (not just the pure functions), even for a BARE RELATIVE server.mjs argv: expected the warning to name BOTH the observed and expected working tree; got [...no working-tree warning present...]

=== Results: 773 passed, 2 failed ===
```

**After the original fix, before the post-review correction:**

```
✓ #254: upgrade full path — a process confirmed to invoke server.mjs but from a DIFFERENT working tree gets a loud warning, not silent trust
✓ #254: injected runner — REAL gather layer reads /proc/<pid>/cwd and warns on a working-tree mismatch end to end (not just the pure functions), even for a BARE RELATIVE server.mjs argv
...(14 more new tests, all passing)...

=== Results: 789 passed, 0 failed ===
```

**After the post-review correction (final state of this branch):**

```
✓ #254: injected runner — default expectedWorkingTree derives from THIS RUNNING FILE's own location, not homedir() (post-review regression guard)
...(all 16 tests above, still passing)...

=== Results: 790 passed, 0 failed ===
```

Three consecutive full-suite runs on the final branch state: 790/0 every time.

## Mutation proof

Five mutations total across two rounds. Each: source file backed up with `cp` first (never
`git checkout -- ...`), a Python script asserts the anchor string is present **exactly once**
before mutating (so a silently-no-op mutation can't be misread as "the guard held"), then
restored from the backup and reconfirmed byte-identical with `shasum -a 256` before the next
mutation.

**Original round (4):**

| # | Mutation | Failing tests (by name) |
|---|---|---|
| A | `classifyWorkingTree`: neutered the comparison (`if (true) { return { state: "match" } }`) — always reports match | `classifyWorkingTree: observed cwd is a DIFFERENT tree → mismatch, names BOTH paths in the reason`; `resolveOwningUnit: confirmed server.mjs process, DIFFERENT working tree (a second OCP checkout) → workingTreeMismatch true, named in owner.reason-adjacent field`; `resolveOwningUnit: BARE RELATIVE server.mjs argv with a DIFFERENT cwd → mismatch IS caught (proves cwd succeeds where argv-text would be blind)`; `#254: upgrade full path — a process confirmed to invoke server.mjs but from a DIFFERENT working tree gets a loud warning, not silent trust`; `#254: injected runner — REAL gather layer reads /proc/<pid>/cwd and warns on a working-tree mismatch end to end ...` (5 tests) |
| B | `resolveOwningUnit`: neutered the wiring to `classifyWorkingTree` (`if (false && probe.cwdTarget !== undefined)`) | `resolveOwningUnit: confirmed server.mjs process, DIFFERENT working tree ...`; `resolveOwningUnit: BARE RELATIVE server.mjs argv with a DIFFERENT cwd ...`; both `#254` end-to-end `runUpgrade()` tests (4 tests — correctly excludes the pure `classifyWorkingTree` unit tests, proving layer separation) |
| C | `planRestart`: neutered the warning push (`if (false && owner.workingTreeMismatch)`) | both dedicated `planRestart:` working-tree-warning tests; both `#254` end-to-end `runUpgrade()` tests (4 tests — correctly excludes both the pure classifier tests and the `resolveOwningUnit`-only composition tests) |
| D | `scripts/upgrade.mjs`: deleted the gather-layer `readlink /proc/<pid>/cwd` line entirely | `#254: injected runner — REAL gather layer reads /proc/<pid>/cwd ...` (and **only** this one — by design: every `mockOwnerProbe`-based test bypasses this gather layer, exactly mirroring PR #251's own mutation-C finding for the analogous `cmdline` read) |

**Post-review round (1), targeting the correction above, re-run against the corrected file:**

| # | Mutation | Failing tests (by name) |
|---|---|---|
| E | `resolveExpectedWorkingTree`'s corrected default reverted to `join(homedir(), "ocp")` (the reviewer-found bug) | `#254: injected runner — default expectedWorkingTree derives from THIS RUNNING FILE's own location, not homedir() ...` (1 test — this is the exact independently-found bug; before this test existed, mutation E would have survived undetected) |

Checksums before/after each restore were byte-identical (`shasum -a 256`) in all five cases.
Mutation D was also re-run against the corrected file (after the import reorganization the
correction required) to confirm it still holds.

## Full suite

`node test-features.mjs`, run 5 times consecutively on the final branch state: **790 passed, 0
failed** every single run — no flakiness observed. Baseline on unmodified `origin/main` (`8b1435d`),
verified separately before any change this session made: **773 passed, 0 failed**, also stable
across 3 consecutive runs.

`server.mjs` is untouched by this PR — no `cli.js` citation applies (`ALIGNMENT.md` Rule 5 governs
`server.mjs` changes only; this is `scripts/lib/restart-unit.mjs` and `scripts/upgrade.mjs`, the
upgrade/restart CLI's own resolution logic, not the proxy's request path).

## Related

- `ALIGNMENT.md` Rule(s) invoked: none — not endpoint-touching, `server.mjs` untouched.
- Related issue: closes #254.
- Refs #237, #251 (the PR this residual gap was split from per Iron Rule 11), #230 (`doctor.mjs`'s
  own working-tree precedent, MED-7 in particular), #239 (the macOS identity-check sibling this PR
  deliberately does not extend to).

### User-visible change self-check (铁律第五律 5.3)

- [x] This PR has no user-visible changes beyond a new, more specific warning on an
  already-narrow edge case (a working-tree-mismatched-but-otherwise-legitimate restart target) —
  no README documentation update needed (no new CLI subcommand, env var, or endpoint).

### Privacy self-check (for PUBLIC repos)

- [x] No real names, personal paths, hostnames, or personal email addresses introduced. Example
  paths in tests/comments (`/home/opc/ocp`, `/opt/ocp`) are the same illustrative shapes already
  used throughout this file's pre-existing tests and comments.
