### PR TITLE
fix(ocp): rollback's git-checkout uses execArgv + validates fromCommit is a SHA

### DIFF
--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -965,6 +965,23 @@ async function runRollback(opts) {
   const meta = opts.mockSnapshotMeta ?? readSnapshot(target.path);
   if (!meta.fromCommit) throw new Error(`snapshot ${target.path} has no from-commit.txt`);
 
+  // SECURITY (issue #262): meta.fromCommit is read back from from-commit.txt, written by
+  // writeSnapshot() (scripts/lib/snapshot.mjs) from `git rev-parse HEAD`'s own output
+  // (runFullUpgrade phase 2, below) -- never from a CLI flag or any other user-supplied string.
+  // That is what makes interpolating it into a shell command safe TODAY, but the invariant was
+  // written down nowhere and enforced by nothing: a hand-edited snapshot directory, a future
+  // feature that lets an operator name/import a snapshot, or metadata restored from a backup
+  // could all produce a value that is no longer a bare SHA. `git rev-parse HEAD` always prints
+  // lowercase hex, 7 (short) to 40 (full) characters; anchored at both ends (matching the #257
+  // precedent in `_targetSemverParts` for the same "validate before using in a command" shape)
+  // so any value carrying anything else -- including shell metacharacters -- is refused before
+  // it ever reaches a command, belt-and-braces alongside the execArgv conversion below.
+  if (!/^[0-9a-f]{7,40}$/.test(meta.fromCommit)) {
+    throw new Error(
+      `snapshot ${target.path} has a malformed from-commit.txt (expected a git SHA, got: ${JSON.stringify(meta.fromCommit)})`
+    );
+  }
+
   const phases = [];
   if (opts.dryRun) {
     return {
@@ -1000,9 +1017,41 @@ async function runRollback(opts) {
       );
     }
   };
+  // SECURITY (issue #262, matching the #259 pattern already used by runFullUpgrade's own
+  // `execArgv` above): argv-form sibling of `exec`, for the one command in this function whose
+  // argument is read back from disk rather than being a fixed string -- `meta.fromCommit`.
+  // `execFileSync(file, args)` never invokes `/bin/sh`, so an argv element can never be
+  // reinterpreted as shell syntax, regardless of its content. `cmd` (the human-readable display
+  // string recorded into `phases`, matching every existing test's `.cmd.includes(...)`-style
+  // assertions) is built via `.join(" ")` purely for bookkeeping/display -- it is NEVER itself
+  // executed. Error/phase shape matches this function's own `exec` above (`{phases, target:
+  // target.path}`), not runFullUpgrade's `execArgv` (`{phases, cmd}`) -- the two functions
+  // already use different error shapes for their existing failure sites and this stays
+  // consistent with runRollback's own convention rather than importing the sibling's.
+  const execArgv = (file, args, label) => {
+    const cmd = [file, ...args].join(" ");
+    if (opts.mockExec) {
+      phases.push({ name: label, cmd, status: "skipped-mock" });
+      return "";
+    }
+    try {
+      execFileSync(file, args, { stdio: ["pipe", "pipe", "pipe"] });
+      phases.push({ name: label, cmd, status: "ok" });
+    } catch (err) {
+      const detail = err.stderr?.toString().trim();
+      phases.push({ name: label, cmd, status: "fail", stderr: detail });
+      throw Object.assign(
+        new Error(`rollback phase ${label} failed: ${detail || err.message}`),
+        { phases, target: target.path }
+      );
+    }
+  };
 
   const ocpDir = opts.ocpDir || join(homedir(), "ocp");
-  exec(`git -C ${ocpDir} checkout ${meta.fromCommit}`, "git-checkout");
+  // Issue #262: was `exec(\`git -C ${ocpDir} checkout ${meta.fromCommit}\`, "git-checkout")` --
+  // a shell template string carrying a disk-read value. Now argv form; see execArgv above and
+  // the SHA-shape validation above meta.fromCommit is first read.
+  execArgv("git", ["-C", ocpDir, "checkout", meta.fromCommit], "git-checkout");
 
   if (!opts.mockExec) {
     const tryCopy = (src, dst) => {

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -3420,6 +3420,101 @@ test("#274: rollback post-flight is skipped-mock under plain mockExec with no in
   assert.equal(pf.status, "skipped-mock");
 });
 
+// ── #262 SECURITY (same shape as #257's injection, on the rollback path) ───────────────────────
+// meta.fromCommit is read back from from-commit.txt inside the snapshot directory and was
+// interpolated into an `exec()` shell template string for `git -C ${ocpDir} checkout
+// ${meta.fromCommit}`. Today that value always originates from OCP's own `git rev-parse HEAD`
+// (writeSnapshot, scripts/lib/snapshot.mjs) — there is no path from a CLI flag to it — but
+// nothing enforced that invariant on the read side. Fix has two independent layers, mirroring
+// #259's precedent for the sibling upgrade-path sites: (1) an anchored git-SHA-shape check
+// before meta.fromCommit is used for anything, and (2) execArgv (execFileSync argv form, never
+// /bin/sh) for the checkout call itself.
+//
+// mockExec:false is deliberate and required for the money test below: mockExec:true would skip
+// the real git call entirely, so the vulnerable shell-interpolation line (or its fixed
+// execArgv replacement) would never actually run — the injection could only ever be
+// demonstrated, or ruled out, with real execution. Safe to run for real: with layer (1) intact,
+// validation throws before ANY phase (including the dry-run preview branch) is ever reached —
+// no snapshot listing beyond the injected mocks, no exec/execArgv call, nothing mutates.
+console.log("\nRollback checkout argv-form + fromCommit validation (issue #262):");
+
+test("#262 SECURITY: a snapshot fromCommit carrying shell metacharacters is refused AND never reaches a shell (marker file must not exist)", async () => {
+  const scratchDir = _ltMkdtemp(join(_ltTmp(), "ocp-262-injection-"));
+  try {
+    const markerPath = join(scratchDir, "PWNED");
+    const payload = `abc1234 ; touch ${markerPath} ; false`;
+    let caught = null;
+    try {
+      await runUpgrade({
+        rollback: true, yes: true, mockExec: false, ocpDir: scratchDir,
+        mockSnapshots: [{ name: "upgrade-snapshot-2026-05-11T08:30:00Z", path: scratchDir }],
+        mockSnapshotMeta: { fromCommit: payload, fromVersion: "v3.10.0", toVersion: "v3.14.0", path: scratchDir },
+      });
+    } catch (e) { caught = e; }
+    // Deliberately does NOT assert on caught.message / which layer refused it (that is covered
+    // separately, and precisely, by the two non-metacharacter tests below). This test asserts
+    // exactly one property, checked FIRST so it is never short-circuited by an unrelated
+    // message-format change: the payload's injected command must never execute, regardless of
+    // which of the two independent layers (SHA-shape validation, or execArgv's argv form) is
+    // the one that happened to stop it.
+    assert.ok(!_ltExists(markerPath),
+      `SECURITY: the payload's injected command must NEVER execute -- a marker file at ` +
+      `${markerPath} would prove fromCommit reached a real shell.`);
+    assert.ok(caught, "a shell-metacharacter fromCommit must be refused, not silently accepted");
+  } finally {
+    _ltRm(scratchDir, { recursive: true, force: true });
+  }
+});
+
+// Isolates the ANCHORED-REGEX layer specifically from the metacharacter-payload test above: this
+// payload carries no shell metacharacters at all, so it cannot be caught by execArgv's "never
+// invokes /bin/sh" property — only the SHA-shape validation can refuse it. Distinguishes "the
+// guard actually validates shape" from "the guard only happens to catch strings with `;` in
+// them".
+test("#262: a from-commit.txt value that is not a git SHA (no shell metacharacters at all) is refused, not silently accepted", async () => {
+  await assert.rejects(async () => {
+    await runUpgrade({
+      rollback: true, yes: true, mockExec: true,
+      mockSnapshots: [{ name: "upgrade-snapshot-2026-05-11T08:30:00Z", path: "/tmp/snap-x" }],
+      mockSnapshotMeta: { fromCommit: "not-a-real-sha-at-all", fromVersion: "v3.10.0", toVersion: "v3.14.0", path: "/tmp/snap-x" },
+    });
+  }, /malformed from-commit\.txt/);
+});
+
+test("#262: an uppercase-hex fromCommit is refused — git rev-parse HEAD only ever emits lowercase, so uppercase means the value did not come from that call", async () => {
+  await assert.rejects(async () => {
+    await runUpgrade({
+      rollback: true, yes: true, mockExec: true,
+      mockSnapshots: [{ name: "upgrade-snapshot-2026-05-11T08:30:00Z", path: "/tmp/snap-x" }],
+      mockSnapshotMeta: { fromCommit: "ABC1234", fromVersion: "v3.10.0", toVersion: "v3.14.0", path: "/tmp/snap-x" },
+    });
+  }, /malformed from-commit\.txt/);
+});
+
+test("#262: a too-short fromCommit (6 hex chars, one short of git's minimum abbreviation) is refused", async () => {
+  await assert.rejects(async () => {
+    await runUpgrade({
+      rollback: true, yes: true, mockExec: true,
+      mockSnapshots: [{ name: "upgrade-snapshot-2026-05-11T08:30:00Z", path: "/tmp/snap-x" }],
+      mockSnapshotMeta: { fromCommit: "abc123", fromVersion: "v3.10.0", toVersion: "v3.14.0", path: "/tmp/snap-x" },
+    });
+  }, /malformed from-commit\.txt/);
+});
+
+test("#262 control: a full 40-char lowercase-hex fromCommit (a real, non-abbreviated git SHA) is accepted, proving the guard is not accidentally 7-chars-only", async () => {
+  const result = await runUpgrade({
+    rollback: true, yes: true, mockExec: true,
+    mockSnapshots: [{ name: "upgrade-snapshot-2026-05-11T08:30:00Z", path: "/tmp/snap-x" }],
+    mockSnapshotMeta: {
+      fromCommit: "0123456789abcdef0123456789abcdef01234567",
+      fromVersion: "v3.10.0", toVersion: "v3.14.0", path: "/tmp/snap-x",
+    },
+  });
+  assert.equal(result.path, "rollback");
+  assert.equal(result.executed, true);
+  assert.ok(result.phases.some(p => p.name === "git-checkout"));
+});
+
 test("gcSnapshots keeps last N regardless of age", () => {
   const root = mkdtempSync(testJoin(tmpdir(), "ocp-gc-test-"));
   const dotOcp = testJoin(root, ".ocp");


### PR DESCRIPTION
## Summary

`runRollback()` (scripts/upgrade.mjs) did
`exec(\`git -C ${ocpDir} checkout ${meta.fromCommit}\`, "git-checkout")` --
`meta.fromCommit` is read back from `from-commit.txt` inside the snapshot directory and was
interpolated into a template string that `execSync` hands to `/bin/sh`. Same shape as #257, on
the rollback path specifically -- PR #259's hardening of the sibling upgrade-path sites did not
cover this one. Fixed with the same pattern #259 established: an anchored shape check, plus
`execFileSync(file, [args])` argv form.

Does not touch `server.mjs` (scoped entirely to `scripts/upgrade.mjs` and `test-features.mjs`).

## Endpoint Class (REQUIRED)

- [x] **Not endpoint-touching** — CLI upgrade-tooling change; does not modify any request handler in `server.mjs`.

## Severity (stated as the issue itself does)

Not a live vulnerability today. `meta.fromCommit` originates from OCP's own `git rev-parse HEAD`
(`writeSnapshot`, `scripts/lib/snapshot.mjs`) -- there is no path from a CLI flag to it, and
writing the snapshot metadata file already requires running as the service owner. This is
defense in depth on the recovery path: the invariant that makes it safe today ("`fromCommit` is
always a git-generated SHA") was written down nowhere and enforced by nothing.

## Fix — two independent layers (the #259 precedent)

1. **Shape validation.** `/^[0-9a-f]{7,40}$/` (matching `git rev-parse HEAD`'s own lowercase-hex,
   7-to-40-char output) on `meta.fromCommit`, checked before it is used for anything, including
   the `--dry-run` preview branch. A malformed value refuses loudly with no git command run.
2. **`execArgv`** (an `execFileSync` argv-form sibling added to `runRollback`, mirroring
   `runFullUpgrade`'s existing `execArgv`), replacing `exec()` for the git-checkout call.
   `execFileSync` never invokes `/bin/sh`.

## execSync audit (requested by the issue)

Every remaining `execSync`/`exec` template literal in `scripts/upgrade.mjs`:

| Site | Interpolated value | Origin | Structurally constrained? |
|---|---|---|---|
| `runPostFlightCheck` — `curl .../health` | `port` | `process.env.CLAUDE_PROXY_PORT \|\| DEFAULT_PORT` | No — conventionally a port number, process-internal (env var), never read back from a file another process wrote |
| `runFullUpgrade` phase 6 — `curl .../health`, `curl .../v1/models` | `port` | same as above | Same |
| `runFullUpgrade` — `git fetch`, `git rev-parse HEAD`, `npm install`, `node setup.mjs` | `ocpDir` | `opts.ocpDir \|\| join(homedir(), "ocp")`, or `dirname(dirname(import.meta.url))` | No — process-internal, not adversary-reachable, but not regex-anchored either |
| `runRollback` — `npm install` | `ocpDir` | same as above | Same |
| `runFreshInstall` — `execSync(cmd, {stdio:"inherit"})` | `cmd` | `doctor.next_action.ai_executable`, a fixed array literal in `scripts/doctor.mjs` | Fully code-controlled, not disk-read; different risk class entirely |

None of the above carries a value with the same "written to disk by one call, read back by
another process invocation, potentially days apart" shape that made `meta.fromCommit` worth
closing specifically -- they are all either literal `process.env`/`homedir()`-derived values or a
fixed source-level constant. Flagged here per the issue's own "consider auditing the remaining
sites" ask; no code change proposed for them in this PR (would be scope creep beyond #262, and
`ocpDir`/`port` do not have an analogous "on-disk, cross-invocation" trust boundary to validate
against).

## Test plan

- [x] 5 new named tests under `test-features.mjs` § "Rollback checkout argv-form + fromCommit
      validation (issue #262)": a real (`mockExec:false`), non-mocked injection proof using a
      disposable scratch dir + marker-file check (same technique as the existing #257 SECURITY
      test), an isolated non-metacharacter shape test, an uppercase-hex rejection test, a
      too-short rejection test, and a 40-char-SHA control.
- [x] 4 of 5 fail on pre-fix `scripts/upgrade.mjs` (853 passed / **4 failed**, named above) --
      notably, the injection test's marker file is **actually created** on pre-fix code, an
      empirical reproduction of the vulnerability, not just a refusal-message check. All 5 pass
      after the fix (857 passed / 0 failed).
- [x] Mutation table (3 mutations, restored from file backup + `shasum -a 256` each time, never
      `git checkout --`):
  - **(A) SHA-validation neutered alone** → the 3 shape-specific tests fail by name; the
    SECURITY test's core "no marker file" assertion *survives* -- because `execArgv`
    independently still blocks the payload. Documented as real redundant coverage, not a gap.
  - **(B) `execArgv` reverted to the old shell-template form alone, validation intact** → no
    test fails. Correct and expected, not a gap: once validation holds, no value that can reach
    this line differs in behavior between `exec` and `execArgv` (a validated pure-hex string has
    no shell-special meaning either way) -- this specific combination is unreachable by
    construction, not uncovered.
  - **(C) both A and B together** → reproduces the original vulnerability exactly (marker file
    created again, same failure signature as the pre-fix run) -- proves `execArgv` was doing
    real independent work in (A), not decorative.
- [x] Full `npm test` green: **857 passed, 0 failed**.

## Type of change

- [x] Bug fix (security hardening / defense in depth)

## Reviewer checklist

- [ ] Confirmed the `/^[0-9a-f]{7,40}$/` anchor matches `git rev-parse HEAD`'s real output shape
      (lowercase hex, no `git rev-parse --short` truncation below 7 observed in practice).
- [ ] Confirmed `execArgv`'s error/phase shape (`{phases, target: target.path}`) intentionally
      matches `runRollback`'s own `exec` convention rather than `runFullUpgrade`'s sibling
      (`{phases, cmd}`) -- the two functions already use different shapes for their pre-existing
      failure sites.
- [ ] Reviewed the execSync audit table above and agrees no other site in this file shares
      `meta.fromCommit`'s on-disk, cross-invocation trust boundary.
- [ ] Reran (or reviewed) the 3-mutation table and agrees mutation (B)'s "survival" is genuine
      redundancy, not a gap, given mutation (C) proves the combination is real.
- [ ] I am not the commit author of any commit in this PR (Iron Rule 10).

## Related

- `ALIGNMENT.md` Rule(s) invoked: none (no `server.mjs` change; no endpoint touched)
- Related issue / prior PR: #262; refs #257, #259
