### PR TITLE
fix(upgrade): rollback fallback names the second enabled unit, instead of asserting none exists

### DIFF
--- a/scripts/lib/restart-unit.mjs
+++ b/scripts/lib/restart-unit.mjs
@@ -151,6 +151,18 @@
  * platform-branched (`owner.platform === "darwin"`) since the Linux wording names `systemd`,
  * `/proc/<pid>/cgroup`, and `/proc/<pid>/cmdline` — none of which exist on macOS.
  *
+ * issue #253 (split from #234 by independent review of PR #250): the `allowNotListeningFallback`
+ * warning above (HIGH-A) used to assert "there is no other candidate unit to weigh this against"
+ * unconditionally. Untrue on the exact host that motivated #215: a SYSTEM unit and a USER unit
+ * both enabled for the same port. With the system unit down, this fallback starts the default USER
+ * unit, which binds loopback only — silently placing the host into the boot race
+ * scripts/doctor.mjs's #230 `multi_unit_boot_race` check already knows how to detect, while
+ * post-flight (127.0.0.1-only) reports success regardless. `opts.secondUnitNote`
+ * (scripts/upgrade.mjs computes it by REUSING that same #230 detection — see
+ * `detectMultiUnitBootRace`/`describeSecondUnit` there — not re-implementing unit enumeration a
+ * second time) names the other enabled unit when one is known to exist, so the warning states what
+ * it actually knows instead of what was merely true on the host this fallback was designed for.
+ *
  * A FIFTH independent review (issue #254, split from #237 by review of PR #251) found that #237's
  * own fix, while it fully closes the reported "wholly foreign service" vulnerability, leaves one
  * narrower case open: classifyCmdlineOwner confirms a process invokes A server.mjs, never that it
@@ -846,6 +858,12 @@ function launchdCmds(opts) {
  *     path: restarting the user-level unit instead would again leave the real
  *     (system) listener untouched.
  *
+ * opts.secondUnitNote (issue #253): a short, pre-formatted description of another enabled unit
+ * sharing the OCP port with `opts.expectedUnit` (e.g. `system-scope "ocp.service" (bind 0.0.0.0)`),
+ * or falsy when none is known — computed in scripts/upgrade.mjs by reusing
+ * scripts/doctor.mjs's #230 detectMultiUnitBootRace, never shelled out to from this pure function.
+ * Only consulted by the "not-listening" + allowNotListeningFallback warning below.
+ *
  * opts.isRoot / opts.sudoAuthorized (review finding MED-4): NOPASSWD sudoers
  * entries are per-command ("deploy ALL=(root) NOPASSWD: /bin/systemctl restart
  * ocp.service"), so a generic `sudo -n true` probe is the wrong question and
@@ -911,14 +929,31 @@ export function planRestart(owner, opts = {}) {
     // default unit with a loud warning instead of a permanent refusal; the upgrade path's
     // refusal is untouched.
     if (opts.allowNotListeningFallback) {
+      // issue #253: this used to assert "there is no other candidate unit to weigh this against"
+      // unconditionally — true on the host this fallback was originally designed for, but not in
+      // general. The exact host that motivated #215 has a SYSTEM unit and a USER unit BOTH
+      // enabled for the same port: with the system unit down (the not-listening state reached
+      // here) this fallback starts the default USER unit, which binds loopback only — silently
+      // landing the host in the boot race scripts/doctor.mjs's #230 multi_unit_boot_race check
+      // already warns about, while post-flight (127.0.0.1-only) reports success regardless.
+      // opts.secondUnitNote (computed in scripts/upgrade.mjs by reusing that SAME #230 detection,
+      // not re-implementing it) names the other unit when one is known to exist, instead of
+      // asserting none does.
+      const secondUnitClause = opts.secondUnitNote
+        ? `This host ALSO has ${opts.secondUnitNote} enabled and targeting this same port (see ` +
+          `scripts/doctor.mjs's #230 multi_unit_boot_race check) — if THAT unit is the one meant ` +
+          `to serve this port, starting "${opts.expectedUnit}" here will NOT restore it, and ` +
+          `post-flight (which only checks 127.0.0.1) cannot tell the difference. Run \`ocp doctor\` ` +
+          `for the full boot-race diagnosis before trusting this restart, or start the intended ` +
+          `unit manually instead (issue #253).`
+        : `There is no other candidate unit to weigh this against — refusing here would leave the ` +
+          `rollback stuck (re-running hits this identical state). If a different unit is meant to ` +
+          `own this port long-term, start it manually instead and ignore this one.`;
       warnings.push(
         `[restart] WARNING: nothing was listening on the OCP port before this rollback restart. ` +
         `Starting the default unit ("${opts.expectedUnit}") anyway: unlike the upgrade path, ` +
         `rollback has no doctor health gate and its own snapshot only ever restores ` +
-        `"${opts.expectedUnit}"'s config in the first place (scripts/lib/snapshot.mjs), so there ` +
-        `is no other candidate unit to weigh this against — refusing here would leave the ` +
-        `rollback stuck (re-running hits this identical state). If a different unit is meant to ` +
-        `own this port long-term, start it manually instead and ignore this one.`
+        `"${opts.expectedUnit}"'s config in the first place (scripts/lib/snapshot.mjs). ${secondUnitClause}`
       );
       if (owner.platform === "darwin") {
         return { action: "launchd", warnings, cmds: launchdCmds(opts) };

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -11,7 +11,7 @@
  *   fresh_install from-version < v3.4.0 (--yes required for non-interactive)
  *   rollback      restore from snapshot
  */
-import { runDoctor } from "./doctor.mjs";
+import { runDoctor, detectMultiUnitBootRace } from "./doctor.mjs";
 import { execSync, execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
@@ -164,6 +164,25 @@ function mapLaunchctlPrintFailureToProbeValue(err) {
     return { launchdPrintOutput: "" };
   }
   return { launchdPrintOutput: null };
+}
+
+// issue #253: does a SECOND enabled unit — besides expectedUnit — also target the same port this
+// rollback is about to fall back onto? Reuses scripts/doctor.mjs's own #230 detectMultiUnitBootRace
+// (its `multi_unit_boot_race` check) rather than re-implementing unit enumeration a second time —
+// the exact reuse issue #253 itself asks for. multiUnit is the already-classified result (never
+// shells out itself — this function is pure); returns a short human-readable descriptor of every
+// OTHER enabled unit sharing this port, or null if there is none / detection was inconclusive.
+// Best-effort by design: this is a diagnostic addition to a warning message, not a new refusal —
+// a `null` here must never be read as "confirmed no second unit", only as "nothing more specific
+// to say", so the caller's existing fallback wording (which already covers the "don't know"
+// case honestly) is untouched when this returns null.
+function describeSecondUnit(multiUnit, port, expectedUnit) {
+  if (!multiUnit || multiUnit.state !== "warn") return null;
+  const group = multiUnit.groups.find(g => g.length > 0 && String(g[0].port) === String(port));
+  if (!group) return null;
+  const others = group.filter(u => u.name !== expectedUnit);
+  if (others.length === 0) return null;
+  return others.map(u => `${u.scope}-scope "${u.name}" (bind ${u.bind})`).join(" and ");
 }
 
 // Resolve which unit actually owns the OCP port and build a restart plan for it, instead
@@ -378,6 +397,33 @@ function resolveRestartPlan({ opts, port, isRollback = false, fromCommit = null 
     );
   }
 
+  // issue #253: the allowNotListeningFallback warning below (planRestart) used to assert "there is
+  // no other candidate unit to weigh this against" unconditionally — true on the #221 host this
+  // fallback was designed for, but not in general: the exact host that motivated #215 has a SYSTEM
+  // unit and a USER unit both enabled for the same port, and #230's own multi_unit_boot_race check
+  // already knows how to detect that shape. Only probed when it's actually about to matter
+  // (rollback, and the port genuinely isn't listening — the one state where the fallback fires) so
+  // a healthy rollback never pays for an extra `systemctl`/plist scan. opts.mockSecondUnitNote is
+  // the test seam, mirroring sudoAuthorized's own opts.mockSudoAuthorized pattern just above: an
+  // explicit answer always wins; otherwise, in a mocked/test context with no injected runner, this
+  // skips rather than shells out for real (never silently probes a live host from inside a test).
+  let secondUnitNote = opts.mockSecondUnitNote;
+  if (secondUnitNote === undefined && isRollback && owner.kind === "not-listening") {
+    const isBareProduction = !opts.run && !opts.mockExec && !opts.mockOwnerProbe;
+    if (opts.run || isBareProduction) {
+      try {
+        const multiUnit = detectMultiUnitBootRace({ mockPlatform: platform, run });
+        secondUnitNote = describeSecondUnit(multiUnit, port, expectedUnit);
+      } catch {
+        // Best-effort: this is a diagnostic addition to a warning, not a new refusal — a failed
+        // probe here must never abort an otherwise-recoverable rollback.
+        secondUnitNote = null;
+      }
+    } else {
+      secondUnitNote = null;
+    }
+  }
+
   const plan = planRestart(owner, {
     expectedUnit,
     isRoot,
@@ -389,6 +435,9 @@ function resolveRestartPlan({ opts, port, isRollback = false, fromCommit = null 
     // left rollback permanently stuck — re-running hits this identical state forever. See
     // scripts/lib/restart-unit.mjs's planRestart for the fallback itself.
     allowNotListeningFallback: isRollback,
+    // issue #253: name the second enabled unit (if any) in the fallback warning, instead of
+    // asserting none exists.
+    secondUnitNote,
   });
   return { owner, plan };
 }

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -9919,6 +9919,83 @@ test("HIGH-A wiring: rollback with nothing listening on the port PROCEEDS instea
     "the fallback must surface loudly in phases, not silently");
 });
 
+console.log("\nRestart-unit resolution (issue #253) — rollback fallback names the second enabled unit:");
+
+// issue #253: split from #234 per independent review of PR #250. HIGH-A's own allowNotListeningFallback
+// warning (just above) asserted "there is no other candidate unit to weigh this against" — true on
+// the host that motivated the fallback itself, but not on the host that motivated #215: a SYSTEM
+// unit and a USER unit both enabled for the same port. With the system unit down, this fallback
+// starts the default USER unit (loopback only), silently landing the host in the boot race
+// scripts/doctor.mjs's #230 multi_unit_boot_race check already knows how to detect — while
+// post-flight (127.0.0.1-only) reports success regardless. These tests drive the fix's three
+// layers: planRestart's own warning text (pure), scripts/upgrade.mjs's wiring via the
+// opts.mockSecondUnitNote test hook, and the REAL scripts/doctor.mjs#230 detection reused end to
+// end (not re-implemented) via a fake command router.
+
+test("planRestart: rollback fallback names the second enabled unit when opts.secondUnitNote is known, instead of asserting none exists", () => {
+  const owner = { kind: "not-listening", platform: "linux", pid: null, unit: null, mismatched: false };
+  const plan = planRestart(owner, {
+    expectedUnit: "ocp-proxy.service",
+    allowNotListeningFallback: true,
+    secondUnitNote: 'system-scope "ocp.service" (bind 0.0.0.0)',
+  });
+  assert.ok(
+    plan.warnings.some(w => w.includes('system-scope "ocp.service" (bind 0.0.0.0)')),
+    `expected the fallback warning to name the second unit; got: ${JSON.stringify(plan.warnings)}`
+  );
+});
+
+test("planRestart: rollback fallback WITHOUT a known second unit keeps the honest 'no other candidate' wording (regression guard)", () => {
+  const owner = { kind: "not-listening", platform: "linux", pid: null, unit: null, mismatched: false };
+  const plan = planRestart(owner, { expectedUnit: "ocp-proxy.service", allowNotListeningFallback: true });
+  assert.ok(plan.warnings.some(w => w.includes("no other candidate unit")));
+});
+
+test("#253: rollback wiring — allowNotListeningFallback names the second enabled unit via opts.mockSecondUnitNote", async () => {
+  const result = await runUpgrade({
+    rollback: true, yes: true, mockExec: true,
+    mockPlatform: "linux",
+    mockSnapshots: [{ name: "upgrade-snapshot-2026-05-11T08:30:00Z", path: "/tmp/snap-x" }],
+    mockSnapshotMeta: { fromCommit: "abc1234", fromVersion: "v3.10.0", toVersion: "v3.14.0", path: "/tmp/snap-x" },
+    mockOwnerProbe: { ssOutput: "" }, // ran cleanly, confirmed nothing listening — the down-service rollback case
+    mockSecondUnitNote: 'system-scope "ocp.service" (bind 0.0.0.0)',
+  });
+  const restartCmds = result.phases.filter(p => p.name === "restart").map(p => p.cmd);
+  assert.deepEqual(restartCmds, ["systemctl --user restart -- ocp-proxy.service"], "still proceeds — this is a diagnosis addition, not a new refusal");
+  assert.ok(
+    result.phases.some(p => p.name === "restart-resolve" && p.note && p.note.includes('system-scope "ocp.service" (bind 0.0.0.0)')),
+    `expected the fallback warning phase to name the second unit; got phases=${JSON.stringify(result.phases)}`
+  );
+});
+
+test("#253: injected runner — REAL gather layer reuses scripts/doctor.mjs's #230 detectMultiUnitBootRace and names the second enabled unit end to end (not just the mocked hook)", async () => {
+  // The exact issue #215 field-incident fixture shape (FIELD_INCIDENT_USER_SHOW/SYSTEM_SHOW,
+  // defined earlier in this file for the #220/#230 doctor.mjs tests): system unit ocp.service
+  // (bind 0.0.0.0), user unit ocp-proxy.service (bind 127.0.0.1), same working tree, same port —
+  // reused here rather than inventing a parallel fixture, since it's the scenario #253 itself cites.
+  const run = makeFakeRun({
+    "ss -lptn": "", // nothing listening — the not-listening/fallback path
+    "--user list-unit-files": "ocp-proxy.service enabled\n",
+    "list-unit-files": "ocp.service enabled\n",
+    "--user show": FIELD_INCIDENT_USER_SHOW,
+    "systemctl show": FIELD_INCIDENT_SYSTEM_SHOW,
+    "daemon-reload": "", // MED-8's own best-effort daemon-reload — unrelated to what this test covers
+  });
+  const result = await runUpgrade({
+    rollback: true, yes: true, mockExec: true,
+    mockPlatform: "linux",
+    mockSnapshots: [{ name: "upgrade-snapshot-2026-05-11T08:30:00Z", path: "/tmp/snap-x" }],
+    mockSnapshotMeta: { fromCommit: "abc1234", fromVersion: "v3.10.0", toVersion: "v3.14.0", path: "/tmp/snap-x" },
+    run,
+  });
+  const restartCmds = result.phases.filter(p => p.name === "restart").map(p => p.cmd);
+  assert.deepEqual(restartCmds, ["systemctl --user restart -- ocp-proxy.service"]);
+  assert.ok(
+    result.phases.some(p => p.name === "restart-resolve" && p.note && p.note.includes("ocp.service") && p.note.includes("0.0.0.0")),
+    `expected the REAL gather layer to detect and name the second enabled unit; got phases=${JSON.stringify(result.phases)}`
+  );
+});
+
 // ── MED-C: UNIT_NAME_RE must reject a leading "-" (argv injection, not just shell metacharacters) ──
 
 test("MED-C: parseCgroupUnit rejects a leading-dash unit segment — never resolves it as a restart target", () => {


### PR DESCRIPTION
# Pull Request

## Summary

Closes #253 — split from #234 per independent review of PR #250. PR #250 already addressed #234's
primary defect ("rollback restores one unit's config and restarts a different one — the guard keys
on scope, not name"), but #234's own "Related" section flagged a second, related gap that PR #250
did not address and this PR now handles.

`planRestart`'s `allowNotListeningFallback` warning (`scripts/lib/restart-unit.mjs`, HIGH-A / PR
#221) asserted "there is no other candidate unit to weigh this against" **unconditionally**. That
is untrue on the exact host that motivated #215: a SYSTEM unit and a USER unit both enabled for the
same port. With the system unit down (the `not-listening` state this fallback exists for), the
fallback starts the default USER unit — which binds loopback only — silently placing the host into
the boot race `scripts/doctor.mjs`'s own #230 `multi_unit_boot_race` check already knows how to
detect, and **the rollback path has no post-flight check at all** (unlike the upgrade path's
`postFlightOk`/`runPostFlightCheck`) to catch that LAN reachability was never actually restored.

## Post-review corrections (all three addressed in a follow-up commit on this branch)

An independent fresh-context review of the original commit found three issues, all fixed here:

1. **PR body closing-keyword collision (this section, previously line 5).** The original text
   paired a past-tense form of "fix" directly against the issue-234 reference with only a space
   between them, matching GitHub's close-on-merge pattern (a recognized verb immediately followed
   by whitespace then a hash-number) — which would have auto-closed issue 234 as an unintended side
   effect on merge. Reworded throughout this body so no closing-style verb ever sits immediately
   before a `#` reference to any issue other than #253 itself.
2. **The new warning (and two module comments) falsely implied rollback has a post-flight check.**
   Original wording: "...and post-flight (which only checks 127.0.0.1) cannot tell the difference."
   That phrasing is accurate for the *upgrade* path (which really does run `postFlightOk`) but false
   for *rollback*, which has no post-flight check to run at all — the restart command exiting 0 is
   the entire success signal. Fixed to state that plainly. A new regression test
   (`planRestart: rollback fallback with a known second unit never claims post-flight can 'tell the
   difference' ...`) pins the corrected wording; verified it catches the original bug by reverting
   the text, confirming the test fails by name, and restoring from a file backup + `shasum -a 256`.
3. **#253's own issue text has a second, unaddressed suggested item** ("consider whether the
   rollback path should have a post-flight check at all") that this PR was never scoped to fix —
   bundling that larger design question into this PR would repeat the exact Iron-Rule-11 violation
   #253 itself was split out to avoid. Filed as its own tracker, **issue #274**, referenced directly
   from the warning text (not just this PR body) so the reference survives independently of either
   document once #253 auto-closes on merge.

A fourth, independently-found **test coverage gap** (not a code bug) is also fixed: no prior test
exercised `describeSecondUnit`'s `u.name !== expectedUnit` self-exclusion filter — the field-
incident fixture's conflict group legitimately contains both the expected unit and the real second
unit, but the original test only asserted the real second unit was named, never that the expected
unit was NOT also redundantly named as if it were a second, different unit from itself. New test
added; verified it catches a mutation that removes the filter.

## Endpoint Class (REQUIRED)

- [x] **Not endpoint-touching.** `server.mjs` does not appear in this diff; no HTTP request handler
  is touched. This is a fix to the rollback restart-resolution logic in
  `scripts/lib/restart-unit.mjs` and `scripts/upgrade.mjs` (the `ocp update --rollback` CLI path).

## Claude Code Alignment Evidence (REQUIRED)

N/A — not endpoint-touching. `server.mjs` is untouched, so no `cli.js:NNNN` citation applies
(`ALIGNMENT.md` Rule 5 governs `server.mjs` changes only). Confirmed by `git diff --stat`: only
`scripts/lib/restart-unit.mjs`, `scripts/upgrade.mjs`, and `test-features.mjs` changed.

## What changed

Per the issue's own suggestion — reuse `scripts/doctor.mjs`'s existing #230
`detectMultiUnitBootRace` detection rather than re-implementing unit enumeration a second time:

- `scripts/upgrade.mjs`:
  - Imports `detectMultiUnitBootRace` from `./doctor.mjs`.
  - New helper `describeSecondUnit(multiUnit, port, expectedUnit)` — finds the conflict group (if
    any) matching this rollback's own port, filters out `expectedUnit` itself, and formats every
    OTHER enabled unit into a short descriptor (e.g. `system-scope "ocp.service" (bind 0.0.0.0)`).
  - `resolveRestartPlan()` calls the detection only when it's actually about to matter — rollback,
    and the port genuinely isn't listening (the one state where the fallback fires) — so a healthy
    rollback never pays for an extra `systemctl`/plist scan. `opts.mockSecondUnitNote` is the test
    seam, mirroring `sudoAuthorized`'s own `opts.mockSudoAuthorized` pattern already in this
    function: an explicit answer always wins; a mocked/test context with no injected runner skips
    rather than shelling out for real.
- `scripts/lib/restart-unit.mjs`: `planRestart` accepts the new `opts.secondUnitNote` and, when
  present, names it in the `allowNotListeningFallback` warning instead of asserting no other
  candidate exists — and states plainly that rollback has no post-flight check to catch this (issue
  #274), rather than implying one exists. When `opts.secondUnitNote` is absent (none found, or
  detection wasn't attempted), the prior, still-honest "no other candidate" wording is unchanged.
- `test-features.mjs`: 6 new tests total — a pure `planRestart` test asserting the second unit is
  named when known, a regression guard confirming the prior wording survives when none is known, a
  rollback wiring test via the new `opts.mockSecondUnitNote` hook, a real-injected-`run()` test
  proving the actual gather layer (the genuine `detectMultiUnitBootRace` call, reusing the exact
  issue #215 field-incident fixture already defined in this file for the #220/#230 `doctor.mjs`
  tests), a wording regression guard (item 2 above), and an `expectedUnit`-self-exclusion regression
  guard (item 4 above).

## Test evidence

**Before the fix** (unmodified `main`; source changes temporarily reverted via `git stash` to
produce this snapshot cleanly, then restored — no working-tree state was lost, nothing was
committed at that point):

```
✗ planRestart: rollback fallback names the second enabled unit when opts.secondUnitNote is known, instead of asserting none exists: expected the fallback warning to name the second unit; got: [...no second-unit text present...]
✓ planRestart: rollback fallback WITHOUT a known second unit keeps the honest 'no other candidate' wording (regression guard)
✗ #253: rollback wiring — allowNotListeningFallback names the second enabled unit via opts.mockSecondUnitNote: expected the fallback warning phase to name the second unit; got phases=[...no second-unit text present...]
✗ #253: injected runner — REAL gather layer reuses scripts/doctor.mjs's #230 detectMultiUnitBootRace and names the second enabled unit end to end (not just the mocked hook): expected the REAL gather layer to detect and name the second enabled unit; got phases=[...no second-unit text present...]

=== Results: 774 passed, 3 failed ===
```

**After the original fix, before the post-review corrections:**

```
=== Results: 777 passed, 0 failed ===
```

**After the post-review corrections (final state of this branch):**

```
✓ planRestart: rollback fallback names the second enabled unit when opts.secondUnitNote is known, instead of asserting none exists
✓ planRestart: rollback fallback WITHOUT a known second unit keeps the honest 'no other candidate' wording (regression guard)
✓ planRestart: rollback fallback with a known second unit never claims post-flight can 'tell the difference' — rollback has no post-flight at all (post-review correction)
✓ #253: rollback wiring — allowNotListeningFallback names the second enabled unit via opts.mockSecondUnitNote
✓ #253: injected runner — REAL gather layer reuses scripts/doctor.mjs's #230 detectMultiUnitBootRace and names the second enabled unit end to end (not just the mocked hook)
✓ #253: injected runner — describeSecondUnit excludes expectedUnit ITSELF from the 'second unit' descriptor (regression guard, independently found gap)

=== Results: 779 passed, 0 failed ===
```

Both new post-review regression tests were verified to fail against their respective
pre-correction code (text revert / filter removal) before the fix, and pass after — same
file-backup + `shasum -a 256` discipline as every other mutation in this PR.

Three consecutive full-suite runs on the final branch state: 779/0 every time.

## Mutation proof

Six mutations total across two rounds. Each: source file backed up with `cp` first (never
`git checkout -- ...`), a Python script asserts the anchor string is present **exactly once**
before mutating, then restored from the backup and reconfirmed byte-identical with
`shasum -a 256` before the next mutation.

**Original round (4):**

| # | Mutation | Failing tests (by name) |
|---|---|---|
| A | `planRestart`'s message-construction branch neutered (`const secondUnitClause = false && opts.secondUnitNote ? ... : ...`) — always uses the "no other candidate" wording | `planRestart: rollback fallback names the second enabled unit when opts.secondUnitNote is known ...`; `#253: rollback wiring — allowNotListeningFallback names the second enabled unit via opts.mockSecondUnitNote`; `#253: injected runner — REAL gather layer ...` (3 tests — correctly leaves the regression-guard test passing, since that test never expects second-unit text either way) |
| B | `resolveRestartPlan`'s detection gate neutered (`if (false && secondUnitNote === undefined && ...)`) — auto-detection never runs | `#253: injected runner — REAL gather layer ...` (1 test — correctly excluded: `opts.mockSecondUnitNote` bypasses this gate entirely by design, the same shape #251 documented for `mockOwnerProbe` bypassing its own gather layer) |
| C | `describeSecondUnit`'s own formatting logic neutered (`return null;` unconditionally) | `#253: injected runner — REAL gather layer ...` (1 test, same reason as B) |
| D | `scripts/upgrade.mjs`: the actual `detectMultiUnitBootRace({ mockPlatform: platform, run })` call deleted entirely | `#253: injected runner — REAL gather layer ...` (1 test, same reason as B/C) |

**Post-review round (2), targeting the two corrections above:**

| # | Mutation | Failing tests (by name) |
|---|---|---|
| E | Warning text reverted to the exact pre-correction ("post-flight ... cannot tell the difference") wording | `planRestart: rollback fallback with a known second unit never claims post-flight can 'tell the difference' ...` (1 test) |
| F | `describeSecondUnit`'s `u.name !== expectedUnit` filter removed (`const others = group;`) | `#253: injected runner — describeSecondUnit excludes expectedUnit ITSELF ...` (1 test — this is the exact independently-found coverage gap; before this test existed, mutation F would have survived undetected) |

Checksums before/after each restore were byte-identical (`shasum -a 256`) in all six cases. Three
of the original four mutations converge on the same single failing test **by design** — every
other #253 test uses `opts.mockSecondUnitNote`, which deliberately bypasses the detection layer
those three mutations target (mirrors PR #251's own mutation-C finding for the analogous
`cmdline` gather call: "caught ONLY by the real-`run()`-based wiring test — by design").

## Full suite

`node test-features.mjs`, run 3 times consecutively on the final branch state: **779 passed, 0
failed** every single run — no flakiness observed. Baseline on unmodified `origin/main` (`8b1435d`),
verified separately before any change this session made: **773 passed, 0 failed**, also stable
across 3 consecutive runs.

`server.mjs` is untouched by this PR — no `cli.js` citation applies (`ALIGNMENT.md` Rule 5 governs
`server.mjs` changes only; this is `scripts/lib/restart-unit.mjs` and `scripts/upgrade.mjs`, the
upgrade/rollback CLI's own resolution logic, not the proxy's request path).

## Related

- `ALIGNMENT.md` Rule(s) invoked: none — not endpoint-touching, `server.mjs` untouched.
- Related issue: closes #253.
- Refs #234, #250 (the PR this residual gap was split from per Iron Rule 11), #230 (the
  `multi_unit_boot_race` detection this fix reuses rather than re-implementing), #215, #221
  (HIGH-A, the fallback's own original design rationale), #274 (the newly filed follow-up
  tracker for #253's own second, unaddressed suggested item — rollback has no post-flight check
  at all).

### User-visible change self-check (铁律第五律 5.3)

- [x] This PR has no user-visible changes beyond more specific wording in an already-rare rollback
  warning — no README documentation update needed (no new CLI subcommand, env var, or endpoint).

### Privacy self-check (for PUBLIC repos)

- [x] No real names, personal paths, hostnames, or personal email addresses introduced.
