### PR TITLE
fix(ocp): cmd_restart gateway distinguishes 'not installed' from 'installed and failed'

### DIFF
--- a/ocp
+++ b/ocp
@@ -673,7 +673,32 @@ EOF
 cmd_restart() {
   if [[ "${1:-}" == "gateway" ]]; then
     echo "Restarting gateway..."
-    openclaw gateway restart 2>&1
+    # Issue #263 (the #261 pattern's instance inside cmd_restart, itself the follow-up to
+    # #242's `_pyfail`): a bare `openclaw gateway restart 2>&1` with no `||` handling meant
+    # `set -e` (ocp:7) killed the ENTIRE `ocp` process the instant `openclaw` was missing from
+    # $PATH (bash's own "command not found", exit 127) -- with no OCP-level framing at all, and
+    # no way to tell that apart from openclaw being installed but its OWN restart genuinely
+    # failing, which produced the identical unframed-death shape. OpenClaw is an OPTIONAL
+    # sibling tool (AGENTS.md "What this project is"): its absence is a normal configuration,
+    # not a fault, so it gets its own branch here rather than folding into the generic
+    # `_curl_or_die`-style "could not run" message #261 uses for curl -- "not installed" is
+    # reported once, calmly, and this function returns SUCCESS (0); "installed and failed" is
+    # the opposite: openclaw's own combined output is preserved (2>&1 here is safe -- it feeds a
+    # visible failure message, not a misdiagnosis, unlike the #261 pattern) and surfaced loudly
+    # on stderr with a nonzero return, because that IS the operator's gateway breaking.
+    local gw_out gw_status=0
+    gw_out=$(openclaw gateway restart 2>&1) || gw_status=$?
+    if [[ $gw_status -eq 127 ]] || [[ "$gw_out" == *"command not found"* ]]; then
+      echo "  OpenClaw is not installed — skipping gateway restart (it is an optional sibling tool, not a proxy dependency)."
+      return 0
+    fi
+    if [[ $gw_status -ne 0 ]]; then
+      echo "✗ openclaw gateway restart failed (exit $gw_status):" >&2
+      echo "$gw_out" >&2
+      return 1
+    fi
+    [[ -n "$gw_out" ]] && echo "$gw_out"
+    echo "✓ Gateway restarted."
   else
     echo "Restarting proxy..."
     local self_r script_dir

--- a/ocp
+++ b/ocp
@@ -681,15 +681,37 @@ cmd_restart() {
     # failing, which produced the identical unframed-death shape. OpenClaw is an OPTIONAL
     # sibling tool (AGENTS.md "What this project is"): its absence is a normal configuration,
     # not a fault, so it gets its own branch here rather than folding into the generic
-    # `_curl_or_die`-style "could not run" message #261 uses for curl -- "not installed" is
+    # `_curl_or_die`-style "could not run" message #261 uses for curl -- "not found on $PATH" is
     # reported once, calmly, and this function returns SUCCESS (0); "installed and failed" is
     # the opposite: openclaw's own combined output is preserved (2>&1 here is safe -- it feeds a
     # visible failure message, not a misdiagnosis, unlike the #261 pattern) and surfaced loudly
-    # on stderr with a nonzero return, because that IS the operator's gateway breaking.
+    # on stderr with a nonzero return, because that IS the operator's gateway breaking. This
+    # branch is reached only via an explicit `ocp restart gateway`: the no-argument
+    # `( cmd_restart )` call sites on the update/recovery path take the PROXY branch below,
+    # never this one (independent review corrected this issue's original scope claim).
+    #
+    # Independent review round 1 (blocking): the classifier here used to also check
+    # `[[ "$gw_out" == *"command not found"* ]]` -- a text-substring match against COMBINED
+    # (2>&1) output -- alongside the exit-127 check. Removing it left the suite green; it
+    # carried zero tested behavior. What it did carry was false-positive surface worse than
+    # #261's analogous curl-side check (which only ever inspects curl's own stderr, never a
+    # response body): openclaw is a subcommand dispatcher that shells out, so a genuinely
+    # FAILING, INSTALLED openclaw can print "command not found" as part of its OWN diagnostic
+    # output (e.g. a plugin/dependency lookup message) -- reintroducing this issue's own defect
+    # through the very marker meant to fix it: a real gateway failure silently reported as a
+    # successful no-op. Bash guarantees exit 127 for "command not found" unconditionally, so the
+    # numeric check alone already carries the full signal. Removed.
     local gw_out gw_status=0
     gw_out=$(openclaw gateway restart 2>&1) || gw_status=$?
-    if [[ $gw_status -eq 127 ]] || [[ "$gw_out" == *"command not found"* ]]; then
-      echo "  OpenClaw is not installed — skipping gateway restart (it is an optional sibling tool, not a proxy dependency)."
+    if [[ $gw_status -eq 127 ]]; then
+      # Independent review round 1: this message reports what PATH-lookup semantics actually
+      # established -- NOT "OpenClaw is not installed". A non-interactive shell's $PATH (e.g. a
+      # bare `ssh host 'ocp restart gateway'`) can omit directories an interactive login
+      # shell's $PATH includes, so this exact branch can fire on a host where OpenClaw is
+      # installed, configured, and running. Overclaiming "not installed" here would be a
+      # second wrong diagnosis stacked on top of the one #263 exists to fix -- say only what
+      # was actually observed.
+      echo "  OpenClaw was not found on \$PATH — skipping gateway restart (it is an optional sibling tool, not a proxy dependency; this reports what this shell's \$PATH resolved, not whether OpenClaw is actually installed — a non-interactive \$PATH can differ from an interactive one's)."
       return 0
     fi
     if [[ $gw_status -ne 0 ]]; then

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -9901,6 +9901,16 @@ function _bwHarnessRun({
   overrideCmdRestart = true,
   resolveRestartExit = 0, resolveRestartStdout = [], resolveRestartStderr = [],
   serviceStubsSucceed = false, curlHealthExit = 1,
+  // Issue #263: simulates "openclaw is not on $PATH at all" — the same always-127-exit shadow
+  // stub technique `pythonAbsent`/`curlAbsent` already use, rather than simply omitting the
+  // `bin/openclaw` file. (Unlike curl, openclaw is not normally under /usr/bin or /bin on this
+  // repo's own dev hosts — it is a homebrew/npm-global install — so omission alone happens to
+  // work here today, but the shadow-stub technique is used anyway for the same reason #261
+  // adopted it for curl: it does not depend on what happens to be missing from a given host's
+  // /usr/bin:/bin, which is real system directory this harness's $PATH always includes for
+  // python3/cat/sed/mktemp. Independent of serviceStubsSucceed: "not installed" is a third
+  // state, not a variant of "installed and succeeds/fails".
+  openclawAbsent = false,
   // Issue #242: generic curl response fixtures for the nine read-only display commands
   // (usage/logs/models/sessions/clear/keys/settings), none of which existed as a harness
   // capability before this issue (every prior call site here only ever needed the `/health`
@@ -10045,7 +10055,7 @@ function _bwHarnessRun({
     // resolved restart command actually being run (still only ever against this harness's own
     // fake binaries — serviceStubsSucceed never reaches a real service either), so they opt in
     // via serviceStubsSucceed; every other call site keeps the strict refuse-and-log default.
-    for (const name of ["launchctl", "systemctl", "pkill", "nohup", "openclaw"]) {
+    for (const name of ["launchctl", "systemctl", "pkill", "nohup"]) {
       mkStub(name, serviceStubsSucceed ? [
         `echo "FAKE-${name.toUpperCase()}-CALL $*" >> "${logPath}"`,
         `exit 0`,
@@ -10056,6 +10066,27 @@ function _bwHarnessRun({
         `exit 95`,
       ].join("\n"));
     }
+
+    // Issue #263: `openclaw` gets its own three-state stub (not the shared loop above) because
+    // `cmd_restart gateway`'s fix needs to distinguish THREE situations, not two: not installed
+    // (openclawAbsent — a normal, silent-or-informational configuration, see #263's own scope
+    // discussion), installed and succeeds (serviceStubsSucceed), and installed and fails (the
+    // default — same "refuse loudly, AGENTS.md 'unreachable by construction'" posture the
+    // shared loop already uses for launchctl/systemctl/pkill/nohup, preserved byte-identically
+    // when openclawAbsent is false, its default).
+    mkStub("openclaw", openclawAbsent ? [
+      `echo "FAKE-OPENCLAW-ABSENT-CALL $*" >> "${logPath}"`,
+      `exit 127`,
+    ].join("\n") : serviceStubsSucceed ? [
+      `echo "FAKE-OPENCLAW-CALL $*" >> "${logPath}"`,
+      `echo "FAKE-OPENCLAW: gateway restarted"`,
+      `exit 0`,
+    ].join("\n") : [
+      `echo "FAKE-OPENCLAW-CALL $*" >> "${logPath}"`,
+      `echo "FAKE-OPENCLAW: refusing -- this harness must never reach a real ` +
+        `service-mutating command (AGENTS.md 'unreachable by construction')" >&2`,
+      `exit 95`,
+    ].join("\n"));
 
     // Issue #224: `sleep` is a no-op stub purely for test speed (the real `cmd_restart` calls
     // `sleep 3` after a successful restart command, before its own health check) — never a
@@ -11065,6 +11096,56 @@ test("#224: _cmd_update_light no longer swallows cmd_restart's refusal (operator
   assert.ok((r.stdout + r.stderr).includes("MOCK-RESOLVER-REFUSAL-MARKER-LIGHT"),
     `_cmd_update_light must surface cmd_restart's refusal message instead of discarding it via ` +
     `its old "> /dev/null 2>&1"; stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+});
+
+// ── #263: cmd_restart gateway's `openclaw gateway restart 2>&1` had the same shape as the
+// python3 sites #242 fixed and the curl sites #261 fixes — a bare external-command call with no
+// `||` handling, so `set -e` (ocp:7) killed the whole `ocp` process the instant `openclaw` was
+// missing (bash's own "command not found", exit 127), with no OCP-level framing distinguishing
+// that from openclaw being installed but its OWN restart genuinely failing. OpenClaw is an
+// OPTIONAL sibling tool (AGENTS.md "What this project is") — its absence is a normal
+// configuration, not a fault, so this is the one call site in this family where "the command
+// could not run" gets a SUCCESS exit code (0) and a calm, informational message rather than
+// #261's "loud local-fault" treatment, while "installed and failed" stays loud and non-zero.
+// `overrideCmdRestart: false` drives these through the REAL cmd_restart body via ocp's real
+// top-level dispatch (`args: ["restart", "gateway"]`), the only way to reach this branch.
+console.log("\ncmd_restart gateway: 'not installed' vs 'installed and failed' (#263):");
+
+test("#263 cmd_restart gateway: openclaw NOT installed is reported once, calmly, on stdout, and reports SUCCESS", () => {
+  const r = _bwHarnessRun({ args: ["restart", "gateway"], overrideCmdRestart: false, openclawAbsent: true });
+  assert.equal(r.status, 0,
+    `absence of an OPTIONAL sibling tool must not fail 'ocp restart gateway'; status=${r.status} ` +
+    `stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stdout.toLowerCase().includes("not installed"),
+    `expected an informational 'not installed' message on stdout, got stdout=${JSON.stringify(r.stdout)}`);
+  assert.equal(r.stderr, "", `not-installed is not an error — stderr must stay clean; got: ${JSON.stringify(r.stderr)}`);
+  assert.ok(_bwCalled(r.log, "FAKE-OPENCLAW-ABSENT-CALL"), `sanity check the absent stub was actually reached; log=${JSON.stringify(r.log)}`);
+});
+
+test("#263 cmd_restart gateway: openclaw installed but its OWN restart fails is reported LOUDLY, on stderr, with a nonzero exit", () => {
+  const r = _bwHarnessRun({ args: ["restart", "gateway"], overrideCmdRestart: false });
+  assert.notEqual(r.status, 0,
+    `a REAL failure of an installed tool must be reported as failure, not silently treated like ` +
+    `an absent one; status=${r.status}`);
+  assert.ok(r.stderr.includes("✗ openclaw gateway restart failed"),
+    `expected a loud, labeled failure on stderr, got stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(_bwCalled(r.log, "FAKE-OPENCLAW-CALL"), `sanity check the (installed) stub was actually reached; log=${JSON.stringify(r.log)}`);
+});
+
+test("#263 control: cmd_restart gateway with openclaw installed and succeeding reports success and shows openclaw's own output", () => {
+  const r = _bwHarnessRun({ args: ["restart", "gateway"], overrideCmdRestart: false, serviceStubsSucceed: true });
+  assert.equal(r.status, 0, `expected a clean exit; status=${r.status} stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stdout.includes("gateway restarted"), `expected openclaw's own reported output, got stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(r.stdout.includes("✓ Gateway restarted."), `expected the success line, got stdout=${JSON.stringify(r.stdout)}`);
+});
+
+test("#263 the money contrast: 'not installed' (exit 0) and 'installed and failed' (nonzero) are genuinely distinguishable exit codes -- the bug's own complaint was that they were not", () => {
+  const absent = _bwHarnessRun({ args: ["restart", "gateway"], overrideCmdRestart: false, openclawAbsent: true });
+  const failed = _bwHarnessRun({ args: ["restart", "gateway"], overrideCmdRestart: false });
+  assert.equal(absent.status, 0, `not-installed must be status 0; got ${absent.status}`);
+  assert.notEqual(failed.status, 0, `installed-and-failed must be nonzero; got ${failed.status}`);
+  assert.notEqual(absent.status, failed.status,
+    `the two situations #263 describes as "today indistinguishable" must now genuinely differ`);
 });
 
 // ── #241: _cmd_update_light gets --post-flight-only verification + explicit --target no-op ───

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -9908,9 +9908,18 @@ function _bwHarnessRun({
   // work here today, but the shadow-stub technique is used anyway for the same reason #261
   // adopted it for curl: it does not depend on what happens to be missing from a given host's
   // /usr/bin:/bin, which is real system directory this harness's $PATH always includes for
-  // python3/cat/sed/mktemp. Independent of serviceStubsSucceed: "not installed" is a third
+  // python3/cat/sed/mktemp. Independent of serviceStubsSucceed: "not found on $PATH" is a third
   // state, not a variant of "installed and succeeds/fails".
   openclawAbsent = false,
+  // Independent review round 1 (case 6, blocking): lets the "installed and fails" branch of the
+  // openclaw stub report an ARBITRARY exit code and output, instead of always the fixed
+  // exit-95/refusal-text default. Needed to reproduce a genuinely-installed, genuinely-failing
+  // openclaw whose own diagnostic output happens to contain the substring "command not found"
+  // (a real subcommand-dispatcher failure mode, e.g. a plugin/dependency lookup message) without
+  // that text ever implying "not found on $PATH". `undefined` (the default) leaves the existing
+  // fixed refusal behavior byte-identical to before this option existed.
+  openclawFailExit = undefined,
+  openclawFailOutput = undefined,
   // Issue #242: generic curl response fixtures for the nine read-only display commands
   // (usage/logs/models/sessions/clear/keys/settings), none of which existed as a harness
   // capability before this issue (every prior call site here only ever needed the `/health`
@@ -10068,12 +10077,16 @@ function _bwHarnessRun({
     }
 
     // Issue #263: `openclaw` gets its own three-state stub (not the shared loop above) because
-    // `cmd_restart gateway`'s fix needs to distinguish THREE situations, not two: not installed
-    // (openclawAbsent — a normal, silent-or-informational configuration, see #263's own scope
-    // discussion), installed and succeeds (serviceStubsSucceed), and installed and fails (the
-    // default — same "refuse loudly, AGENTS.md 'unreachable by construction'" posture the
+    // `cmd_restart gateway`'s fix needs to distinguish THREE situations, not two: not found on
+    // $PATH (openclawAbsent — a normal, silent-or-informational configuration, see #263's own
+    // scope discussion), installed and succeeds (serviceStubsSucceed), and installed and fails
+    // (the default — same "refuse loudly, AGENTS.md 'unreachable by construction'" posture the
     // shared loop already uses for launchctl/systemctl/pkill/nohup, preserved byte-identically
-    // when openclawAbsent is false, its default).
+    // when openclawAbsent is false and openclawFailExit/openclawFailOutput are both undefined,
+    // all three defaults). openclawFailExit/openclawFailOutput (independent review round 1,
+    // case 6) let the installed-and-fails branch report an arbitrary exit code and combined
+    // output, so a failure whose OWN text happens to contain "command not found" can be
+    // reproduced without that ever meaning "not found on $PATH".
     mkStub("openclaw", openclawAbsent ? [
       `echo "FAKE-OPENCLAW-ABSENT-CALL $*" >> "${logPath}"`,
       `exit 127`,
@@ -10083,9 +10096,11 @@ function _bwHarnessRun({
       `exit 0`,
     ].join("\n") : [
       `echo "FAKE-OPENCLAW-CALL $*" >> "${logPath}"`,
-      `echo "FAKE-OPENCLAW: refusing -- this harness must never reach a real ` +
-        `service-mutating command (AGENTS.md 'unreachable by construction')" >&2`,
-      `exit 95`,
+      ...(openclawFailOutput !== undefined
+        ? [`echo ${JSON.stringify(openclawFailOutput)} >&2`]
+        : [`echo "FAKE-OPENCLAW: refusing -- this harness must never reach a real ` +
+             `service-mutating command (AGENTS.md 'unreachable by construction')" >&2`]),
+      `exit ${openclawFailExit ?? 95}`,
     ].join("\n"));
 
     // Issue #224: `sleep` is a no-op stub purely for test speed (the real `cmd_restart` calls
@@ -11109,16 +11124,25 @@ test("#224: _cmd_update_light no longer swallows cmd_restart's refusal (operator
 // #261's "loud local-fault" treatment, while "installed and failed" stays loud and non-zero.
 // `overrideCmdRestart: false` drives these through the REAL cmd_restart body via ocp's real
 // top-level dispatch (`args: ["restart", "gateway"]`), the only way to reach this branch.
-console.log("\ncmd_restart gateway: 'not installed' vs 'installed and failed' (#263):");
+//
+// Independent review round 1: the message says "not found on $PATH", not "not installed" — a
+// non-interactive shell's $PATH (a bare `ssh host 'ocp restart gateway'`, in particular) can
+// omit directories an interactive login shell's $PATH includes, so exit 127 here does not prove
+// absence, only that this invocation's $PATH did not resolve openclaw. Test names/assertions
+// below were updated to match; this is a wording correction, not a behavior change (still exit
+// 0, still calm, still on stdout).
+console.log("\ncmd_restart gateway: 'not found on $PATH' vs 'installed and failed' (#263):");
 
-test("#263 cmd_restart gateway: openclaw NOT installed is reported once, calmly, on stdout, and reports SUCCESS", () => {
+test("#263 cmd_restart gateway: openclaw not found on $PATH is reported once, calmly, on stdout, and reports SUCCESS", () => {
   const r = _bwHarnessRun({ args: ["restart", "gateway"], overrideCmdRestart: false, openclawAbsent: true });
   assert.equal(r.status, 0,
     `absence of an OPTIONAL sibling tool must not fail 'ocp restart gateway'; status=${r.status} ` +
     `stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
-  assert.ok(r.stdout.toLowerCase().includes("not installed"),
-    `expected an informational 'not installed' message on stdout, got stdout=${JSON.stringify(r.stdout)}`);
-  assert.equal(r.stderr, "", `not-installed is not an error — stderr must stay clean; got: ${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stdout.includes("not found on"),
+    `expected the corrected 'not found on $PATH' wording (NOT 'not installed' -- that overclaims), got stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(!r.stdout.toLowerCase().includes("not installed"),
+    `must NOT claim "not installed" -- a non-interactive $PATH lookup cannot establish that; stdout=${JSON.stringify(r.stdout)}`);
+  assert.equal(r.stderr, "", `absence-from-$PATH is not an error — stderr must stay clean; got: ${JSON.stringify(r.stderr)}`);
   assert.ok(_bwCalled(r.log, "FAKE-OPENCLAW-ABSENT-CALL"), `sanity check the absent stub was actually reached; log=${JSON.stringify(r.log)}`);
 });
 
@@ -11139,13 +11163,39 @@ test("#263 control: cmd_restart gateway with openclaw installed and succeeding r
   assert.ok(r.stdout.includes("✓ Gateway restarted."), `expected the success line, got stdout=${JSON.stringify(r.stdout)}`);
 });
 
-test("#263 the money contrast: 'not installed' (exit 0) and 'installed and failed' (nonzero) are genuinely distinguishable exit codes -- the bug's own complaint was that they were not", () => {
+test("#263 the money contrast: 'not found on $PATH' (exit 0) and 'installed and failed' (nonzero) are genuinely distinguishable exit codes -- the bug's own complaint was that they were not", () => {
   const absent = _bwHarnessRun({ args: ["restart", "gateway"], overrideCmdRestart: false, openclawAbsent: true });
   const failed = _bwHarnessRun({ args: ["restart", "gateway"], overrideCmdRestart: false });
-  assert.equal(absent.status, 0, `not-installed must be status 0; got ${absent.status}`);
+  assert.equal(absent.status, 0, `not-found-on-$PATH must be status 0; got ${absent.status}`);
   assert.notEqual(failed.status, 0, `installed-and-failed must be nonzero; got ${failed.status}`);
   assert.notEqual(absent.status, failed.status,
     `the two situations #263 describes as "today indistinguishable" must now genuinely differ`);
+});
+
+// ── Independent review round 1 (BLOCKING, case 6): the classifier used to also match a
+// "command not found" TEXT substring against openclaw's COMBINED (2>&1) output, alongside the
+// exit-127 check -- removed above because it carried zero tested behavior AND a real
+// false-positive risk: openclaw is a subcommand dispatcher that shells out, so a genuinely
+// FAILING, INSTALLED openclaw can print "command not found" as part of its own diagnostic
+// output for an unrelated reason (a plugin/dependency lookup message, reproduced below). Before
+// removal this reintroduced #263's own defect through the very marker meant to fix it: a real
+// gateway failure silently reported as a successful no-op. This is the regression test for that
+// specific text-arm, using the harness's new openclawFailExit/openclawFailOutput fixtures.
+test("#263 case 6 (independent review round 1, blocking): openclaw installed and genuinely failing, whose own output happens to contain the phrase 'command not found', must still be reported LOUDLY and non-zero", () => {
+  const r = _bwHarnessRun({
+    args: ["restart", "gateway"], overrideCmdRestart: false,
+    openclawFailExit: 2,
+    openclawFailOutput: "gateway plugin error: dependency lookup failed (command not found in registry)",
+  });
+  assert.notEqual(r.status, 0,
+    `a REAL failure must not be swallowed just because its own text happens to contain ` +
+    `'command not found' -- that is #263's own defect, reintroduced through the marker meant ` +
+    `to fix it; status=${r.status} stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stderr.includes("✗ openclaw gateway restart failed"),
+    `expected the loud, labeled failure message, got stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(!r.stdout.includes("not found on"),
+    `must NOT be misreported as absent-from-$PATH; stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(_bwCalled(r.log, "FAKE-OPENCLAW-CALL"), `sanity check the (installed, failing) stub was actually reached; log=${JSON.stringify(r.log)}`);
 });
 
 // ── #241: _cmd_update_light gets --post-flight-only verification + explicit --target no-op ───


### PR DESCRIPTION
## Summary

`cmd_restart`'s gateway branch ran a bare `openclaw gateway restart 2>&1` with no `||` handling — the same shape #242 catalogued and #252 fixed for nine python3 sites, and #261 fixes for three curl sites (refs #261, refs #242). Under `set -euo pipefail` (ocp:7), that bare command meant `set -e` killed the ENTIRE `ocp` process the instant `openclaw` was missing from `$PATH` (bash's own "command not found", exit 127) — with **no OCP-level framing at all**, and no way to tell that apart from openclaw being installed but its own restart genuinely failing, which produced the identical unframed-death shape.

`cmd_restart` is on the recovery path (`ocp update`, `ocp restart`, post-upgrade recovery), so a wrong diagnosis here costs the most.

## The design question (the actual work)

OpenClaw is an **optional sibling tool** (see `AGENTS.md` "What this project is" — OCP's secondary role is registering itself as a provider inside OpenClaw, but OpenClaw itself is not a dependency). Its absence is a normal configuration, not a fault. So this call site needed a genuine **three-way** distinction, not the two-way "local fault vs. network fault" split #261 uses for curl:

1. **Not installed** → normal, expected. Report it once, calmly, on stdout. `cmd_restart gateway` (and anything that calls `cmd_restart` on the recovery path) must NOT fail just because an optional tool isn't present.
2. **Installed and failed** → a real problem. Report it loudly, on stderr, with a nonzero exit — this is the operator's gateway actually breaking.
3. **Installed and succeeds** → normal happy path, unchanged in spirit (now with actual framing instead of raw pass-through).

I chose "invoke openclaw directly and inspect the exit code" (exit 127 / "command not found" text ⇒ not-installed) over a `command -v openclaw` pre-check, for two reasons: it's the same "attempt, then inspect" technique #261's `_curl_or_die` already uses in this same family (consistency), and it's what the rest of `ocp` already does at every other external-command call site — no site in this file pre-checks existence before invoking. `command -v` would also have been strictly harder to test: it only checks whether *some* file exists on `$PATH`, so a test harness stub (any stub, even a broken one) always satisfies it — the harness has to make openclaw genuinely unresolvable, which the "shadow stub that always exits 127" technique below achieves either way, so there was no test-side reason to prefer the pre-check.

## Fix

```
gw_out=$(openclaw gateway restart 2>&1) || gw_status=$?
if [[ $gw_status -eq 127 ]] || [[ "$gw_out" == *"command not found"* ]]; then
  echo "  OpenClaw is not installed — skipping gateway restart (it is an optional sibling tool, not a proxy dependency)."
  return 0
fi
if [[ $gw_status -ne 0 ]]; then
  echo "✗ openclaw gateway restart failed (exit $gw_status):" >&2
  echo "$gw_out" >&2
  return 1
fi
[[ -n "$gw_out" ]] && echo "$gw_out"
echo "✓ Gateway restarted."
```

`2>&1` here is intentional and safe — unlike the #261 pattern, it isn't used to decide WHICH message fires (the exit code does that); it's used only to preserve openclaw's own combined output so it can be shown verbatim in the loud-failure branch.

## Test harness extension

Extends `_bwHarnessRun` (#225 lineage, `test-features.mjs`) with an `openclawAbsent` option. `openclaw`'s stub is split out of the shared `launchctl`/`systemctl`/`pkill`/`nohup` loop into its own three-state stub (not-installed / installed-succeeds / installed-fails — the last two byte-identical to the pre-existing `serviceStubsSucceed` behavior, so this is additive, not a behavior change for any existing test). Uses the same always-`exit 127` shadow-stub technique `pythonAbsent` (and #261's `curlAbsent`) already use, rather than omitting the file — more portable than depending on a given host's `/usr/bin:/bin` happening to lack the binary (this repo's own dev hosts DO have a real `openclaw` on `$PATH`, just not under `/usr/bin` or `/bin`, so omission happens to work today, but the shadow-stub technique doesn't rely on that).

Four new tests, driven through the real top-level dispatch (`args: ["restart", "gateway"]`, `overrideCmdRestart: false`):

- not-installed → status 0, informational stdout, clean stderr.
- installed-and-failed → loud, labeled, nonzero, on stderr.
- control: installed-and-succeeds → status 0, shows openclaw's own output + the success line.
- direct contrast: the two exit codes actually differ (the bug's own complaint was that they didn't).

## Evidence — RED then GREEN

Baseline on `origin/main` (`8b1435d`): **773 passed, 0 failed**.

**RED** (pristine `ocp` swapped in via a checksum-verified `cp`, not `git checkout`): **773 passed, 4 failed**:
```
✗ #263 cmd_restart gateway: openclaw NOT installed is reported once, calmly, on stdout, and
  reports SUCCESS: absence of an OPTIONAL sibling tool must not fail 'ocp restart gateway';
  status=127 stdout="Restarting gateway...\n" stderr=""
✗ #263 cmd_restart gateway: openclaw installed but its OWN restart fails is reported LOUDLY...:
  expected a loud, labeled failure on stderr, got stderr=""
✗ #263 control: cmd_restart gateway with openclaw installed and succeeding reports success...:
  expected the success line, got stdout="Restarting gateway...\nFAKE-OPENCLAW: gateway restarted\n"
✗ #263 the money contrast: ...: not-installed must be status 0; got 127
```
On unmodified `main`, a missing `openclaw` produces raw bash exit 127 with **zero** OCP-level output on stderr — literally indistinguishable in shape from "installed and failed" (also zero stderr, since the old code has no `||` handling at all and just dies via `set -e`).

**GREEN** (fix applied, restored from a checksum-verified backup): **777 passed, 0 failed**.

## Mutation testing

Two guards, each broken independently, restored via `cp` + `shasum -a 256` (never `git checkout`), anchor existence asserted before mutating:

| Mutation | Change | Result | Killed by (named) |
|---|---|---|---|
| A | `if [[ $gw_status -eq 127 ]] \|\| [[ "$gw_out" == *"command not found"* ]]; then` → `if false; then` (neuters not-installed detection) | 775 passed, 2 failed | `#263 cmd_restart gateway: openclaw NOT installed...` (now reports failure, status 1, instead of 0), `#263 the money contrast...` (not-installed no longer status 0) |
| B | `return 1` → `return 0` in the installed-and-failed branch (swallows the failure) | 775 passed, 2 failed | `#263 cmd_restart gateway: openclaw installed but its OWN restart fails...` (now status 0), `#263 the money contrast...` (installed-and-failed no longer nonzero) |

Both backups verified byte-identical to the pre-mutation file via `shasum -a 256` before and after restore.

## Full suite

`npm test`: **777 passed, 0 failed** (final, post-restore, pre-push).

## Scope

Does **not** touch `server.mjs`. No `cli.js` citation applies — this is `ocp` (the bash CLI wrapper), not the proxy itself; `ALIGNMENT.md`'s Rules govern `server.mjs`'s wire behavior, not this file.

No port literals added (verified via diff grep).

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gbqUZ8HfBZpjjbzQ85oH8
