### PR TITLE
fix(ocp): distinguish 'could not run' from 'ran and failed' at cmd_status and cmd_settings PATCH

### DIFF
--- a/ocp
+++ b/ocp
@@ -251,7 +251,23 @@ EOF
 }
 
 cmd_status() {
-  curl -sf --max-time 15 "$PROXY/status" | _json
+  # Issue #273 (found during independent review of #261/#267): this was a BARE pipeline with no
+  # failure handling -- `curl -sf ... | _json` -- and under `-sf` (silent + fail-on-HTTP-error)
+  # curl suppresses its OWN diagnostic text on a genuine connection failure too, not just HTTP
+  # error bodies, so a real "the proxy is down" case produced status=7 with stdout AND stderr
+  # both completely empty (verified directly, not assumed: a real curl against a closed port
+  # exits 7 silently on both streams; a shadow-stubbed curl exiting 127, simulating "not on
+  # $PATH", is exactly as silent). This is the command an operator runs FIRST when something
+  # looks wrong, and it used to answer by saying nothing at all.
+  #
+  # Routed through `_curl_or_die` (#261/#267) like the other captured-assignment sites, but this
+  # one needs a second stage afterward that none of the three #261 sites needed: `_json`'s own
+  # `python3 -m json.tool 2>/dev/null || cat` pretty-printer. Capture the verified-successful body
+  # first, THEN pipe it into `_json` -- a formatter failure still degrades to the raw JSON via
+  # `_json`'s own `cat` fallback rather than losing the response a second time.
+  local data
+  data=$(_curl_or_die "proxy unreachable" curl -sf --max-time 15 "$PROXY/status") || exit 1
+  echo "$data" | _json
 }
 
 # ── health ───────────────────────────────────────────────────────────────
@@ -948,9 +964,20 @@ for tier in ('opus','sonnet','haiku'):
     local key="$1"
     local value="$2"
     local result
-    result=$(curl -s --max-time 5 -X PATCH "$PROXY/settings" \
+    # Issue #273 (found during independent review of #261/#267): a fourth `2>&1`-into-capture
+    # site, literally the shape `_curl_or_die`'s own comment describes: `result=$(curl ... 2>&1)`.
+    # Unlike a `local result=$(...)` (which masks the exit status from `set -e` -- see this file's
+    # own #261-era `_pyfail`/`cmd_restart` exit-vs-return lesson), this is a PLAIN assignment, so a
+    # curl-exec failure (127, curl missing from $PATH) used to trip `errexit` immediately -- the
+    # whole `ocp settings <key> <value>` invocation died right there, before the
+    # `if echo "$result" | python3 ...` line below was ever reached, taking the `2>&1`-captured
+    # diagnostic down with it: status=127, stdout=[], stderr=[]. Deliberately still WITHOUT `-f`
+    # here (unlike most `_curl_or_die` call sites): the server can answer with a 2xx-or-not body
+    # carrying an `errors` array for a validation failure, which the code below must still be able
+    # to read -- `-f` would make curl swallow that body on a non-2xx response.
+    result=$(_curl_or_die "proxy unreachable" curl -s --max-time 5 -X PATCH "$PROXY/settings" \
       -H "Content-Type: application/json" \
-      -d "{\"$key\": $value}" 2>&1)
+      -d "{\"$key\": $value}") || return 1
     if echo "$result" | python3 -c "import sys,json; d=json.loads(sys.stdin.read()); errs=d.get('errors',[]); exit(1 if errs else 0)" 2>/dev/null; then
       echo "✓ $key = $value"
     else

