### PR TITLE
fix(ocp): rollback runs a post-flight check against the snapshot's fromVersion

### DIFF
--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -1085,6 +1085,62 @@ async function runRollback(opts) {
   }
   for (const c of restartPlan.plan.cmds) exec(c.cmd, c.label);
 
+  // Issue #274 (split from #253's own item 2): unlike runFullUpgrade's phase 6, this used to
+  // return success unconditionally once the restart phase's shell commands exited 0 -- a
+  // rollback that "succeeded" while the restored tree was not what actually came back up had
+  // nothing left to catch it. That is the same failure shape this file has hit three times
+  // already: #214 (retry short-circuited into a no-op while the tree was new and the process
+  // old -- only /health told the truth), #241 (the light path had no post-flight), and #232 (a
+  // health verdict that did not track serving). Reuses runPostFlightCheck()/postFlightOk() --
+  // the SAME acceptance predicate every other path in this file already uses -- rather than a
+  // fourth hand-rolled check.
+  //
+  // Target is meta.fromVersion, deliberately NOT doctor.latest_version or any upgrade target:
+  // rollback's entire point is restoring the OLDER version recorded in the snapshot's own
+  // from-version.txt (writeSnapshot, scripts/lib/snapshot.mjs, writes fromVersion as
+  // doctor.current_version at the time the snapshot was taken -- the version the just-restored
+  // fromCommit actually served). Comparing against toVersion/doctor.latest_version would check
+  // the rollback against the version it is trying to LEAVE, not the one it is restoring --
+  // exactly backwards. See PR body for the fuller design-question writeup #274 asked for.
+  //
+  // opts.mockProbe: the SAME test hook runPostFlightCheck already exposes for its own callers
+  // (not a new name) -- reused verbatim so this phase is independently testable without a live
+  // server, the same way opts.run already lets resolveRestartPlan's own gathering be driven
+  // end-to-end regardless of opts.mockExec. Under plain opts.mockExec with no mockProbe, this
+  // phase is skipped like every other mutating phase above, so every existing all-mock rollback
+  // test is unaffected. A real (non-mockExec) rollback always runs the real check.
+  let postFlight = { ok: true, lastSeen: null, target: String(meta.fromVersion || "").replace(/^v/, "") };
+  if (opts.mockProbe || !opts.mockExec) {
+    postFlight = await runPostFlightCheck(meta.fromVersion, {
+      mockProbe: opts.mockProbe,
+      attempts: opts.postFlightAttempts,
+      intervalMs: opts.postFlightIntervalMs,
+    });
+    phases.push({
+      name: "post-flight",
+      status: postFlight.ok ? "ok" : "fail",
+      ...(postFlight.ok ? {} : {
+        message: `health did not return auth.ok=true AND version=${postFlight.target} within the post-flight budget`
+          + (postFlight.lastSeen
+            ? ` (last saw version=${postFlight.lastSeen} — the restored tree may not be what's running; check \`ss -ltnp\` / \`lsof -i\`)`
+            : " (unreachable)"),
+      }),
+    });
+  } else {
+    phases.push({ name: "post-flight", status: "skipped-mock" });
+  }
+
+  if (!postFlight.ok) {
+    // No further fallback to retry (#221's HIGH-A finding about permanent-refusal traps does
+    // not apply here: the restart phase already ran, this only decides whether to REPORT
+    // success truthfully) -- throw, matching runFullUpgrade's own post-flight-failure shape,
+    // so operators get the same failure contract regardless of which path failed.
+    throw Object.assign(
+      new Error(`rollback post-flight failed: restored tree may not be what's running — run \`ocp doctor\` before assuming the rollback succeeded`),
+      { phases, target: target.path }
+    );
+  }
+
   return { path: "rollback", executed: true, changed: true, target: target.path, phases };
 }
 

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -3354,6 +3354,72 @@ test("rollback latest snapshot restores files (mockExec)", async () => {
   assert.ok(result.phases.some(p => p.name === "git-checkout"));
 });
 
