### PR TITLE
fix(ocp): refuse --target on noop/restart/fresh_install instead of dropping it silently

### DIFF
--- a/ocp
+++ b/ocp
@@ -1013,8 +1013,10 @@ Notes:
   current-vs-latest decision, not something the caller chooses -- so the
   SAME `ocp update --target vX.Y.Z` command would otherwise pin or silently
   not, depending only on where the host happens to sit in the release
-  cycle. Re-run without --target, or once a checkout-capable path (light or
-  full upgrade) is available.
+  cycle. Re-run without --target, or once a cross-minor release makes the
+  full upgrade path available -- that is currently the ONLY path that
+  honors --target (the light/patch-bump path warns and ignores it, see
+  above). To move to an OLDER version instead, use `ocp update --rollback`.
 EOF
 }
 
@@ -1185,7 +1187,7 @@ for c in d.get('checks', []):
           echo "✗ --target $_TARGET_VAL was requested, but doctor reports the tree already matches the latest release and only the RUNNING SERVICE is stale -- this path restarts the current tree as-is and never runs git, so it cannot check out a different tag." >&2
           ;;
       esac
-      echo "  Run \`ocp update\` again once a newer release makes a checkout-capable path (light or full upgrade) available, or omit --target to accept this path's own outcome." >&2
+      echo "  Run \`ocp update\` again once a cross-minor release makes the full upgrade path available -- that is currently the ONLY path that honors --target (the light/patch-bump path warns and ignores it). To move to an OLDER version instead, use \`ocp update --rollback\`. Or omit --target to accept this path's own outcome." >&2
       return 1
     fi
   fi

--- a/ocp
+++ b/ocp
@@ -1016,7 +1016,10 @@ Notes:
   cycle. Re-run without --target, or once a cross-minor release makes the
   full upgrade path available -- that is currently the ONLY path that
   honors --target (the light/patch-bump path warns and ignores it, see
-  above). To move to an OLDER version instead, use `ocp update --rollback`.
+  above). To move to an OLDER version instead, use
+  `ocp update --rollback --list` to pick a snapshot, then
+  `ocp update --rollback <path>` to restore it -- --target is NOT accepted
+  on --rollback (it restores a stored snapshot, not a requested version).
 EOF
 }
 
@@ -1056,6 +1059,15 @@ cmd_update() {
 
   # Pass through --check fast path (existing behaviour)
   if [[ "${1:-}" == "--check" ]]; then
+    # Issue #260/#272 review round 2 (LOW, optional): --check is read-only (no mutation, no
+    # wrong end state -- it only fetches + prints status), but --target was still silently
+    # accepted and ignored here with zero signal, the last fully-silent hole in this whole
+    # chain. Reuses the same shared detector the noop/restart refusal and the light-path
+    # warning both already use.
+    _detect_target_flag "$@"
+    if [[ $_TARGET_SEEN -eq 1 ]]; then
+      echo "  ⚠ --target $_TARGET_VAL has no effect on --check -- --check is read-only (fetch + report only) and never pins anything. Run \`ocp update --target $_TARGET_VAL\` (without --check) to actually apply it." >&2
+    fi
     cd "$script_dir"
     git fetch origin main --quiet 2>/dev/null || true
     local local_ver remote_ver
@@ -1187,7 +1199,7 @@ for c in d.get('checks', []):
           echo "✗ --target $_TARGET_VAL was requested, but doctor reports the tree already matches the latest release and only the RUNNING SERVICE is stale -- this path restarts the current tree as-is and never runs git, so it cannot check out a different tag." >&2
           ;;
       esac
-      echo "  Run \`ocp update\` again once a cross-minor release makes the full upgrade path available -- that is currently the ONLY path that honors --target (the light/patch-bump path warns and ignores it). To move to an OLDER version instead, use \`ocp update --rollback\`. Or omit --target to accept this path's own outcome." >&2
+      echo "  Run \`ocp update\` again once a cross-minor release makes the full upgrade path available -- that is currently the ONLY path that honors --target (the light/patch-bump path warns and ignores it). To move to an OLDER version instead, run \`ocp update --rollback --list\` to pick a snapshot, then \`ocp update --rollback <path>\` to restore it -- --target is NOT accepted on --rollback. Or omit --target to accept this path's own outcome." >&2
       return 1
     fi
   fi

--- a/ocp
+++ b/ocp
@@ -1003,7 +1003,47 @@ Notes:
   answers). Passing --target on the light path prints a runtime warning
   (accepts both `--target vX.Y.Z` and `--target=vX.Y.Z`) rather than
   silently doing nothing unexpected.