--- a/ocp
+++ b/ocp
@@ -113,7 +113,8 @@ _pyfail() {
 #
 # Usage: `data=$(_curl_or_die "<network-failure label>" _curl -sf ... "$url") || exit 1` — the
 # first argument after the label is the command to run (`_curl` for authenticated call sites,
-# plain `curl` for the one unauthenticated one), so this stays a drop-in replacement for the old
+# plain `curl` for the unauthenticated ones — cmd_usage's main call, cmd_status, cmd_settings
+# PATCH, and cmd_health, per #273), so this stays a drop-in replacement for the old
 # `<cmd> ... 2>&1) || { echo "Error: <label>"; exit 1; }` shape at each site, byte-identical on
 # the success path and on a genuine network failure (same label text), and message text goes to
 # stderr (matching the sibling display commands' own stderr convention, PR #252 round 1 fix 3 —
@@ -282,7 +283,14 @@ EOF
 }
 
 cmd_health() {
-  curl -sf --max-time 10 "$PROXY/health" | _json
+  # Issue #273 (found during this PR's own independent review, Iron Rule 10 — not in #273's own
+  # text): byte-for-byte the same bare-pipeline shape `cmd_status` had pre-fix, and just as
+  # silent for the identical reason -- see that function's own comment block above for the full
+  # verified repro (curl exits 7 silently on a real connection failure under -sf; a shadow-
+  # stubbed curl exiting 127 is exactly as silent). Same fix, same shape.
+  local data
+  data=$(_curl_or_die "proxy unreachable" curl -sf --max-time 10 "$PROXY/health") || exit 1
+  echo "$data" | _json
 }
 
 # ── logs ─────────────────────────────────────────────────────────────────