+console.log("\nRollback post-flight verification (issue #274) — a 'successful' rollback must confirm what's actually serving:");
+
+// Before this fix, runRollback reported success unconditionally once the restart phase's shell
+// commands exited 0 — it never checked that the restored tree is what actually came back up.
+// opts.mockProbe is the SAME test hook runPostFlightCheck already exposes to its other callers
+// (the bash "restart"/"light" paths via --post-flight-only); reused here, not a new name, so
+// this phase is testable end-to-end without a live server, independent of opts.mockExec.
+
+test("#274 (the money test): rollback reports FAILURE when post-flight does not confirm the snapshot's fromVersion, even though every restart phase exited 0", async () => {
+  await assert.rejects(async () => {
+    await runUpgrade({
+      rollback: true, yes: true, mockExec: true,
+      mockSnapshots: [{ name: "upgrade-snapshot-2026-05-11T08:30:00Z", path: "/tmp/snap-x" }],
+      mockSnapshotMeta: { fromCommit: "abc1234", fromVersion: "v3.10.0", toVersion: "v3.14.0", path: "/tmp/snap-x" },
+      // A stale/orphan process still answers auth.ok=true but serves the version rollback was
+      // trying to LEAVE, not the one it restored — exactly the "reports success while serving
+      // the wrong tree" shape #274 describes.
+      mockProbe: () => ({ auth: { ok: true }, version: "3.14.0" }),
+      postFlightAttempts: 1, postFlightIntervalMs: 0,
+    });
+  }, /rollback post-flight failed/);
+});
+
+test("#274 control: rollback reports SUCCESS when post-flight confirms the snapshot's fromVersion (proves the money test's failure is real, not rollback just always failing now)", async () => {
+  const result = await runUpgrade({
+    rollback: true, yes: true, mockExec: true,
+    mockSnapshots: [{ name: "upgrade-snapshot-2026-05-11T08:30:00Z", path: "/tmp/snap-x" }],
+    mockSnapshotMeta: { fromCommit: "abc1234", fromVersion: "v3.10.0", toVersion: "v3.14.0", path: "/tmp/snap-x" },
+    mockProbe: () => ({ auth: { ok: true }, version: "3.10.0" }),
+    postFlightAttempts: 1, postFlightIntervalMs: 0,
+  });
+  assert.equal(result.path, "rollback");
+  assert.equal(result.executed, true);
+  const pf = result.phases.find(p => p.name === "post-flight");
+  assert.ok(pf, "post-flight phase must be recorded");
+  assert.equal(pf.status, "ok");
+});
+
+test("#274: rollback post-flight targets meta.fromVersion, NOT toVersion — a probe still serving toVersion must fail even though that version IS a real, known version", async () => {
+  // Guards the specific design decision #274 asked for: rollback restores fromCommit (which
+  // served fromVersion), so a probe confirming toVersion (the version being rolled BACK FROM)
+  // must still fail — checking toVersion here would be checking the rollback against the
+  // version it is trying to leave, not the one it is restoring.
+  await assert.rejects(async () => {
+    await runUpgrade({
+      rollback: true, yes: true, mockExec: true,
+      mockSnapshots: [{ name: "upgrade-snapshot-2026-05-11T08:30:00Z", path: "/tmp/snap-x" }],
+      mockSnapshotMeta: { fromCommit: "abc1234", fromVersion: "v3.10.0", toVersion: "v3.14.0", path: "/tmp/snap-x" },
+      mockProbe: () => ({ auth: { ok: true }, version: "3.14.0" }), // toVersion, not fromVersion
+      postFlightAttempts: 1, postFlightIntervalMs: 0,
+    });
+  }, /rollback post-flight failed/);
+});
+
+test("#274: rollback post-flight is skipped-mock under plain mockExec with no injected probe (existing all-mock rollback tests stay inert)", async () => {
+  const result = await runUpgrade({
+    rollback: true, yes: true, mockExec: true,
+    mockSnapshots: [{ name: "upgrade-snapshot-2026-05-11T08:30:00Z", path: "/tmp/snap-x" }],
+    mockSnapshotMeta: { fromCommit: "abc1234", fromVersion: "v3.10.0", toVersion: "v3.14.0", path: "/tmp/snap-x" },
+  });
+  assert.equal(result.path, "rollback");
+  const pf = result.phases.find(p => p.name === "post-flight");
+  assert.ok(pf, "post-flight phase must still be recorded, even when skipped");
+  assert.equal(pf.status, "skipped-mock");
+});
+
 test("gcSnapshots keeps last N regardless of age", () => {
   const root = mkdtempSync(testJoin(tmpdir(), "ocp-gc-test-"));
   const dotOcp = testJoin(root, ".ocp");


### PR DESCRIPTION
## Summary

`runRollback()` (scripts/upgrade.mjs) previously returned success unconditionally once the
restart phase's shell commands exited 0 -- unlike `runFullUpgrade`, it never confirmed the
restored tree was actually what came back up serving. This adds a post-flight check on the
rollback path, reusing the existing `runPostFlightCheck()` / `postFlightOk()` acceptance
predicate against `meta.fromVersion` (the snapshot's own recorded from-version, i.e. what
`fromCommit` actually served) -- not `doctor.latest_version` or the snapshot's `toVersion`.

Does not touch `server.mjs` (this PR is scoped entirely to `scripts/upgrade.mjs` and
`test-features.mjs`).

## Endpoint Class (REQUIRED)

- [x] **Not endpoint-touching** — this is a CLI upgrade-tooling change (`scripts/upgrade.mjs`); it does not modify any request handler in `server.mjs`.

## Design decision this PR makes (issue #274 asked for one)

Issue #274 explicitly left two questions open: **what should the check assert**, and **what
should it do on failure**.

1. **What to check**: version match against `meta.fromVersion`, using the exact same
   `postFlightOk()` predicate the upgrade paths already use (`auth.ok === true` AND
   `/health.version` matches, tolerating a leading `v`). `meta.fromVersion` is written by
   `writeSnapshot()` (`scripts/lib/snapshot.mjs`) as `doctor.current_version` *at the moment the
   snapshot was taken* -- i.e. the version the just-restored `fromCommit` actually served.
   Checking against `toVersion` (the version being rolled back *away from*) or
   `doctor.latest_version` would validate the rollback against the wrong version entirely; a
   dedicated test (`#274: rollback post-flight targets meta.fromVersion, NOT toVersion`) locks
   this in.
2. **What to do on failure**: throw, matching `runFullUpgrade`'s own post-flight-failure shape
   (error carries `.phases` and `.target`, same as every other rollback failure in this file).
   #221's HIGH-A "permanent-refusal-trap" finding is about refusing to even *attempt* a restart
   when the target is ambiguous -- it doesn't apply here, because the restart has already run by
   the time this check executes; this only decides whether to *report* that attempt's outcome
   truthfully instead of unconditionally claiming success.

## Test hook

`opts.mockProbe` -- the **same** name/convention `runPostFlightCheck` already exposes to its
other callers (the bash `restart`/`light` paths via `--post-flight-only`) -- is reused verbatim,
not reinvented, so the new phase is independently testable without a live server, the same way
`opts.run` already lets `resolveRestartPlan`'s gathering be driven end-to-end regardless of
`opts.mockExec`. Under plain `opts.mockExec` with no `mockProbe`, the phase is skipped exactly
like every other mutating phase in `runRollback` -- every pre-existing all-mock rollback test
(~20 of them) is unaffected.

## Test plan

- [x] 4 new named tests added under `test-features.mjs` § "Rollback post-flight verification
      (issue #274)": the money test, a success control, a target-selection guard
      (`fromVersion` vs `toVersion`), and a `skipped-mock` regression guard.
- [x] All 4 fail on pre-fix `scripts/upgrade.mjs` (852 passed / **4 failed**, named above) and
      pass after the fix (856 passed / 0 failed).
- [x] Each guard mutation-verified: guard neutered, target swapped to `toVersion`, gate
      neutered, `skipped-mock` branch lied about status -- every mutation caught by a named
      test; restored from a file backup verified byte-identical via `shasum -a 256` each time,
      never via `git checkout --`.
- [x] Full `npm test` green: **856 passed, 0 failed**.

## Type of change

- [x] Bug fix

## Reviewer checklist

- [ ] Confirmed `meta.fromVersion` (not `toVersion` / `doctor.latest_version`) is the correct
      post-flight target for a rollback, by reading `writeSnapshot()` in
      `scripts/lib/snapshot.mjs`.
- [ ] Confirmed the failure-mode decision (throw, no retry) against #221's HIGH-A finding and
      agrees it does not apply to an already-executed restart's verification step.
- [ ] Ran the mutation table locally (or reviewed the failing/passing output above) and agrees
      each guard has real coverage.
- [ ] I am not the commit author of any commit in this PR (Iron Rule 10).

## Related

- `ALIGNMENT.md` Rule(s) invoked: none (no `server.mjs` change; no endpoint touched)
- Related issue / prior PR: #274 (split from #253); refs #214, #221, #232, #241