+
+  --target REFUSES (non-zero exit, no changes made) on the noop, restart,
+  and fresh_install paths (issue #260): none of these three has ANY
+  mechanism to redirect what it does onto a specific version -- noop does
+  nothing, restart re-serves the current tree exactly as-is, and
+  fresh_install replays doctor's own fixed install steps rather than
+  checking out a tag. Which of these three paths runs is doctor's own
+  current-vs-latest decision, not something the caller chooses -- so the
+  SAME `ocp update --target vX.Y.Z` command would otherwise pin or silently
+  not, depending only on where the host happens to sit in the release
+  cycle. Re-run without --target, or once a checkout-capable path (light or
+  full upgrade) is available.
 EOF
+}
+
+# Issue #260: shared by cmd_update's kind dispatch (noop/restart refusal) AND
+# _cmd_update_light (the light path's own pre-existing --target WARNING, issue #241/#255) —
+# detects whether --target/--target=X was passed anywhere in "$@", regardless of which kind
+# ends up handling the request. Extracted out of _cmd_update_light's own inline loop (which
+# used to be the only caller) so noop/restart can reuse the identical two-token/one-token
+# detection instead of a second, potentially-drifting copy. Sets the CALLER's own
+# _TARGET_SEEN (0/1) and _TARGET_VAL globals — not a subshell/command-substitution return,
+# so the caller doesn't need to fork a process just to read a flag.
+_detect_target_flag() {
+  _TARGET_SEEN=0
+  _TARGET_VAL=""
+  local _args=("$@") _i
+  for ((_i = 0; _i < ${#_args[@]}; _i++)); do
+    case "${_args[_i]}" in
+      --target)
+        _TARGET_SEEN=1
+        _TARGET_VAL="${_args[_i+1]:-<no value given>}"
+        break
+        ;;
+      --target=*)
+        _TARGET_SEEN=1
+        _TARGET_VAL="${_args[_i]#--target=}"
+        break
+        ;;
+    esac
+  done
 }
 
 cmd_update() {
@@ -1112,6 +1152,44 @@ for c in d.get('checks', []):
 " 2>/dev/null || true
   fi
 
+  # Issue #260: --target is a PIN ("do not put me on anything else"), not a preference. Before
+  # #260, noop/restart accepted --target and dropped it with NO signal at all -- exit 0 having
+  # done something other than what was asked, the exact "reported success while the wrong thing
+  # happened" shape #214/#241 both record. `doctor` -- not the caller -- picks which kind runs
+  # (a current-vs-latest comparison), so the SAME `ocp update --target vX.Y.Z` command pins or
+  # silently doesn't depending on where the host happens to sit in the release cycle. Refuse
+  # (non-zero, naming what was asked and what the path can actually do) rather than warn: a
+  # refusal costs one re-run without the flag and changes no state; silently proceeding --
+  # including proceeding to do NOTHING -- costs a version state the caller believes is pinned.
+  # Deliberately checked BEFORE the kind-specific bodies below, not inside them: neither noop's
+  # early return nor _cmd_update_restart has any mechanism that could honor a pin regardless.
+  #
+  # fresh_install is NOT handled here even though it also cannot honor a pin (its own
+  # ai_executable[] steps are a fixed, unparameterized script) -- unlike noop/restart, that kind
+  # already unconditionally `exec`s to `scripts/upgrade.mjs "$@"` below (same arm as "upgrade",
+  # which DOES honor --target per #259), so its own doctor re-resolution and opts.target handling
+  # happen at that Node layer instead; see runUpgrade()'s own target-vs-kind guard.
+  #
+  # The light/patch-bump path ("update" kind, issue #241/#255) is UNCHANGED here -- it already
+  # prints a --target warning to stderr rather than staying silent, and reopening warn-vs-refuse
+  # for that specific, already-reviewed, already-shipped decision is out of this issue's own
+  # stated scope (see this PR's own description for the full reasoning either way).
+  if [[ "$kind" == "noop" || "$kind" == "restart" ]]; then
+    _detect_target_flag "$@"
+    if [[ $_TARGET_SEEN -eq 1 ]]; then
+      case "$kind" in
+        noop)
+          echo "✗ --target $_TARGET_VAL was requested, but doctor reports the tree is already at the latest release -- there is nothing to check out, and the noop path makes no git or service changes at all. The pin cannot be honored because this path has no mechanism to honor ANY version request, pinned or not." >&2
+          ;;
+        restart)
+          echo "✗ --target $_TARGET_VAL was requested, but doctor reports the tree already matches the latest release and only the RUNNING SERVICE is stale -- this path restarts the current tree as-is and never runs git, so it cannot check out a different tag." >&2
+          ;;
+      esac
+      echo "  Run \`ocp update\` again once a newer release makes a checkout-capable path (light or full upgrade) available, or omit --target to accept this path's own outcome." >&2
+      return 1
+    fi
+  fi
+
   case "$kind" in
     noop)
       echo "Already at latest. Nothing to do."