--- a/ocp
+++ b/ocp
@@ -118,7 +118,8 @@ _pyfail() {
 # `<cmd> ... 2>&1) || { echo "Error: <label>"; exit 1; }` shape at each site, byte-identical on
 # the success path and on a genuine network failure (same label text), and message text goes to
 # stderr (matching the sibling display commands' own stderr convention, PR #252 round 1 fix 3 —
-# these three call sites were the ones that review explicitly left untouched).
+# those three call sites, cmd_usage's two arms plus cmd_keys add, were the ones that review
+# explicitly left untouched at the time).
 _curl_or_die() {
   local network_label="$1"; shift
   local errfile out status err

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -12236,6 +12236,49 @@ test("#273 stream parity: cmd_status / cmd_settings PATCH 'proxy unreachable' gu
   assert.equal(settings.stdout, "", `cmd_settings PATCH: stdout must stay clean; got: ${JSON.stringify(settings.stdout)}`);
 });
 
+// ── cmd_health: found during this PR's own independent review (Iron Rule 10), not in #273's own
+// text — the reviewer noticed `cmd_health` (ocp:284-286 at the time) is BYTE-FOR-BYTE the same
+// bare-pipeline shape `cmd_status` had pre-fix (`curl -sf ... | _json`, zero failure handling),
+// 14 lines below the function this PR already fixes. It is the SAME severity as #273's own two
+// sites (total silence on both streams, in both fault modes — verified with the harness itself,
+// using the exact fixtures the cmd_status tests above already established), not the lower
+// severity of the seven sites deferred to #278 (those still let bash's own message through
+// unredirected). Fixed here rather than deferred, per the reviewer's own Iron Rule 11 reasoning:
+// deferring same-severity work to a lower-severity follow-up is the one split that rule does not
+// license. Tests mirror the cmd_status set exactly (same helper, same fixtures, same shape).
+console.log("\nocp cmd_health: the same silent-failure shape as cmd_status, found during PR #279's own independent review (#273):");
+
+test("#273 cmd_health: the money test — curl present but the proxy genuinely unreachable must not be COMPLETELY SILENT (reproduces the exact status=7/stdout=[]/stderr=[] signature)", () => {
+  const r = _bwHarnessRun({ args: ["health"], curlResponses: [{ match: "/health", body: "", exit: 7 }] });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(!(r.stdout === "" && r.stderr === ""),
+    `must not reproduce the silent status=7/stdout=[]/stderr=[] signature this issue exists to kill; stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stderr.includes("proxy unreachable"), `expected a diagnostic naming the proxy, got stderr=${JSON.stringify(r.stderr)}`);
+  assert.equal(r.stdout, "", `the diagnostic belongs on stderr, not stdout; got stdout=${JSON.stringify(r.stdout)}`);
+});
+
+test("#273 cmd_health: curl missing from $PATH must be reported as a local fault, not 'proxy unreachable' or silence", () => {
+  const r = _bwHarnessRun({ args: ["health"], curlAbsent: true });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(!(r.stdout === "" && r.stderr === ""), `must not be silent; stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(!r.stderr.includes("proxy unreachable") && !r.stdout.includes("proxy unreachable"),
+    `must NOT misattribute a missing curl binary to the proxy; stderr=${JSON.stringify(r.stderr)} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(/curl/i.test(r.stderr), `expected the message to name curl/the local command failure, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#273 control: cmd_health with curl present and the proxy genuinely reachable still prints the (pretty-printed) health body", () => {
+  const r = _bwHarnessRun({ args: ["health"], curlResponses: [{ match: "/health", body: JSON.stringify({ status: "ok", version: "3.26.0" }) }] });
+  assert.equal(r.status, 0, `expected a clean exit, got status=${r.status} stderr=${r.stderr}`);
+  assert.ok(r.stdout.includes('"status"') && r.stdout.includes("ok"), `expected the health JSON on stdout, got: ${JSON.stringify(r.stdout)}`);
+  assert.equal(r.stderr, "", `a successful run must not print anything to stderr; got: ${JSON.stringify(r.stderr)}`);
+});
+
+test("#273 stream parity: cmd_health 'proxy unreachable' guard writes to stderr, stdout stays empty", () => {
+  const r = _bwHarnessRun({ args: ["health"] });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.equal(r.stdout, "", `cmd_health: stdout must stay clean of the error text; got: ${JSON.stringify(r.stdout)}`);
+});
+
 console.log("\nRestart-unit resolution (issue #233 defect 1) — macOS lsof exit-code handling:");
 
 // Background: `lsof -nP -iTCP:<port> -sTCP:LISTEN` EXITS 1 with EMPTY stdout when nothing

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -12125,6 +12125,117 @@ test("#261 fold-in A (independent review round 1, security): a mktemp failure is
     `redirect its stderr into; log=${JSON.stringify(r.log)}`);
 });
 
+// ═════════════════════════════════════════════════════════════════════════════
+// Issue #273 (found during independent review of #267): two more sites in the same "the command
+// could not run" vs "the request failed" family that #261's own sweep did not name.
+//
+// `cmd_status` (a BARE pipeline, `curl -sf ... "$PROXY/status" | _json`, no failure handling at
+// all) is a WORSE case than the three #261 sites: those at least printed something (the wrong
+// diagnosis, on a genuine network failure, per #256/#261's own history) — `cmd_status` printed
+// NOTHING on EITHER stream, in EITHER scenario. Verified directly (not assumed) against the
+// unmodified script before writing these tests: a real curl against a closed port (proxy
+// genuinely down) exits 7 with empty stdout AND empty stderr, because `-sf` (silent + fail)
+// suppresses curl's own connection-error text too, not merely HTTP error bodies; a shadow-stubbed
+// curl exiting 127 (curl absent from $PATH) is exactly as silent. This is the command an operator
+// runs FIRST when something looks wrong, and it used to answer by saying nothing at all.
+//
+// `cmd_settings` PATCH is a fourth `2>&1`-into-capture site, literally the shape `_curl_or_die`'s
+// own comment describes: `result=$(curl -s ... 2>&1)`. Unlike a `local result=$(...)` (which
+// masks the exit status from `set -e` — see this file's own #261-era `_pyfail`/`cmd_restart`
+// exit-vs-return lesson), this is a PLAIN assignment, so a curl-exec failure (127, curl missing
+// from $PATH) trips `errexit` immediately and the whole `ocp settings <key> <value>` invocation
+// dies right there — before the `if echo "$result" | python3 ...` line is ever reached — taking
+// the `2>&1`-captured diagnostic down with it: status=127, stdout=[], stderr=[].
+//
+// Both route through the existing `_curl_or_die` helper (#261/#267) rather than inventing a
+// second mechanism. `cmd_status` needed a different shape than a plain captured assignment,
+// though: it still pipes the verified-successful body onward into `_json` (the
+// `python3 -m json.tool 2>/dev/null || cat` formatter) afterward — none of the three #261 sites
+// needed a second stage, they fed the captured value straight into their own `python3 -c "..."`
+// heredoc.
+console.log("\nocp cmd_status / cmd_settings PATCH: two more silent-failure sites (#273):");
+
+test("#273 cmd_status: the money test — curl present but the proxy genuinely unreachable must not be COMPLETELY SILENT (reproduces the exact status=7/stdout=[]/stderr=[] signature)", () => {
+  // exit:7, body:"" reproduces curl's own real silent-connection-failure shape under `-sf` —
+  // verified directly against a real closed port before writing this fixture (see block comment
+  // above) — rather than the harness's default-refusal arm, which (being a stub script, not a
+  // real curl under `-s`) always prints its own "FAKE-CURL: refusing..." line regardless of `-s`/
+  // `-f` and would therefore NOT reproduce the true silence this issue is about.
+  const r = _bwHarnessRun({ args: ["status"], curlResponses: [{ match: "/status", body: "", exit: 7 }] });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(!(r.stdout === "" && r.stderr === ""),
+    `must not reproduce the silent status=7/stdout=[]/stderr=[] signature this issue exists to kill; stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stderr.includes("proxy unreachable"), `expected a diagnostic naming the proxy, got stderr=${JSON.stringify(r.stderr)}`);
+  assert.equal(r.stdout, "", `the diagnostic belongs on stderr, not stdout (a consumer piping 'ocp status' output must not read it as data); got stdout=${JSON.stringify(r.stdout)}`);
+});
+
+test("#273 cmd_status: curl missing from $PATH must be reported as a local fault, not 'proxy unreachable' or silence", () => {
+  const r = _bwHarnessRun({ args: ["status"], curlAbsent: true });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(!(r.stdout === "" && r.stderr === ""), `must not be silent; stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(!r.stderr.includes("proxy unreachable") && !r.stdout.includes("proxy unreachable"),
+    `must NOT misattribute a missing curl binary to the proxy; stderr=${JSON.stringify(r.stderr)} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(/curl/i.test(r.stderr), `expected the message to name curl/the local command failure, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#273 control: cmd_status with curl present and the proxy genuinely reachable still prints the (pretty-printed) status body (proves the fix does not just replace one silence with another)", () => {
+  const r = _bwHarnessRun({ args: ["status"], curlResponses: [{ match: "/status", body: JSON.stringify({ ok: true, uptime: "1h" }) }] });
+  assert.equal(r.status, 0, `expected a clean exit, got status=${r.status} stderr=${r.stderr}`);
+  assert.ok(r.stdout.includes('"ok"') && r.stdout.includes("true"), `expected the status JSON on stdout, got: ${JSON.stringify(r.stdout)}`);
+  assert.equal(r.stderr, "", `a successful run must not print anything to stderr; got: ${JSON.stringify(r.stderr)}`);
+});
+
+test("#273 cmd_settings PATCH: the money test — curl present but the proxy genuinely unreachable must not be COMPLETELY SILENT (reproduces the exact status=7/stdout=[]/stderr=[] signature)", () => {
+  const r = _bwHarnessRun({ args: ["settings", "maxPromptChars", "200000"], curlResponses: [{ match: "/settings", body: "", exit: 7 }] });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(!(r.stdout === "" && r.stderr === ""),
+    `must not reproduce the silent signature this issue exists to kill; stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(r.stderr.includes("proxy unreachable"), `expected a diagnostic naming the proxy, got stderr=${JSON.stringify(r.stderr)}`);
+  assert.equal(r.stdout, "", `the diagnostic belongs on stderr, not stdout; got stdout=${JSON.stringify(r.stdout)}`);
+});
+
+test("#273 cmd_settings PATCH: curl missing from $PATH must be reported as a local fault, not 'proxy unreachable' or silence (reproduces the exact status=127/stdout=[]/stderr=[] signature)", () => {
+  const r = _bwHarnessRun({ args: ["settings", "maxPromptChars", "200000"], curlAbsent: true });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(!(r.stdout === "" && r.stderr === ""), `must not be silent; stdout=${JSON.stringify(r.stdout)} stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(!r.stderr.includes("proxy unreachable") && !r.stdout.includes("proxy unreachable"),
+    `must NOT misattribute a missing curl binary to the proxy; stderr=${JSON.stringify(r.stderr)} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(/curl/i.test(r.stderr), `expected the message to name curl/the local command failure, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#273 control: cmd_settings PATCH with curl present and the proxy genuinely reachable still reports the result (proves the fix does not just replace one silence with another)", () => {
+  const r = _bwHarnessRun({
+    args: ["settings", "maxPromptChars", "200000"],
+    curlResponses: [{ match: "/settings", body: JSON.stringify({ maxPromptChars: { value: 200000 } }) }],
+  });
+  assert.equal(r.status, 0, `expected a clean exit, got status=${r.status} stderr=${r.stderr}`);
+  assert.ok(r.stdout.includes("maxPromptChars = 200000"), `expected the success line, got: ${JSON.stringify(r.stdout)}`);
+  assert.equal(r.stderr, "", `a successful run must not print anything to stderr; got: ${JSON.stringify(r.stderr)}`);
+});
+
+test("#273 non-regression: cmd_settings PATCH still surfaces server-side VALIDATION errors from a 2xx-or-not JSON body (the reason this call site deliberately omits curl's -f)", () => {
+  // A validation failure is NOT a network fault -- the server answered, just with an `errors`
+  // array instead of an accepted value. `_curl_or_die` must not be handed `-f` here, or curl
+  // would swallow this body on a non-2xx response and this path would misreport a validation
+  // failure as "proxy unreachable" -- a DIFFERENT misdiagnosis in the same family this issue is
+  // about, and one the fix could easily introduce by reflexively copying `-sf` from other sites.
+  const r = _bwHarnessRun({
+    args: ["settings", "maxPromptChars", "999999999"],
+    curlResponses: [{ match: "/settings", body: JSON.stringify({ errors: ["maxPromptChars must be <= 1000000"] }), exit: 0 }],
+  });
+  assert.equal(r.status, 0, `a validation rejection is not a crash; expected a clean exit, got status=${r.status} stderr=${r.stderr}`);
+  assert.ok(r.stdout.includes("maxPromptChars must be <= 1000000"), `expected the server's validation message, got stdout=${JSON.stringify(r.stdout)}`);
+});
+
+test("#273 stream parity: cmd_status / cmd_settings PATCH 'proxy unreachable' guards write to stderr, stdout stays empty (matches the #242/#261 sibling sites)", () => {
+  const status = _bwHarnessRun({ args: ["status"] });
+  assert.notEqual(status.status, 0, `expected a nonzero exit; status=${status.status}`);
+  assert.equal(status.stdout, "", `cmd_status: stdout must stay clean of the error text; got: ${JSON.stringify(status.stdout)}`);
+  const settings = _bwHarnessRun({ args: ["settings", "maxPromptChars", "200000"] });
+  assert.notEqual(settings.status, 0, `expected a nonzero exit; status=${settings.status}`);
+  assert.equal(settings.stdout, "", `cmd_settings PATCH: stdout must stay clean; got: ${JSON.stringify(settings.stdout)}`);
+});
+
 console.log("\nRestart-unit resolution (issue #233 defect 1) — macOS lsof exit-code handling:");
 
 // Background: `lsof -nP -iTCP:<port> -sTCP:LISTEN` EXITS 1 with EMPTY stdout when nothing


### PR DESCRIPTION
## Summary

Fixes the two sites #273 named, plus a third of the identical severity found during this PR's own independent review (Iron Rule 10) before merge.

**1. `cmd_status` (`ocp:253` pre-fix)** — a bare `curl -sf ... | _json` pipeline with no failure handling. Under `-sf`, curl suppresses its own diagnostic text on a genuine connection failure too, not only HTTP error bodies, so a real "proxy is down" case produced a nonzero exit with stdout AND stderr both completely empty. Verified directly (not assumed) before writing the fix: a real curl against a closed port exits 7 silently on both streams; a shadow-stubbed curl exiting 127 ("not on `$PATH`") is exactly as silent. This is the command an operator runs first when something looks wrong, and it answered by saying nothing at all.

**2. `cmd_settings` PATCH (`ocp:951-953` pre-fix)** — a fourth `2>&1`-into-capture site, literally the shape `_curl_or_die`'s own comment describes. Because the assignment was plain (not `local result=$(...)`, which would mask the exit status from `set -e`), a curl-exec failure (127, curl missing from `$PATH`) tripped `errexit` immediately, discarding the `2>&1`-captured diagnostic along with it before the response could ever be inspected: status=127, stdout=[], stderr=[].

**3. `cmd_health` (`ocp:284-286` pre-fix, found by the independent reviewer, not in #273's own text)** — byte-for-byte the same bare-pipeline shape as `cmd_status`, 14 lines below it, and just as silent under the identical two fault modes. The reviewer's Iron Rule 11 argument for fixing it here rather than deferring: it's the same severity as this PR's own two sites (total silence in both fault modes), not the lower severity already deferred to #278 (see below) — bundling same-severity work into a lower-severity follow-up is the one split that rule does not license.

## Fix

All three routed through the existing `_curl_or_die` helper (#261/#267) — no new mechanism.

`cmd_status` and `cmd_health` needed a different shape than a plain captured assignment: they still pipe the verified-successful body onward into `_json` (`python3 -m json.tool 2>/dev/null || cat`) afterward, which none of the three #261 sites needed (they fed the captured value straight into their own `python3 -c "..."` heredoc).

`cmd_settings` PATCH deliberately keeps curl's `-f` flag **omitted** — the server can answer with a 2xx-or-not body carrying a validation `errors` array, which the existing code must still be able to read; `-f` would make curl swallow that body on a non-2xx response. Proven load-bearing by a mutation test (see below).

Also fixed a comment going stale under this PR's own additions: `_curl_or_die`'s usage comment used to say "plain `curl` for the one unauthenticated [call site]" — now four (`cmd_usage` main, `cmd_status`, `cmd_settings` PATCH, `cmd_health`).

**Scope note (ALIGNMENT.md):** `ocp` is a bash CLI wrapper around the proxy's HTTP API, not `server.mjs`. ALIGNMENT.md's Rules govern `server.mjs`'s wire behavior, not this file — does not touch `server.mjs`, so no `cli.js` citation applies. Wire-neutral besides: identical URL/method/headers/body/flags at every site except the `2>&1`/bare-pipeline shape itself, so the Class B `/status`, `/health`, `/settings` grandfather freeze (ALIGNMENT.md, "frozen at their current behaviour as of v3.16.4") is untouched — no ADR needed.

## Evidence — RED then GREEN

Baseline on `origin/main` (`6cb930f`): **852 passed, 0 failed** (established before writing any test).

**RED, cmd_status + cmd_settings PATCH** (8 new tests added, `ocp` unmodified): **856 passed, 4 failed** — exactly the 4 money tests:

```
✗ #273 cmd_status: the money test — curl present but the proxy genuinely unreachable must not be
  COMPLETELY SILENT (reproduces the exact status=7/stdout=[]/stderr=[] signature): must not
  reproduce the silent status=7/stdout=[]/stderr=[] signature this issue exists to kill;
  stdout="" stderr=""
✗ #273 cmd_status: curl missing from $PATH must be reported as a local fault, not 'proxy
  unreachable' or silence: must not be silent; stdout="" stderr=""
✗ #273 cmd_settings PATCH: the money test — curl present but the proxy genuinely unreachable
  must not be COMPLETELY SILENT (reproduces the exact status=7/stdout=[]/stderr=[] signature):
  must not reproduce the silent signature this issue exists to kill; stdout="" stderr=""
✗ #273 cmd_settings PATCH: curl missing from $PATH must be reported as a local fault, not
  'proxy unreachable' or silence (reproduces the exact status=127/stdout=[]/stderr=[]
  signature): must not be silent; stdout="" stderr=""
```

**GREEN:** 860 passed, 0 failed.

**RED, cmd_health** (4 more tests added, on top of the fix above): **862 passed, 2 failed** — exactly the 2 new money tests:

```
✗ #273 cmd_health: the money test — curl present but the proxy genuinely unreachable must not be
  COMPLETELY SILENT (reproduces the exact status=7/stdout=[]/stderr=[] signature): must not
  reproduce the silent status=7/stdout=[]/stderr=[] signature this issue exists to kill;
  stdout="" stderr=""
✗ #273 cmd_health: curl missing from $PATH must be reported as a local fault, not 'proxy
  unreachable' or silence: must not be silent; stdout="" stderr=""
```

**GREEN (final):** **864 passed, 0 failed**. All 12 new tests pass.

## Mutation testing

Every mutation applied to the live `ocp` file, verified via `grep -c` that the exact anchor text existed before mutating, restored via `cp` from a pre-mutation backup (never `git checkout --`), confirmed byte-identical via `shasum -a 256` before and after every restore.

| # | Mutation | Result | Named test(s) that fail | Verdict |
|---|---|---|---|---|
| 1 | Revert `cmd_status` entirely to the original bare pipeline | 858 passed, 2 failed | `#273 cmd_status: the money test...`, `#273 cmd_status: curl missing from $PATH...` | Killed, no collateral |
| 2 | Revert `cmd_settings` PATCH entirely to the original `2>&1`-capture shape | 858 passed, 2 failed | `#273 cmd_settings PATCH: the money test...`, `#273 cmd_settings PATCH: curl missing from $PATH...` | Killed, no collateral |
| 3 | Change `cmd_status`'s `_curl_or_die` label from `"proxy unreachable"` to `"something went wrong"` | 859 passed, 1 failed | `#273 cmd_status: the money test...` (message-content assertion) | Killed |
| 4 | Same label mutation on `cmd_settings` PATCH | 859 passed, 1 failed | `#273 cmd_settings PATCH: the money test...` (message-content assertion) | Killed |
| 5 | Add `-f` back to the `cmd_settings` PATCH curl call (the exact regression this fix could introduce by reflexively copying `-sf` from other sites) | 860 passed, 0 failed | none | **Survived — genuine harness limitation, not proof of safety.** The fake `curl` stub's `curlResponses` fixture always exits with the caller-specified code regardless of `-f`/any flag — it has no concept of real curl's fail-on-non-2xx semantics. No test in this suite can currently distinguish "`-f` present" from "`-f` absent" at this call site. Confirmed the underlying JSON-error-extraction logic this call site depends on IS covered (mutation 6 below); the gap is specifically `-f`'s HTTP-status-driven behavior, which the harness cannot simulate without new infrastructure. Documented here rather than silently claimed as covered — flagged to the independent reviewer, who confirmed the honesty of this disclosure by reading the stub generator directly. |
| 6 | (Confirmatory, not part of this PR's diff) Neuter the pre-existing validation-error extraction (`errs=d.get('errors',[])` → `errs=[]`) | 859 passed, 1 failed | `#273 non-regression: cmd_settings PATCH still surfaces server-side VALIDATION errors...` | Killed — confirms mutation 5's surviving guard has real, if narrower, coverage: the non-regression test protects the JSON-parsing path, just not the `-f`-flag-specific HTTP-status behavior |
| 7 | Remove `\|\| exit 1` from `cmd_status`'s `_curl_or_die` guard | 860 passed, 0 failed | none | Survived, but a benign reason, not a gap: `data` is declared via a separate `local data` statement, so the following plain `data=$(...)` assignment is already subject to `set -e` errexit on a nonzero exit — verified this by removing the guard and confirming no observable behavior changed. Kept for explicit intent, matching the sibling `cmd_usage`/`cmd_keys add` call sites' own `\|\| exit 1` convention. |
| 8 | Remove `\|\| return 1` from `cmd_settings` PATCH's guard | 860 passed, 0 failed | none | Same benign reason as #7 |
| 9 | Revert `cmd_health` entirely to the original bare pipeline | 862 passed, 2 failed | `#273 cmd_health: the money test...`, `#273 cmd_health: curl missing from $PATH...` | Killed, no collateral |
| 10 | Change `cmd_health`'s `_curl_or_die` label to `"something went wrong"` | 863 passed, 1 failed | `#273 cmd_health: the money test...` (message-content assertion) | Killed |

## The seven lower-priority sites, an eighth found, and the reviewer's ninth

Per #273's own text, seven further sites print "proxy unreachable" for a local fault without misattributing bash's own message (lower severity — the operator still sees the true diagnostic, just alongside a wrong headline): `cmd_logs` (`ocp:310`), `cmd_models` (`ocp:345`), `cmd_sessions` (`ocp:365`), `cmd_clear` (`ocp:389`), `cmd_keys revoke` (`ocp:453`), `cmd_keys` list (`ocp:477`), `cmd_settings` GET (`ocp:937`).

While surveying the file for these, I also found an eighth, previously untracked site: `cmd_connect`'s health probe (`ocp:557`) actively discards curl's own stderr via `2>/dev/null` — the exact swallow class this whole lineage exists to remove, higher severity than the seven above since it IS a silence.

**Decision: neither in this PR.** Both filed as #278, per Iron Rule 11 (minimum reviewable unit — one PR per severity). Materially different, lower-severity defect class than the sites this PR fixes (visible-but-mislabeled vs. completely silent/misattributed), and bundling them here would repeat exactly the scope-widening #273 itself was filed to avoid.

The independent reviewer then found a **third same-severity site my own survey missed**: `cmd_health`, described above — total silence, not "visible but mislabeled," so it does not belong in #278's bucket at all. Fixed directly in this PR instead (second commit), per the reviewer's own reasoning. #278 is unaffected — it never listed `cmd_health`, so no correction needed there.

## No port literals

Verified via diff grep — none introduced.

## Full suite

`npm test`: **864 passed, 0 failed** (final, post-restore, pre-push).

## Independent review (Iron Rule 10)

Reviewed by a fresh-context subagent in its own isolated worktree, independent of this implementation. Initial verdict was REQUEST CHANGES — the sole blocking finding was the missed `cmd_health` site, addressed in the second commit above (the reviewer explicitly offered "fix it here" as the preferred remediation). All other checks (scope, fix correctness, test rigor — behavioral not textual, spot-checked mutation claims, closing-keyword discipline, the #278 deferral decision, no port literals, full-suite count) passed independent verification with real command output, not asserted on trust.

Closes #273