@@ -1165,23 +1243,14 @@ _cmd_update_light() {
   # both without a second pass. The warning itself now goes to stderr, not stdout: in piped fleet
   # automation (`ocp update --target vX | some-log-parser`), a stdout warning would be silently
   # read as data by whatever consumes the pipe; stderr is where a human-facing advisory belongs.
-  local _args=("$@") _i _target_seen=0 _target_val=""
-  for ((_i = 0; _i < ${#_args[@]}; _i++)); do
-    case "${_args[_i]}" in
-      --target)
-        _target_seen=1
-        _target_val="${_args[_i+1]:-<no value given>}"
-        break
-        ;;
-      --target=*)
-        _target_seen=1
-        _target_val="${_args[_i]#--target=}"
-        break
-        ;;
-    esac
-  done
-  if [[ $_target_seen -eq 1 ]]; then
-    echo "  ⚠ --target $_target_val is not honored on the light/patch-bump path — it always pulls the latest origin/main regardless. Run \`ocp update --help\` for details." >&2
+  #
+  # Issue #260: this detection loop is now `_detect_target_flag` (shared with cmd_update's own
+  # noop/restart refusal, which needed the identical two-token/one-token detection) rather than
+  # a second, potentially-drifting copy. Behavior here is UNCHANGED from #255 -- still a WARNING,
+  # not a refusal; see this PR's own description for why that decision was left as-is.
+  _detect_target_flag "$@"
+  if [[ $_TARGET_SEEN -eq 1 ]]; then
+    echo "  ⚠ --target $_TARGET_VAL is not honored on the light/patch-bump path — it always pulls the latest origin/main regardless. Run \`ocp update --help\` for details." >&2
   fi
 
   # Honor --dry-run BEFORE any mutation (issue #235). This arm used to be called with NO

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -591,6 +591,44 @@ export async function runUpgrade(opts = {}) {
   const kind = doctor.next_action.kind;
   plan.push(`[doctor] from=${doctor.current_version} to=${doctor.latest_version} kind=${kind}`);
 
+  // Issue #260: --target is a PIN ("do not put me on anything else"), not a preference. noop,
+  // restart, and fresh_install have no mechanism to redirect what they do onto a specific
+  // version: noop does nothing, restart re-serves the CURRENT tree exactly as-is, and
+  // fresh_install replays doctor's own ai_executable[] -- a fixed, unparameterized script, not
+  // a tag checkout. Refuse (throw -- matching resolveUpgradeTarget's own refusal shape below,
+  // and mirroring bash's identical noop/restart refusal in `ocp`'s cmd_update) rather than
+  // silently proceeding -- including proceeding to do NOTHING -- when the caller asserted a
+  // pin. Checked here, before both the noop early-return and the --dry-run early-exit below,
+  // so previewing an impossible pin also refuses rather than previewing a plan that quietly
+  // drops it.
+  //
+  // "restart" is reachable here only when something calls runUpgrade() programmatically with a
+  // mockDoctor/live doctor reporting kind="restart" -- the real CLI path (`ocp`'s cmd_update)
+  // handles "restart" entirely in bash (_cmd_update_restart, which never execs into this file
+  // at all) and refuses it there directly, for the identical reason -- see that refusal's own
+  // comment in `ocp`. Included here anyway as defense in depth for any other caller of this
+  // exported function.
+  //
+  // "fresh_install" IS reached for real through the CLI: `ocp`'s cmd_update dispatches BOTH
+  // "upgrade" and "fresh_install" through the same `exec node scripts/upgrade.mjs "$@"` arm
+  // (only "upgrade" honors --target, per #259), so this is the only layer that can refuse it.
+  //
+  // Consistency with the light/patch-bump path ("update" kind, #241/#255): that path stays a
+  // WARNING, not a refusal, here and in `ocp` -- out of this issue's own stated scope (its own
+  // table lists only noop/restart/fresh_install as "no signal at all"; the light path already
+  // gives an observable, if non-blocking, stderr signal). See this PR's description for the
+  // full reasoning either way.
+  if (opts.target && (kind === "noop" || kind === "restart" || kind === "fresh_install")) {
+    const why = kind === "noop"
+      ? "the tree is already at the latest release -- there is nothing to check out"
+      : kind === "restart"
+        ? "the tree already matches the latest release and only the running service is stale -- this path restarts the current tree as-is and never runs git"
+        : "fresh_install replays doctor's own fixed install steps, not a checkout of a specific tag";
+    throw new Error(
+      `--target ${opts.target} was requested, but doctor selected the "${kind}" path, which cannot honor a version pin (${why}). Re-run \`ocp update\` without --target, or once a checkout-capable path (light or full upgrade) is available.`
+    );
+  }
+
   // --- noop ---
   if (kind === "noop") {
     plan.push(`[noop] already at latest (${doctor.latest_version})`);

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -579,6 +579,23 @@ export async function runUpgrade(opts = {}) {
 
   // --- rollback path (no doctor needed; snapshot is authoritative) ---
   if (opts.rollback) {
+    // Independent review of #260/#272 (round 2): --target has NO meaning on --rollback --
+    // rollback restores a STORED SNAPSHOT (selected by path, or the most recent one), never
+    // an arbitrary requested version, and runRollback() below never reads opts.target at
+    // all -- it silently ignores it, the same "accepted and dropped with no signal" shape
+    // #260 exists to close everywhere else. This combination became genuinely reachable in
+    // practice only after this same file's own noop/restart/fresh_install refusal messages
+    // (below) started pointing refused users at `ocp update --rollback` for downgrade
+    // intent -- following that advice with --target still attached would otherwise restore
+    // the newest snapshot while reporting success, believing the requested version was
+    // honored, on the one path that actually mutates disk (git checkout, npm install,
+    // restore plist/db, restart). Refuse rather than silently drop it, matching every other
+    // guard this issue added.
+    if (opts.target) {
+      throw new Error(
+        `--target ${opts.target} has no effect on --rollback -- rollback restores a stored snapshot (selected by path, or the most recent one), not a requested version. Use \`ocp update --rollback --list\` to see available snapshots, then \`ocp update --rollback <path>\` to restore a specific one.`
+      );
+    }
     return await runRollback(opts);
   }
 
@@ -625,7 +642,7 @@ export async function runUpgrade(opts = {}) {
         ? "the tree already matches the latest release and only the running service is stale -- this path restarts the current tree as-is and never runs git"
         : "fresh_install replays doctor's own fixed install steps, not a checkout of a specific tag";
     throw new Error(
-      `--target ${opts.target} was requested, but doctor selected the "${kind}" path, which cannot honor a version pin (${why}). Re-run \`ocp update\` without --target, or once a cross-minor release makes the full upgrade path available -- that is currently the ONLY path that honors --target (the light/patch-bump path warns and ignores it, per #241/#255). To move to an OLDER version instead, use \`ocp update --rollback\`.`
+      `--target ${opts.target} was requested, but doctor selected the "${kind}" path, which cannot honor a version pin (${why}). Re-run \`ocp update\` without --target, or once a cross-minor release makes the full upgrade path available -- that is currently the ONLY path that honors --target (the light/patch-bump path warns and ignores it, per #241/#255). To move to an OLDER version instead, run \`ocp update --rollback --list\` to pick a snapshot, then \`ocp update --rollback <path>\` to restore it -- --target is NOT accepted on --rollback.`
     );
   }
 

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -625,7 +625,7 @@ export async function runUpgrade(opts = {}) {
         ? "the tree already matches the latest release and only the running service is stale -- this path restarts the current tree as-is and never runs git"
         : "fresh_install replays doctor's own fixed install steps, not a checkout of a specific tag";
     throw new Error(
-      `--target ${opts.target} was requested, but doctor selected the "${kind}" path, which cannot honor a version pin (${why}). Re-run \`ocp update\` without --target, or once a checkout-capable path (light or full upgrade) is available.`
+      `--target ${opts.target} was requested, but doctor selected the "${kind}" path, which cannot honor a version pin (${why}). Re-run \`ocp update\` without --target, or once a cross-minor release makes the full upgrade path available -- that is currently the ONLY path that honors --target (the light/patch-bump path warns and ignores it, per #241/#255). To move to an OLDER version instead, use \`ocp update --rollback\`.`
     );
   }
 

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -2009,6 +2009,37 @@ test("#260 non-regression: --target on kind=upgrade (the cross-minor full path) 
   assert.equal(result.target, "v3.12.0");
 });
 
+// Independent review of this PR (#272) found a real MEDIUM: the refusal's own retry guidance
+// told the user to "wait for a checkout-capable path (light or full upgrade)" -- but the light
+// path is NEITHER checkout-capable NOR pin-honoring (it warns and still silently proceeds to
+// `latest`, per #241/#255, a few tests above this one). Following the original wording would
+// have landed the user on an un-pinned version while believing they'd waited for a path that
+// COULD honor the pin -- the exact #260 failure shape, deferred one release instead of
+// prevented. Fixed to name only the full (cross-minor) path, and to point at --rollback for a
+// downgrade instead (mirroring resolveUpgradeTarget's own existing --rollback pointer for the
+// sibling "not newer than current" refusal).
+test("#260 review fix: the fresh_install refusal's retry guidance names ONLY the full upgrade path -- never implies the light path can honor a pin", async () => {
+  await assert.rejects(
+    async () => {
+      await runUpgrade({
+        target: "v3.14.0",
+        yes: true,
+        mockExec: true,
+        mockDoctor: { ready_to_upgrade: false, from_version_supported: false,
+                      next_action: { kind: "fresh_install", ai_executable: ["echo step-1"] },
+                      current_version: "v3.2.0", latest_version: "v3.14.0" }
+      });
+    },
+    (err) => {
+      assert.match(err.message, /full upgrade path/, `message=${JSON.stringify(err.message)}`);
+      assert.match(err.message, /--rollback/, `message=${JSON.stringify(err.message)}`);
+      assert.ok(!/light or full/.test(err.message), `must not claim the light path can honor a pin; message=${JSON.stringify(err.message)}`);
+      assert.ok(!/checkout-capable path \(light/.test(err.message), `message=${JSON.stringify(err.message)}`);
+      return true;
+    }
+  );
+});
+
 // ── --target on the FULL (cross-minor) upgrade path (issue #257) ───────────────────────────────
 // `--target` was parsed from argv and threaded into runUpgrade(opts), but opts.target was never
 // actually READ anywhere in runUpgrade / runFullUpgrade / runFreshInstall / runRollback — the
@@ -10908,6 +10939,21 @@ test("#260 non-regression: the light path's OWN --target WARNING (issue #241/#25
   const r = _bwHarnessRun({ kind: "update", args: ["update", "--target", "v9.9.9"] });
   assert.equal(r.status, 0, `light path must remain a WARN, not a refusal -- deliberately out of #260's own scope; stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
   assert.match(r.stderr, /is not honored on the light\/patch-bump path/, `stderr=${JSON.stringify(r.stderr)}`);
+});
+
+// Independent review of this PR (#272) found a real MEDIUM: cmd_update's own noop/restart
+// refusal told the user to retry "once a checkout-capable path (light or full upgrade) is
+// available" -- but the test immediately above proves the light path is neither
+// checkout-capable NOR pin-honoring. Following the original wording would have sent the user
+// to the ONE path guaranteed to silently ignore the pin they were just refused for asking.
+// Fixed to name only the full (cross-minor) path and to point at --rollback for a downgrade.
+test("#260 review fix: cmd_update's noop refusal names ONLY the full upgrade path -- never implies the light path can honor a pin", () => {
+  const r = _bwHarnessRun({ kind: "noop", args: ["update", "--target", "v9.9.9"] });
+  assert.notEqual(r.status, 0, `stdout=${JSON.stringify(r.stdout)}`);
+  assert.match(r.stderr, /full upgrade path/, `stderr=${JSON.stringify(r.stderr)}`);
+  assert.match(r.stderr, /--rollback/, `stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(!/light or full/.test(r.stderr), `must not claim the light path can honor a pin; stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(!/checkout-capable path \(light/.test(r.stderr), `stderr=${JSON.stringify(r.stderr)}`);
 });
 
 // ── #236: the WARN/INFO block must not kill cmd_update when python3 is absent ────────────────

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -1911,6 +1911,104 @@ test("upgrade full path executes 5 phases", async () => {
   }
 });
 
+// ── --target REFUSAL on noop/restart/fresh_install (issue #260) ──────────────────────────────
+// Before #260: --target was accepted and silently dropped with NO signal at all on these three
+// kinds — the doctor-selected kind (not the caller) decides whether the pin gets honored (kind
+// "upgrade", #259), WARNED about but ignored (kind "update"/light path, #241/#255), or dropped
+// outright with zero signal (these three). Refuse (throw) instead: a pin is a constraint, not a
+// preference, and exiting 0 having ignored it is how a caller ends up believing a version is
+// pinned when it isn't. "noop"/"restart" are only reachable here via a direct/mocked call —
+// `ocp`'s real cmd_update refuses them identically in bash BEFORE ever exec'ing into this file
+// (see that refusal's own comment) — but "fresh_install" IS the real CLI-reachable case: bash's
+// cmd_update dispatches both "upgrade" and "fresh_install" through the same
+// `exec node scripts/upgrade.mjs "$@"` arm, so this file is the only layer that can refuse it.
+console.log("\n--target REFUSAL on noop/restart/fresh_install (issue #260):");
+
+test("#260: runUpgrade refuses --target on kind=noop", async () => {
+  await assert.rejects(async () => {
+    await runUpgrade({
+      target: "v3.99.0",
+      mockDoctor: { ready_to_upgrade: true, next_action: { kind: "noop" },
+                    current_version: "v3.26.0", latest_version: "v3.26.0" }
+    });
+  }, /--target v3\.99\.0 was requested.*"noop"/s);
+});
+
+test("#260 control: runUpgrade WITHOUT --target still returns noop cleanly (proves the refusal above is target-specific, not a general noop breakage)", async () => {
+  const result = await runUpgrade({
+    mockDoctor: { ready_to_upgrade: true, next_action: { kind: "noop" },
+                  current_version: "v3.26.0", latest_version: "v3.26.0" }
+  });
+  assert.equal(result.path, "noop");
+  assert.equal(result.executed, true);
+});
+
+test("#260: runUpgrade refuses --target on kind=restart", async () => {
+  await assert.rejects(async () => {
+    await runUpgrade({
+      target: "v3.99.0",
+      mockDoctor: { ready_to_upgrade: true, next_action: { kind: "restart" },
+                    current_version: "v3.26.0", latest_version: "v3.26.0" }
+    });
+  }, /--target v3\.99\.0 was requested.*"restart"/s);
+});
+
+test("#260 control: runUpgrade WITHOUT --target still returns restart cleanly", async () => {
+  const result = await runUpgrade({
+    mockDoctor: { ready_to_upgrade: true, next_action: { kind: "restart" },
+                  current_version: "v3.26.0", latest_version: "v3.26.0" }
+  });
+  assert.equal(result.path, "restart");
+  assert.equal(result.executed, true);
+});
+
+test("#260 (the money test): runUpgrade refuses --target on kind=fresh_install -- the actual CLI-reachable case", async () => {
+  await assert.rejects(async () => {
+    await runUpgrade({
+      target: "v3.14.0",
+      yes: true,
+      mockExec: true,
+      mockDoctor: { ready_to_upgrade: false, from_version_supported: false,
+                    next_action: { kind: "fresh_install", ai_executable: ["echo step-1"] },
+                    current_version: "v3.2.0", latest_version: "v3.14.0" }
+    });
+  }, /--target v3\.14\.0 was requested.*"fresh_install"/s);
+});
+
+test("#260 control: runUpgrade fresh_install WITHOUT --target still runs ai_executable (proves the money test above can fail)", async () => {
+  const result = await runUpgrade({
+    yes: true,
+    mockExec: true,
+    mockDoctor: { ready_to_upgrade: false, from_version_supported: false,
+                  next_action: { kind: "fresh_install", ai_executable: ["echo step-1", "echo step-2"] },
+                  current_version: "v3.2.0", latest_version: "v3.14.0" }
+  });
+  assert.equal(result.path, "fresh_install");
+  assert.equal(result.steps.length, 2);
+});
+
+test("#260: the refusal fires BEFORE --dry-run's own early exit -- previewing an impossible pin also refuses rather than quietly previewing a plan that drops it", () => {
+  return assert.rejects(async () => {
+    await runUpgrade({
+      dryRun: true,
+      target: "v3.99.0",
+      mockDoctor: { ready_to_upgrade: true, next_action: { kind: "noop" },
+                    current_version: "v3.26.0", latest_version: "v3.26.0" }
+    });
+  }, /--target v3\.99\.0 was requested/);
+});
+
+test("#260 non-regression: --target on kind=upgrade (the cross-minor full path) is UNAFFECTED -- still honored per #259", async () => {
+  const result = await runUpgrade({
+    yes: true, mockExec: true,
+    target: "v3.12.0",
+    mockDoctor: { ready_to_upgrade: true, next_action: { kind: "upgrade" },
+                  current_version: "v3.10.0", latest_version: "v3.14.0" }
+  });
+  assert.equal(result.path, "upgrade");
+  assert.equal(result.target, "v3.12.0");
+});
+
 // ── --target on the FULL (cross-minor) upgrade path (issue #257) ───────────────────────────────
 // `--target` was parsed from argv and threaded into runUpgrade(opts), but opts.target was never
 // actually READ anywhere in runUpgrade / runFullUpgrade / runFreshInstall / runRollback — the
@@ -10759,6 +10857,57 @@ test("non-regression control: cmd_update kind=restart with NO --dry-run DOES res
   assert.ok(_bwCalled(r.log, "FAKE-CMD-RESTART-CALLED"), `cmd_restart must run; log=${JSON.stringify(r.log)}`);
   assert.ok(_bwCalled(r.log, "FAKE-NODE-CALL") && r.log.some((l) => l.includes("post-flight-only")),
     `post-flight verification must run; log=${JSON.stringify(r.log)}`);
+});
+
+// ── #260: --target REFUSES (not silent-drop) on noop/restart, driven through ocp's REAL outer
+// dispatch (not a direct function call) — same rigor as #235's own acceptance test above.
+test("#260 (the money test): cmd_update kind=noop --target vX.Y.Z REFUSES -- non-zero exit, no mutation, names what was asked", () => {
+  const r = _bwHarnessRun({ kind: "noop", args: ["update", "--target", "v9.9.9"] });
+  assert.notEqual(r.status, 0, `expected a non-zero exit; stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+  assert.match(r.stderr, /--target v9\.9\.9/, `refusal must name what was asked; stderr=${JSON.stringify(r.stderr)}`);
+  assert.match(r.stderr, /noop/, `refusal must name the path that cannot honor it; stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(!r.stdout.includes("Already at latest. Nothing to do."),
+    `must NOT print the silent-success noop message; stdout=${JSON.stringify(r.stdout)}`);
+});
+
+test("#260: cmd_update kind=noop --target=vX.Y.Z (equals form, LOW-6 shape) ALSO refuses", () => {
+  const r = _bwHarnessRun({ kind: "noop", args: ["update", "--target=v9.9.9"] });
+  assert.notEqual(r.status, 0, `expected a non-zero exit; stdout=${JSON.stringify(r.stdout)}`);
+  assert.match(r.stderr, /--target v9\.9\.9/, `stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#260 control: cmd_update kind=noop WITHOUT --target still succeeds cleanly (proves the money test above can fail)", () => {
+  const r = _bwHarnessRun({ kind: "noop", args: ["update"] });
+  assert.equal(r.status, 0, `expected a clean exit; stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stdout.includes("Already at latest. Nothing to do."), `stdout=${JSON.stringify(r.stdout)}`);
+});
+
+test("#260 (the money test): cmd_update kind=restart --target vX.Y.Z REFUSES BEFORE cmd_restart ever runs -- no partial mutation", () => {
+  const r = _bwHarnessRun({ kind: "restart", args: ["update", "--target", "v9.9.9"] });
+  assert.notEqual(r.status, 0, `expected a non-zero exit; stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+  assert.match(r.stderr, /--target v9\.9\.9/, `stderr=${JSON.stringify(r.stderr)}`);
+  assert.match(r.stderr, /restart/, `stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(!_bwCalled(r.log, "FAKE-CMD-RESTART-CALLED"),
+    `cmd_restart must NEVER run once refused -- a partial restart is worse than the pre-#260 silent no-op; log=${JSON.stringify(r.log)}`);
+  assert.ok(!r.log.some((l) => l.includes("post-flight-only")),
+    `post-flight must never run either; log=${JSON.stringify(r.log)}`);
+});
+
+test("#260 control: cmd_update kind=restart WITHOUT --target still restarts + post-flight verifies (proves the money test above can fail)", () => {
+  const r = _bwHarnessRun({ kind: "restart", args: ["update"] });
+  assert.equal(r.status, 0, `expected a clean exit; stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(_bwCalled(r.log, "FAKE-CMD-RESTART-CALLED"), `log=${JSON.stringify(r.log)}`);
+});
+
+test("#260 acceptance: the refusal survives ocp's REAL outer dispatch (not a direct cmd_update call) -- same rigor #235's own acceptance test applies", () => {
+  const r = _bwHarnessRun({ kind: "noop", args: ["update", "--target", "v9.9.9"] });
+  assert.notEqual(r.status, 0, `--target must survive the real outer dispatch and still refuse; stdout=${JSON.stringify(r.stdout)}`);
+});
+
+test("#260 non-regression: the light path's OWN --target WARNING (issue #241/#255) is UNCHANGED -- still a warning, still exit 0, not a refusal", () => {
+  const r = _bwHarnessRun({ kind: "update", args: ["update", "--target", "v9.9.9"] });
+  assert.equal(r.status, 0, `light path must remain a WARN, not a refusal -- deliberately out of #260's own scope; stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+  assert.match(r.stderr, /is not honored on the light\/patch-bump path/, `stderr=${JSON.stringify(r.stderr)}`);
 });
 
 // ── #236: the WARN/INFO block must not kill cmd_update when python3 is absent ────────────────

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -2967,6 +2967,73 @@ test("rollback --list returns snapshots", async () => {
   assert.equal(result.snapshots.length, 2);
 });
 
+// Independent review of #272 (round 2, the real "before I merge" blocker): --rollback returns
+// through runRollback() BEFORE the noop/restart/fresh_install target-vs-kind guard above ever
+// runs (opts.rollback short-circuits at the very top of runUpgrade), and runRollback() itself
+// never reads opts.target at all -- silently restoring the newest (or named) snapshot while a
+// requested --target is quietly dropped, exit 0. This became genuinely reachable in practice
+// only because this file's own refusal messages (a few tests above, and in `ocp`) started
+// pointing refused users at `ocp update --rollback` for downgrade intent -- following that
+// advice with --target still attached would land on the WRONG restored state while reporting
+// success, the exact #260 shape this whole guard chain exists to close, on the one path that
+// actually mutates disk.
+console.log("\n--rollback + --target guard (issue #260/#272 review round 2):");
+
+test("#272 (the money test): runUpgrade refuses --rollback + --target together -- never reaches runRollback at all", async () => {
+  let snapshotsConsulted = false;
+  await assert.rejects(
+    async () => {
+      await runUpgrade({
+        rollback: true,
+        target: "v3.20.0",
+        // A getter, not a plain array: proves runRollback's own snapshot-listing logic never
+        // even runs -- the guard must fire before runRollback is EVER called, not merely
+        // before it does something destructive partway through.
+        get mockSnapshots() {
+          snapshotsConsulted = true;
+          return [{ name: "upgrade-snapshot-2026-05-01T10:00:00Z", path: "/tmp/snap-1" }];
+        },
+      });
+    },
+    (err) => {
+      assert.match(err.message, /--target v3\.20\.0/, `message=${JSON.stringify(err.message)}`);
+      assert.match(err.message, /has no effect on --rollback/, `message=${JSON.stringify(err.message)}`);
+      assert.match(err.message, /--rollback --list/, `message=${JSON.stringify(err.message)}`);
+      return true;
+    }
+  );
+  assert.equal(snapshotsConsulted, false, "runRollback's own snapshot listing must never run once refused");
+});
+
+test("#272 control: --rollback WITHOUT --target still works normally (proves the money test above is target-specific, not a rollback breakage)", async () => {
+  const result = await runUpgrade({
+    rollback: true,
+    list: true,
+    mockSnapshots: [{ name: "upgrade-snapshot-2026-05-01T10:00:00Z", path: "/tmp/snap-1" }],
+  });
+  assert.equal(result.path, "rollback-list");
+});
+
+test("#272: the three --target-refusal messages no longer imply --rollback accepts --target (must say --list, not just 'use --rollback')", async () => {
+  await assert.rejects(
+    async () => {
+      await runUpgrade({
+        target: "v3.14.0",
+        yes: true,
+        mockExec: true,
+        mockDoctor: { ready_to_upgrade: false, from_version_supported: false,
+                      next_action: { kind: "fresh_install", ai_executable: ["echo step-1"] },
+                      current_version: "v3.2.0", latest_version: "v3.14.0" }
+      });
+    },
+    (err) => {
+      assert.match(err.message, /--rollback --list/, `message=${JSON.stringify(err.message)}`);
+      assert.match(err.message, /NOT accepted on --rollback/, `message=${JSON.stringify(err.message)}`);
+      return true;
+    }
+  );
+});
+
 test("rollback with no snapshots fails clearly", async () => {
   await assert.rejects(async () => {
     await runUpgrade({ rollback: true, dryRun: true, mockSnapshots: [] });
@@ -10954,6 +11021,26 @@ test("#260 review fix: cmd_update's noop refusal names ONLY the full upgrade pat
   assert.match(r.stderr, /--rollback/, `stderr=${JSON.stringify(r.stderr)}`);
   assert.ok(!/light or full/.test(r.stderr), `must not claim the light path can honor a pin; stderr=${JSON.stringify(r.stderr)}`);
   assert.ok(!/checkout-capable path \(light/.test(r.stderr), `stderr=${JSON.stringify(r.stderr)}`);
+});
+
+// Independent review round 2 (LOW, optional -- fixed anyway, cheap given the shared detector
+// already exists): `ocp update --check --target vX.Y.Z` was the last fully-silent hole in this
+// chain -- --check is read-only (fetch + report, no mutation, no wrong end state), but --target
+// was accepted and dropped with zero signal, same as noop/restart/fresh_install were before
+// #260's own fix. A warning (not a refusal -- there is nothing to refuse; --check never mutates
+// anything either way) is enough here.
+test("#260/#272 review round 2: cmd_update --check --target warns (read-only, so a warning suffices, not a refusal)", () => {
+  const r = _bwHarnessRun({ kind: "noop", args: ["update", "--check", "--target", "v9.9.9"] });
+  assert.equal(r.status, 0, `--check must remain read-only/exit 0 regardless; stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+  assert.match(r.stderr, /--target v9\.9\.9 has no effect on --check/, `stderr=${JSON.stringify(r.stderr)}`);
+  assert.match(r.stdout, /OCP Update Check/, `--check's own report must still print; stdout=${JSON.stringify(r.stdout)}`);
+});
+
+test("#260/#272 review round 2 control: cmd_update --check WITHOUT --target prints no warning (proves the test above is target-specific)", () => {
+  const r = _bwHarnessRun({ kind: "noop", args: ["update", "--check"] });
+  assert.equal(r.status, 0, `stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(!/has no effect on --check/.test(r.stderr), `stderr=${JSON.stringify(r.stderr)}`);
+  assert.match(r.stdout, /OCP Update Check/, `stdout=${JSON.stringify(r.stdout)}`);
 });
 
 // ── #236: the WARN/INFO block must not kill cmd_update when python3 is absent ────────────────


### PR DESCRIPTION
## What

`--target` is a version PIN ("do not put me on anything else"), not a preference. State going in:

| doctor kind | `--target` behavior |
|---|---|
| `upgrade` (cross-minor) | honored (#257/#259) |
| `update` (light/patch-bump) | warned, then ignored (#241/#255) |
| `noop` | accepted, dropped, **no signal at all** |
| `restart` | accepted, dropped, **no signal at all** |
| `fresh_install` | accepted, dropped, **no signal at all** |
| `fix_oauth` / `fix_service` | N/A — these already exit non-zero and never reach the update paths above |
| (unrecognized kind, the `*)` arm) | N/A — already exits non-zero |

`doctor` — not the caller — picks which of the first five paths runs, from a current-vs-latest
comparison. So the SAME `ocp update --target vX.Y.Z` command pins or silently doesn't, depending
only on where the host happens to sit in the release cycle. This project has already been burned
by the identical shape twice: #214 and #241 are both "reported success while the wrong thing
happened."

(Note: `scripts/doctor.mjs`'s `next_action.kind` actually has **seven** distinct values, not
five — `fresh_install`, `fix_service`, `fix_oauth`, `restart`, `noop`, `update`, `upgrade`. The
two not in the table above already exit non-zero on their own existing paths, so no kind in the
full set silently reports success while dropping a pin — stated explicitly here since it wasn't
in this PR's original description.)

## Fix

Refuse (non-zero exit, no state changed) on all three "no signal at all" paths, naming what was
asked and what the path can actually do.

### `ocp` (bash) — noop and restart

Both are handled entirely in bash and never touch git or any restart machinery through a
mechanism that could honor a pin. The refusal lives in `cmd_update`'s own kind dispatch, before
either kind's body runs — so a refused noop makes literally zero calls, and a refused restart
never reaches `cmd_restart` at all (no partial mutation).

The `--target`/`--target=X` detection logic (both token shapes, per #241's own LOW-6 finding) is
extracted into a shared `_detect_target_flag` helper, used by the refusal, the pre-existing
light-path warning, and (added in review round 2) the `--check` fast path's own warning.

### `scripts/upgrade.mjs` (`runUpgrade`) — fresh_install

`fresh_install` IS reachable through the real CLI: bash's `cmd_update` dispatches both
`"upgrade"` and `"fresh_install"` through the identical `exec node scripts/upgrade.mjs "$@"` arm
(only `"upgrade"` honors `--target`, per #259), so this file is the only layer that can refuse
it. The check is placed before both the `noop` early-return and the `--dry-run` early-exit, so
previewing an impossible pin also refuses rather than quietly previewing a plan that drops it.
`noop`/`restart` are covered here too, as defense in depth for any caller that reaches
`runUpgrade()` programmatically, bypassing the bash CLI entirely.

## Decision: light path stays a WARNING, not a refusal

The issue explicitly raises this as an open question. I looked at it and decided **not** to
change it in this PR, but my own original reasoning for *why* was wrong on one point and I want
to correct the record rather than leave it standing:

- **Scope** — still my reasoning: the issue's own title and table are scoped to three paths, and
  reopening a fourth, already-shipped, independently-reviewed decision (#255) under this issue's
  number blurs what #260 actually closes. Changing a shipped exit-0 path to exit-1 is its own
  fleet-contract change and deserves its own review round, not a rider on this one.
- **What I got wrong**: I originally argued the light path's gap was "materially smaller" than
  noop/restart/fresh_install's. On the *outcome* axis that's backwards. noop/restart/fresh_install
  leave the host exactly where it was (a stale-but-known state); the light path is the ONLY one
  of the four that actively moves the tree to a concrete version that is **not** the one pinned,
  while exiting 0. And the light path's warning goes to stderr, which is invisible to a `set -e`
  fleet script — the exact #214 failure mode this repo already has on record. The light path's
  gap is not smaller; it just has a *visible signal on interactive stderr* that the other three
  didn't have before this PR. That's a real, if partial, mitigation — but it isn't a smaller
  problem, and I don't want that wrong framing sitting in the PR record as future precedent.

If a maintainer wants the light path to become a hard refusal too, that's its own issue
referencing #255's own reasoning for why the mechanism swap (fast-forward pull → tag checkout)
was deliberately deferred.

## Independent review — two rounds, both addressed

### Round 1 (verified sound, no changes required)

Refusal fires on all three kinds and beats the `--dry-run` early exit; the bash guard precedes
`case "$kind"` with only read-only work before it; #259's injection fix (anchored regex, value
rebuilt from parsed integers, argv-form `git`, target only ever reaching a `throw new
Error(...)` string) is untouched; three arm-level mutations were each caught by name, including
one proving the shared-helper refactor preserved #241/#255's own existing coverage.

### Round 2

**MEDIUM (the actual blocker) — `--rollback` silently dropped `--target`.** `runUpgrade`'s
`opts.rollback` branch returns via `runRollback(opts)` **before** the noop/restart/fresh_install
guard above ever runs, and `runRollback()` itself never reads `opts.target` — silently restoring
a stored snapshot while a requested pin is dropped, exit 0. This became reachable specifically
*because* this PR's own remediation text pointed refused users at `ocp update --rollback` for
downgrade intent. Fixed with a guard at the top of the `--rollback` branch (refuses before
`runRollback` is ever called — proven by a mock snapshot list implemented as a getter that must
never be invoked), plus reworded all three retry-guidance messages to say `--rollback --list` /
`--target is NOT accepted on --rollback` instead of a bare "use `ocp update --rollback`".

**LOW (optional, fixed anyway):** `ocp update --check --target vX.Y.Z` was the last fully-silent
hole — `--check` is read-only, so a warning (not a refusal) is the right fix, reusing the same
shared detector.

## Tests

`test-features.mjs`, two layers, two review rounds:

**Node layer**: `runUpgrade()` driven directly via `mockDoctor`, covering refusal on all three
kinds, a dry-run-ordering test, a non-regression control confirming `--target` on `kind="upgrade"`
is unaffected, the `--rollback`+`--target` money test (with the snapshot-getter proof above) and
its control, and a message-content test for the reworded retry guidance.

**Bash layer**: `ocp`'s real outer dispatch via `_bwHarnessRun` — money tests for noop and
restart (both `--target vX.Y.Z` and `--target=vX.Y.Z` forms), controls proving each money test
can fail, an acceptance test through the real dispatch (matching `#235`'s own rigor), a
non-regression control for the light path's unchanged warning, and a warn/control pair for
`--check --target`.

### Fails on main / passes with the fix

Demonstrated by reverting `ocp` and `scripts/upgrade.mjs` to `origin/main`'s content (file-backup
+ `shasum -a 256` round-trip, never `git checkout`) while keeping the round-1 tests: **8 named
tests fail**, all `#260` tests, every pre-existing test still passes. Restored (checksums
verified byte-identical) and re-run clean.

Baseline on `origin/main` (rebased onto `b2a1f22`): **808 passed, 0 failed**. This branch on the
rebased head: **830 passed, 0 failed** (830 = 808 + 22 new tests across both review rounds),
confirmed stable across multiple runs on this shared, often heavily-loaded dev host.

### Mutation table (both review rounds, rebased head)

Each guard mutated individually, restored via `cp` backup + `shasum -a 256` round-trip (never
`git checkout`), anchor-presence asserted via `grep` before every mutation, full suite
re-confirmed green before the next mutation:

| # | File | Mutation | Named test(s) that fail |
|---|---|---|---|
| M1 | `ocp` | Outer kind-gate for the noop/restart refusal changed to a condition that never matches | 4 named tests: both noop money tests (token + `=` form), the restart money test, the acceptance test |
| M2 | `scripts/upgrade.mjs` | `fresh_install` removed from the Node-layer refusal's kind list | "runUpgrade refuses --target on kind=fresh_install" (the money test) |
| M3 | `ocp` | `_detect_target_flag`'s `--target=*)` case arm emptied | the equals-form test, **and** the pre-existing `#241 LOW-6` test (confirms the shared-helper refactor preserved existing coverage) |
| M4 | `scripts/upgrade.mjs` | Target-vs-kind check moved from before to after the `noop`/`--dry-run` early exits | "runUpgrade refuses --target on kind=noop", the dry-run-ordering test |
| M5 | `scripts/upgrade.mjs` + `ocp` | Reverted the reworded retry-guidance text back to "light or full" | both message-content tests |
| R2-M1 | `scripts/upgrade.mjs` | `--rollback`+`--target` guard removed entirely | the `--rollback`+`--target` money test (fails differently — proceeds into real rollback logic, proving the guard's absence) |
| R2-M2 | `ocp` | `--check`'s `_TARGET_SEEN` condition inverted | the `--check --target` warn test **and** its own control, in opposite directions |

Each mutation run in isolation, restored, and the full suite re-confirmed green before the next.

## Scope

Does not touch `server.mjs`.

Closes #260
