### PR TITLE
fix(setup): distinguish 'could not run' from 'ran, found nothing' in the post-install bind check

### DIFF
--- a/scripts/lib/start-sh.mjs
+++ b/scripts/lib/start-sh.mjs
@@ -211,10 +211,39 @@ fi
 // found nothing" at the call site. `existsSyncFn` threads through to resolveBinaryPath() so
 // tests can pick either branch deterministically regardless of what is actually installed on
 // the host running the suite.
+//
+// Independent review round 1 (MED-2): the linux branch used to be `ss -tlnp | grep ':${port}'`.
+// A `| grep` pipe reports GREP's own exit status, not `ss`'s -- verified live: `ssnotreal -tlnp
+// | grep :N` under both bash and dash exits 1 (grep's own "no match" status), never 127, even
+// though `ss` itself never ran. That made classifyBindCheck()'s exit-127/126 check dead code on
+// Linux, and the port-match filtering is now done in JS (ssLineMatchesPort, below) against the
+// UNFILTERED `ss -tlnp` output instead, so the real exit status of `ss` itself survives.
+// (Rejected alternative, verified live and NOT viable: `sh -o pipefail` -- dash, which is
+// `/bin/sh` on this project's own documented Linux hosts -- Debian/Ubuntu/Raspberry Pi OS --
+// rejects `-o pipefail` outright ("Illegal option"), which would break the bind-check on every
+// single run there, not just the missing-binary case.)
 export function buildBindCheckCommand({ port, platform = process.platform, lsofPath = "/usr/sbin/lsof", existsSyncFn = realExistsSync }) {
   return platform === "linux"
-    ? `ss -tlnp | grep ':${port}'`
+    ? `ss -tlnp`
     : `${resolveBinaryPath(lsofPath, "lsof", existsSyncFn)} -nP -iTCP:${port} -sTCP:LISTEN`;
+}
+
+// Matches one line of `ss -tlnp` output against a target port (issue #246, second half, MED-2).
+// `ss`'s "Local Address:Port" column format varies (IPv4 `0.0.0.0:PORT` / `*:PORT`, IPv6
+// `[::]:PORT` / `*:PORT`), so this splits on the LAST ':' rather than assuming a fixed prefix
+// shape -- correctly handles IPv6's own embedded colons. Anchored on the FULL numeric suffix
+// (not a substring/`.includes(':PORT')` check), so an adjacent port that merely contains our
+// port's digits (e.g. target port 8080 vs an unrelated real listener on 18080) is never misread
+// as a match -- mirrors darwinListeningCheck()'s own netstat suffix-anchoring guard (the bash
+// `case *".$PORT")` above) in JS form, applied to `ss`'s different column layout.
+function ssLineMatchesPort(line, port) {
+  const cols = line.trim().split(/\s+/);
+  if (cols[0] !== "LISTEN") return false;
+  const localAddr = cols[3];
+  if (!localAddr) return false;
+  const idx = localAddr.lastIndexOf(":");
+  if (idx === -1) return false;
+  return localAddr.slice(idx + 1) === String(port);
 }
 
 // Runs buildBindCheckCommand()'s command via an injectable execFn (defaulting to the real
@@ -234,23 +263,45 @@ export function buildBindCheckCommand({ port, platform = process.platform, lsofP
 //   - "empty":         the tool ran fine and found nothing -- unchanged from today's silence.
 //   - "could-not-run": the tool itself never produced a real "no match" -- surface `detail`.
 //
+// `stdio: ["ignore", "pipe", "pipe"]` is REQUIRED here, not decorative (independent review
+// round 1, MED-1): Node's execSync, given no `stdio` option at all, inherits the child's
+// stderr to THIS process's own real stderr in addition to (on the throw path) capturing it
+// into `e.stderr` -- verified live, on BOTH the success and throw paths, with plain
+// `execSync(cmd, { encoding: "utf-8" })`. Left as the default, that silently broke the
+// "empty" contract documented two paragraphs up: an "empty" or even "found" classification is
+// NOT actually silent if the underlying tool wrote anything to its own stderr along the way
+// (a permission warning, a deprecation notice, anything) -- it leaks straight to the
+// installer's console, unprefixed, indistinguishable from real program output. Explicit
+// `stdio: ["pipe","pipe","pipe"]`-equivalent options fully suppress the inherit path while
+// leaving `e.stderr` capture on the throw path and the stdout return value on success both
+// intact (verified live, same script).
+//
 // The empty/could-not-run boundary is inherently heuristic: Node's execSync collapses "tool
 // ran, exited nonzero with nothing to say" (lsof/grep's own plain "no match" exit) and "the
 // shell could not even start the tool" into the same thrown-error shape. Classified here by
 // exit status 127/126 (POSIX "command not found" / "found but not executable") or a small set
 // of shell-level phrases in the surfaced text -- the same style scripts/upgrade.mjs's
 // mapLsofFailureToProbeValue already uses for this repo's other lsof-failure classifiers.
+// The phrase list matches bare `\bnot found\b`, not only `"command not found"` (independent
+// review round 1, MED-2): dash -- `/bin/sh` on this project's own documented Linux hosts --
+// phrases a missing command as `sh: 1: ssnotreal: not found`, WITHOUT the word "command" at
+// all, verified live against a real `/bin/dash`; the narrower phrase silently missed exactly
+// the single most realistic could-not-run case on Linux (`ss` not installed).
 // Anything else (including no status at all, e.g. lsof/grep's own plain "no match" exit)
 // stays "empty" -- the unchanged, pre-#246(second-half) silent case.
 export function classifyBindCheck({ port, platform = process.platform, lsofPath = "/usr/sbin/lsof", existsSyncFn = realExistsSync, execFn = realExecSync }) {
   const cmd = buildBindCheckCommand({ port, platform, lsofPath, existsSyncFn });
   try {
-    const out = execFn(cmd, { encoding: "utf-8" }).trim();
+    const out = execFn(cmd, { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+    if (platform === "linux") {
+      const match = out.split("\n").find((line) => ssLineMatchesPort(line, port));
+      return match ? { kind: "found", line: match.trim() } : { kind: "empty" };
+    }
     return out ? { kind: "found", line: out.split("\n")[0] } : { kind: "empty" };
   } catch (e) {
     const text = String(e.stderr || e.message || "").trim();
     const couldNotRun = e.status === 127 || e.status === 126
-      || /command not found|no such file or directory|permission denied|enoent/i.test(text);
+      || /\bnot found\b|no such file or directory|permission denied|enoent/i.test(text);
     return couldNotRun
       ? { kind: "could-not-run", detail: text.split("\n")[0] || (e.status != null ? `exit ${e.status}` : "unknown error") }
       : { kind: "empty" };

--- a/scripts/lib/start-sh.mjs
+++ b/scripts/lib/start-sh.mjs
@@ -61,8 +61,23 @@
 // scenario -- the same scenario :293 fixes), but does NOT get the netstat cross-check:
 // that would add real complexity for a text-only line whose failure mode is already
 // non-functional, and the issue's own text agrees ("its own blast radius is smaller").
+//
+// Second half of issue #246 (this fix): the ABSOLUTE-PATH half of :426 was fixed alongside
+// :293 above, but two things stayed broken there, matching the issue's own text verbatim:
+// (1) BOTH branches of the bind-check command redirected the underlying tool's own stderr to
+// /dev/null, and (2) the surrounding `catch {}` was completely empty, discarding a genuinely-
+// nothing-there empty match and "lsof/ss itself could not run at all" identically. Verified
+// independently (not just taken on the issue's word) by tracing every assignment to `verified`
+// in setup.mjs's Step 8 block: it is set `true` unconditionally immediately after the bind-
+// check's try/catch, regardless of what happened inside it -- nothing downstream ever branches
+// on this block's outcome, confirming it stays a purely cosmetic diagnostic. Sized accordingly:
+// buildBindCheckCommand()/classifyBindCheck() below turn "any failure -> total silence" into "a
+// real tool-execution fault gets ONE honest diagnostic line, a genuine empty match stays exactly
+// as silent as before" -- no netstat cross-check, no privilege-gap classifier, nothing that
+// would only earn its complexity if something downstream actually acted on the distinction.
 
 import { existsSync as realExistsSync } from "node:fs";
+import { execSync as realExecSync } from "node:child_process";
 
 // Prefers `absolutePath` when it exists on this host, falling back to the bare
 // `fallbackName` (relying on $PATH, exactly the pre-#246 behavior) otherwise -- so a host
@@ -184,4 +199,60 @@ else
   echo "claude-proxy already running on port $PORT"
 fi
 `;
+}
+
+// Pure command-string builder for setup.mjs's Step 8 post-install bind-check (issue #246,
+// second half). No execution happens here -- classifyBindCheck() below is the only caller
+// that actually runs the returned string -- so this is testable with a plain return-value
+// assertion, no subprocess needed. Never appends `2>/dev/null` (or any other stderr redirect)
+// on EITHER platform branch: that redirect is the literal remaining defect the issue
+// describes for the old setup.mjs:426 body -- it threw the underlying tool's own stderr away,
+// which is exactly what made "lsof/ss itself is broken" indistinguishable from "ran fine,
+// found nothing" at the call site. `existsSyncFn` threads through to resolveBinaryPath() so
+// tests can pick either branch deterministically regardless of what is actually installed on
+// the host running the suite.
+export function buildBindCheckCommand({ port, platform = process.platform, lsofPath = "/usr/sbin/lsof", existsSyncFn = realExistsSync }) {
+  return platform === "linux"
+    ? `ss -tlnp | grep ':${port}'`
+    : `${resolveBinaryPath(lsofPath, "lsof", existsSyncFn)} -nP -iTCP:${port} -sTCP:LISTEN`;
+}
+
+// Runs buildBindCheckCommand()'s command via an injectable execFn (defaulting to the real
+// execSync) and classifies the outcome into exactly three kinds (issue #246, second half).
+// setup.mjs's Step 8 bind-check used to collapse every failure -- a genuine empty match AND
+// lsof/ss itself failing to execute -- into the same silent blank line, via a bare `catch {}`
+// sitting on top of a command that had already thrown its own stderr away with
+// `2>/dev/null`. This restores the distinction the operator needs WITHOUT changing anything
+// downstream: see this function's call site in setup.mjs, where `verified` is set true
+// unconditionally right after this block runs regardless of its outcome (traced end-to-end
+// for this fix -- nothing reads this function's return value except the one console.log/
+// warn() line at that call site), which is why this intentionally does NOT get
+// darwinListeningCheck()'s netstat privilege-gap cross-check above: that earns its complexity
+// only when something downstream actually acts on the distinction, and here nothing does.
+//
+//   - "found":         the tool ran and matched something -- print `line`.
+//   - "empty":         the tool ran fine and found nothing -- unchanged from today's silence.
+//   - "could-not-run": the tool itself never produced a real "no match" -- surface `detail`.
+//
+// The empty/could-not-run boundary is inherently heuristic: Node's execSync collapses "tool
+// ran, exited nonzero with nothing to say" (lsof/grep's own plain "no match" exit) and "the
+// shell could not even start the tool" into the same thrown-error shape. Classified here by
+// exit status 127/126 (POSIX "command not found" / "found but not executable") or a small set
+// of shell-level phrases in the surfaced text -- the same style scripts/upgrade.mjs's
+// mapLsofFailureToProbeValue already uses for this repo's other lsof-failure classifiers.
+// Anything else (including no status at all, e.g. lsof/grep's own plain "no match" exit)
+// stays "empty" -- the unchanged, pre-#246(second-half) silent case.
+export function classifyBindCheck({ port, platform = process.platform, lsofPath = "/usr/sbin/lsof", existsSyncFn = realExistsSync, execFn = realExecSync }) {
+  const cmd = buildBindCheckCommand({ port, platform, lsofPath, existsSyncFn });
+  try {
+    const out = execFn(cmd, { encoding: "utf-8" }).trim();
+    return out ? { kind: "found", line: out.split("\n")[0] } : { kind: "empty" };
+  } catch (e) {
+    const text = String(e.stderr || e.message || "").trim();
+    const couldNotRun = e.status === 127 || e.status === 126
+      || /command not found|no such file or directory|permission denied|enoent/i.test(text);
+    return couldNotRun
+      ? { kind: "could-not-run", detail: text.split("\n")[0] || (e.status != null ? `exit ${e.status}` : "unknown error") }
+      : { kind: "empty" };
+  }
 }

--- a/setup.mjs
+++ b/setup.mjs
@@ -18,7 +18,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from "node:fs";
 import { resolveServicePlan } from "./scripts/lib/service-mode.mjs";
 import { installAutoStart } from "./scripts/lib/install-autostart.mjs";
-import { buildStartSh, resolveBinaryPath } from "./scripts/lib/start-sh.mjs";
+import { buildStartSh, classifyBindCheck } from "./scripts/lib/start-sh.mjs";
 import { execSync } from "node:child_process";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
@@ -412,19 +412,22 @@ if (!DRY_RUN) {
         console.log(`    version:  ${body.version ?? "unknown"}`);
         console.log(`    authMode: ${body.authMode ?? "unknown"}`);
 
-        // Verify bind socket
-        try {
-          // issue #246: absolute path (falls back to bare `lsof` only if /usr/sbin/lsof
-          // genuinely does not exist on this host) -- see scripts/lib/start-sh.mjs's header
-          // for why this call site gets absolute-path-only rather than the full netstat
-          // cross-check buildStartSh()'s darwin branch uses.
-          const bindCheck = process.platform === "linux"
-            ? execSync(`ss -tlnp 2>/dev/null | grep ':${PORT}'`, { encoding: "utf-8" }).trim()
-            : execSync(`${resolveBinaryPath("/usr/sbin/lsof", "lsof")} -nP -iTCP:${PORT} -sTCP:LISTEN 2>/dev/null`, { encoding: "utf-8" }).trim();
-          if (bindCheck) {
-            console.log(`    bind:     ${bindCheck.split("\n")[0]}`);
-          }
-        } catch { /* bind check is best-effort */ }
+        // Verify bind socket. issue #246 (second half): classifyBindCheck() builds the same
+        // absolute-path-preferred lsof/ss command as before (see scripts/lib/start-sh.mjs's
+        // header for why this call site stays absolute-path-only, no netstat cross-check),
+        // but never redirects the underlying command's own stderr to /dev/null, and
+        // distinguishes "could not run" (a real tool-execution fault) from "ran, found
+        // nothing" (unchanged -- stays silent). The pre-fix body's bare `catch {}` discarded
+        // both identically. Cosmetic only: `verified` below is set true unconditionally
+        // regardless of this block's outcome -- the HTTP health check above already
+        // confirmed the server is up. See classifyBindCheck()'s own header for the full
+        // trace of why this stays a diagnostic line, not a gate.
+        const bindCheck = classifyBindCheck({ port: PORT, platform: process.platform });
+        if (bindCheck.kind === "found") {
+          console.log(`    bind:     ${bindCheck.line}`);
+        } else if (bindCheck.kind === "could-not-run") {
+          warn(`bind check could not run (${bindCheck.detail}) — cosmetic only, the health check above already confirmed the server is up`);
+        }
 
         verified = true;
       } else {

--- a/setup.mjs
+++ b/setup.mjs
@@ -422,12 +422,22 @@ if (!DRY_RUN) {
         // regardless of this block's outcome -- the HTTP health check above already
         // confirmed the server is up. See classifyBindCheck()'s own header for the full
         // trace of why this stays a diagnostic line, not a gate.
-        const bindCheck = classifyBindCheck({ port: PORT, platform: process.platform });
-        if (bindCheck.kind === "found") {
-          console.log(`    bind:     ${bindCheck.line}`);
-        } else if (bindCheck.kind === "could-not-run") {
-          warn(`bind check could not run (${bindCheck.detail}) — cosmetic only, the health check above already confirmed the server is up`);
-        }
+        //
+        // Independent review round 1 (LOW-1): classifyBindCheck() itself funnels every
+        // expected failure into a returned `kind` rather than throwing, so this inner
+        // try/catch is provably unreachable under normal use today -- but it costs nothing to
+        // keep, and it means an unforeseen future exception here can never silently skip
+        // `verified = true` below, which would misreport a genuinely healthy server as
+        // "did not respond" and exit 1. Insurance against this cosmetic diagnostic ever
+        // becoming load-bearing by accident, not a response to a live defect.
+        try {
+          const bindCheck = classifyBindCheck({ port: PORT, platform: process.platform });
+          if (bindCheck.kind === "found") {
+            console.log(`    bind:     ${bindCheck.line}`);
+          } else if (bindCheck.kind === "could-not-run") {
+            warn(`bind check could not run (${bindCheck.detail}) — cosmetic only, the health check above already confirmed the server is up`);
+          }
+        } catch { /* insurance only -- see comment above; classifyBindCheck() should never reach here */ }
 
         verified = true;
       } else {

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -3991,14 +3991,176 @@ test("buildStartSh non-darwin: bare lsof resolves fine via PATH (unchanged pre-#
 
 // Wiring/premise check (AGENTS.md's carve-out: legitimate for a harness's own boundary, not
 // for the decision logic itself -- the decision logic above is tested behaviorally). Confirms
-// setup.mjs actually calls the real buildStartSh()/resolveBinaryPath() rather than an inline
+// setup.mjs actually calls the real buildStartSh()/classifyBindCheck() rather than an inline
 // reimplementation drifting back in unnoticed.
-test("setup.mjs wiring: imports buildStartSh/resolveBinaryPath from scripts/lib/start-sh.mjs and no longer inlines a bare lsof call", () => {
+test("setup.mjs wiring: imports buildStartSh/classifyBindCheck from scripts/lib/start-sh.mjs and no longer inlines a bare lsof call", () => {
   const src = _ltRead(testJoin(import.meta.dirname, "setup.mjs"), "utf8");
   assert.match(src, /from ["']\.\/scripts\/lib\/start-sh\.mjs["']/, "setup.mjs must import from scripts/lib/start-sh.mjs");
   assert.match(src, /buildStartSh\(/, "setup.mjs must call buildStartSh()");
-  assert.match(src, /resolveBinaryPath\(/, "setup.mjs must call resolveBinaryPath()");
+  // issue #246 (second half): resolveBinaryPath's absolute-path preference is no longer
+  // called directly from setup.mjs -- it now lives entirely inside classifyBindCheck()
+  // (scripts/lib/start-sh.mjs), which setup.mjs's Step 8 calls instead. The old assertion
+  // here (`resolveBinaryPath(` must appear in setup.mjs) is stale as of this change and is
+  // replaced by classifyBindCheck() below plus the dedicated wiring test further down.
+  assert.match(src, /classifyBindCheck\(/, "setup.mjs must call classifyBindCheck()");
   assert.ok(!/\n\s*lsof -i :/.test(src), "setup.mjs must not re-inline the old bare `lsof -i :` check");
+});
+
+// ── scripts/lib/start-sh.mjs: buildBindCheckCommand / classifyBindCheck (issue #246, second
+// half -- setup.mjs's Step 8 post-install bind-check) ──────────────────────────────────────
+// setup.mjs itself still can never be executed by this suite (see the section header above
+// and AGENTS.md's "NEVER run setup.mjs" constraint) -- same rationale, same extraction
+// pattern, applied to the SECOND of setup.mjs's two lsof call sites (the first, :293's
+// port-liveness gate, was fixed by the section above; PR #269). This one is a pure
+// diagnostic-line builder (see classifyBindCheck()'s own header in start-sh.mjs for the full
+// trace of why `verified` never depends on its outcome), so its money test only needs to
+// prove real-subprocess stderr-preservation, not the full listening-decision state machine
+// the section above exercises.
+import { buildBindCheckCommand, classifyBindCheck } from "./scripts/lib/start-sh.mjs";
+import { execSync as _bindCheckExecSync } from "node:child_process";
+
+console.log("\nscripts/lib/start-sh.mjs -- buildBindCheckCommand (issue #246, second half):");
+
+test("buildBindCheckCommand: darwin prefers the resolveBinaryPath-preferred absolute lsof path", () => {
+  const cmd = buildBindCheckCommand({ port: _startShTestPort, platform: "darwin", lsofPath: "/usr/sbin/lsof", existsSyncFn: () => true });
+  assert.equal(cmd, `/usr/sbin/lsof -nP -iTCP:${_startShTestPort} -sTCP:LISTEN`);
+});
+
+test("buildBindCheckCommand: darwin falls back to the bare name when the absolute path does not exist", () => {
+  const cmd = buildBindCheckCommand({ port: _startShTestPort, platform: "darwin", lsofPath: "/usr/sbin/lsof", existsSyncFn: () => false });
+  assert.equal(cmd, `lsof -nP -iTCP:${_startShTestPort} -sTCP:LISTEN`);
+});
+
+test("buildBindCheckCommand: linux uses ss -tlnp | grep", () => {
+  const cmd = buildBindCheckCommand({ port: _startShTestPort, platform: "linux" });
+  assert.equal(cmd, `ss -tlnp | grep ':${_startShTestPort}'`);
+});
+
+test("buildBindCheckCommand: darwin branch never redirects stderr to /dev/null (issue #246 second half's actual defect)", () => {
+  const cmd = buildBindCheckCommand({ port: _startShTestPort, platform: "darwin", existsSyncFn: () => true });
+  assert.ok(!cmd.includes("2>/dev/null"), `must not redirect stderr: ${cmd}`);
+});
+
+test("buildBindCheckCommand: linux branch never redirects stderr to /dev/null", () => {
+  const cmd = buildBindCheckCommand({ port: _startShTestPort, platform: "linux" });
+  assert.ok(!cmd.includes("2>/dev/null"), `must not redirect stderr: ${cmd}`);
+});
+
+console.log("\nscripts/lib/start-sh.mjs -- classifyBindCheck (issue #246, second half):");
+
+test("classifyBindCheck: execFn returns a line -> kind 'found', line captured verbatim (first line only)", () => {
+  const result = classifyBindCheck({
+    port: _startShTestPort, platform: "darwin",
+    execFn: () => "node    1 u   4u  IPv4 0x0      0t0  TCP *:12345 (LISTEN)\nextra ignored line\n",
+  });
+  assert.equal(result.kind, "found");
+  assert.equal(result.line, "node    1 u   4u  IPv4 0x0      0t0  TCP *:12345 (LISTEN)");
+});
+
+test("classifyBindCheck: execFn returns empty string -> kind 'empty'", () => {
+  const result = classifyBindCheck({ port: _startShTestPort, platform: "darwin", execFn: () => "" });
+  assert.deepEqual(result, { kind: "empty" });
+});
+
+test("classifyBindCheck: execFn throws lsof/grep's own plain 'no match' (status 1, empty stderr) -> kind 'empty' (unchanged, stays silent)", () => {
+  const err = Object.assign(new Error("Command failed"), { status: 1, stderr: "" });
+  const result = classifyBindCheck({ port: _startShTestPort, platform: "darwin", execFn: () => { throw err; } });
+  assert.equal(result.kind, "empty");
+});
+
+test("classifyBindCheck: execFn throws exit 127 'command not found' -> kind 'could-not-run', detail carries the diagnostic text", () => {
+  const err = Object.assign(new Error("Command failed"), { status: 127, stderr: "sh: lsof: command not found" });
+  const result = classifyBindCheck({ port: _startShTestPort, platform: "darwin", execFn: () => { throw err; } });
+  assert.equal(result.kind, "could-not-run");
+  assert.match(result.detail, /command not found/);
+});
+
+test("classifyBindCheck: execFn throws exit 126 'permission denied' -> kind 'could-not-run'", () => {
+  const err = Object.assign(new Error("Command failed"), { status: 126, stderr: "Permission denied" });
+  const result = classifyBindCheck({ port: _startShTestPort, platform: "darwin", execFn: () => { throw err; } });
+  assert.equal(result.kind, "could-not-run");
+  assert.match(result.detail, /Permission denied/);
+});
+
+test("classifyBindCheck: execFn throws with only .message (no .stderr) containing ENOENT -> the .message fallback still classifies it could-not-run", () => {
+  const err = new Error("spawnSync sh ENOENT");
+  const result = classifyBindCheck({ port: _startShTestPort, platform: "darwin", execFn: () => { throw err; } });
+  assert.equal(result.kind, "could-not-run");
+  assert.match(result.detail, /ENOENT/);
+});
+
+// The pre-#246(second-half) setup.mjs:423 body, copied verbatim (before this PR's fix) so the
+// exact regression this half fixes stays provable even after setup.mjs's own source moves on
+// -- same idea as _preFix246StartSh above, applied to this call site.
+function _preFix246BindCheck({ port, lsofPath }) {
+  return `${lsofPath} -nP -iTCP:${port} -sTCP:LISTEN 2>/dev/null`;
+}
+
+console.log("\nclassifyBindCheck MONEY TEST -- real subprocess stderr preservation (issue #246, second half):");
+
+test("MONEY TEST: pre-fix command string swallows a real broken binary's stderr; buildBindCheckCommand's fixed command preserves it", () => {
+  const root = mkdtempSync(testJoin(tmpdir(), "bind-check-money-"));
+  try {
+    // A real, executable fake `lsof` that fails loudly on its OWN stderr -- proves this test
+    // exercises real command execution, not an injected error object.
+    const fakeLsofPath = testJoin(root, "fake-lsof");
+    testWriteFile(fakeLsofPath, `#!/bin/bash\necho "fake-lsof: distinctive-marker-text" >&2\nexit 2\n`);
+    _ltChmod(fakeLsofPath, 0o755);
+
+    let preFixThrew = false;
+    let preFixStderr = "UNSET";
+    try {
+      _bindCheckExecSync(_preFix246BindCheck({ port: _startShTestPort, lsofPath: fakeLsofPath }), { encoding: "utf-8" });
+    } catch (e) {
+      preFixThrew = true;
+      preFixStderr = String(e.stderr || "");
+    }
+    assert.ok(preFixThrew, "the fake lsof stub exits 2 -- pre-fix command must throw");
+    assert.equal(preFixStderr.trim(), "",
+      `pre-fix command's own 2>/dev/null must swallow stderr (defect reproduction); got ${JSON.stringify(preFixStderr)}`);
+
+    const fixedCmd = buildBindCheckCommand({ port: _startShTestPort, platform: "darwin", lsofPath: fakeLsofPath });
+    let fixedThrew = false;
+    let fixedStderr = "UNSET";
+    try {
+      _bindCheckExecSync(fixedCmd, { encoding: "utf-8" });
+    } catch (e) {
+      fixedThrew = true;
+      fixedStderr = String(e.stderr || "");
+    }
+    assert.ok(fixedThrew, "the fake lsof stub exits 2 -- fixed command must also throw");
+    assert.match(fixedStderr, /distinctive-marker-text/,
+      `fixed command must preserve the real stub's stderr; got ${JSON.stringify(fixedStderr)}`);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("setup.mjs wiring: no longer contains the raw '-sTCP:LISTEN'/'ss -tlnp' inline command construction or the empty best-effort catch (issue #246, second half)", () => {
+  const src = _ltRead(testJoin(import.meta.dirname, "setup.mjs"), "utf8");
+  assert.ok(!src.includes("-sTCP:LISTEN"), "setup.mjs must not inline the old lsof command construction (now inside classifyBindCheck())");
+  assert.ok(!src.includes("ss -tlnp"), "setup.mjs must not inline the old ss command construction (now inside classifyBindCheck())");
+  assert.ok(!src.includes("bind check is best-effort"), "setup.mjs must not keep the old empty best-effort catch comment");
+});
+
+// A stricter, PROXIMITY-anchored wiring check (not just "both strings exist somewhere in the
+// 447-line file" -- install-autostart.mjs's own header describes exactly that weaker shape
+// failing to catch a review mutation that emptied a gate while leaving the guarded code
+// unguarded, "co-location, not containment"). setup.mjs's own Step 8 body can never be
+// executed by this suite (AGENTS.md), so this can only be a textual check -- but anchoring the
+// match to "'could-not-run' followed shortly by a warn( call" at least proves the warn() call
+// sits INSIDE the could-not-run branch, not merely somewhere else in the file. Still strictly
+// weaker evidence than a behavioral test: it cannot prove the warn() call fires at runtime,
+// only that the source is shaped as if it does. classifyBindCheck() itself (the actual
+// could-not-run/empty/found classification logic) is covered behaviorally above; this test's
+// only job is the wiring from that classification to the one line of setup.mjs that prints it.
+test("setup.mjs wiring: the could-not-run branch actually calls warn() (proximity-anchored, not just co-located in the file)", () => {
+  const src = _ltRead(testJoin(import.meta.dirname, "setup.mjs"), "utf8");
+  assert.match(
+    src,
+    /bindCheck\.kind === ["']could-not-run["'][\s\S]{0,200}?warn\(/,
+    "setup.mjs must call warn() within the could-not-run branch, not merely elsewhere in the file",
+  );
 });
 
 // ── Doctor --check oauth fast path tests ──

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -4031,9 +4031,16 @@ test("buildBindCheckCommand: darwin falls back to the bare name when the absolut
   assert.equal(cmd, `lsof -nP -iTCP:${_startShTestPort} -sTCP:LISTEN`);
 });
 
-test("buildBindCheckCommand: linux uses ss -tlnp | grep", () => {
+// Independent review round 1 (MED-2): this used to be `ss -tlnp | grep ':${port}'`. A `| grep`
+// pipe reports GREP's own exit status, not `ss`'s, which made the exit-127/126 could-not-run
+// check dead code on Linux (verified live against real /bin/dash: a missing `ss` piped through
+// `grep` exits 1, never 127). No pipe, no grep -- port matching now happens in JS
+// (ssLineMatchesPort) against the unfiltered `ss -tlnp` output, so `ss`'s own real exit status
+// survives to classifyBindCheck()'s catch block.
+test("buildBindCheckCommand: linux uses bare 'ss -tlnp', no pipe/grep (issue #246 second half, MED-2 fix)", () => {
   const cmd = buildBindCheckCommand({ port: _startShTestPort, platform: "linux" });
-  assert.equal(cmd, `ss -tlnp | grep ':${_startShTestPort}'`);
+  assert.equal(cmd, "ss -tlnp");
+  assert.ok(!cmd.includes("|"), `must not pipe through grep (masks ss's own exit status): ${cmd}`);
 });
 
 test("buildBindCheckCommand: darwin branch never redirects stderr to /dev/null (issue #246 second half's actual defect)", () => {
@@ -4089,6 +4096,70 @@ test("classifyBindCheck: execFn throws with only .message (no .stderr) containin
   assert.match(result.detail, /ENOENT/);
 });
 
+// Independent review round 1 (MED-2): dash -- /bin/sh on this project's own documented Linux
+// hosts (Debian/Ubuntu/Raspberry Pi OS) -- phrases a missing command as `sh: 1: ssnotreal: not
+// found`, WITHOUT the word "command", verified live against a real /bin/dash. The pre-fix
+// phrase list (`/command not found|.../i`) silently missed this -- the single most realistic
+// could-not-run case on Linux -- and fell through to "empty" (silent). This test drives the
+// exact dash phrasing through a fake execFn with a non-127 status (simulating the OLD
+// pipe-masked shape, so this test isolates the PHRASE fix specifically; the real pipe-removal
+// fix is proven separately by the real-subprocess MONEY TEST 2 below).
+test("classifyBindCheck: execFn throws dash's exact 'not found' phrasing (no 'command' word) -> kind 'could-not-run' (MED-2 phrase-list fix)", () => {
+  const err = Object.assign(new Error("Command failed"), { status: 1, stderr: "/bin/dash: 1: ssnotreal: not found\n" });
+  const result = classifyBindCheck({ port: _startShTestPort, platform: "linux", execFn: () => { throw err; } });
+  assert.equal(result.kind, "could-not-run");
+  assert.match(result.detail, /not found/);
+});
+
+console.log("\nscripts/lib/start-sh.mjs -- classifyBindCheck linux ss-output parsing (issue #246, second half, MED-2):");
+
+test("classifyBindCheck (linux): a LISTEN row on our exact port among several non-matching rows -> kind 'found'", () => {
+  const result = classifyBindCheck({
+    port: _startShTestPort, platform: "linux",
+    execFn: () => `State  Recv-Q Send-Q Local Address:Port  Peer Address:Port\n` +
+      `LISTEN 0      128    127.0.0.1:22        0.0.0.0:*\n` +
+      `LISTEN 0      511    0.0.0.0:${_startShTestPort}         0.0.0.0:*\n`,
+  });
+  assert.equal(result.kind, "found");
+  assert.match(result.line, new RegExp(`:${_startShTestPort}\\b`));
+});
+
+test("classifyBindCheck (linux): ss runs cleanly but no row matches our port -> kind 'empty'", () => {
+  const result = classifyBindCheck({
+    port: _startShTestPort, platform: "linux",
+    execFn: () => `State  Recv-Q Send-Q Local Address:Port  Peer Address:Port\n` +
+      `LISTEN 0      128    127.0.0.1:22        0.0.0.0:*\n`,
+  });
+  assert.deepEqual(result, { kind: "empty" });
+});
+
+test("classifyBindCheck (linux): a decoy port that merely CONTAINS our port's digits as a substring must NOT match (suffix anchoring)", () => {
+  const decoyPort = `9${_startShTestPort}`;
+  const result = classifyBindCheck({
+    port: _startShTestPort, platform: "linux",
+    execFn: () => `LISTEN 0 128 0.0.0.0:${decoyPort} 0.0.0.0:*\n`,
+  });
+  assert.deepEqual(result, { kind: "empty" },
+    `an adjacent port containing our port's digits must not be read as a match`);
+});
+
+test("classifyBindCheck (linux): a non-LISTEN row (e.g. a header or a non-listening state) on the exact port must NOT match", () => {
+  const result = classifyBindCheck({
+    port: _startShTestPort, platform: "linux",
+    execFn: () => `State  Recv-Q Send-Q Local Address:Port  Peer Address:Port\n` +
+      `ESTAB  0      0      10.0.0.5:${_startShTestPort}       10.0.0.9:443\n`,
+  });
+  assert.deepEqual(result, { kind: "empty" });
+});
+
+test("classifyBindCheck (linux): an IPv6 local address ([::]:PORT) on our exact port -> kind 'found'", () => {
+  const result = classifyBindCheck({
+    port: _startShTestPort, platform: "linux",
+    execFn: () => `LISTEN 0 128 [::]:${_startShTestPort} [::]:*\n`,
+  });
+  assert.equal(result.kind, "found");
+});
+
 // The pre-#246(second-half) setup.mjs:423 body, copied verbatim (before this PR's fix) so the
 // exact regression this half fixes stays provable even after setup.mjs's own source moves on
 // -- same idea as _preFix246StartSh above, applied to this call site.
@@ -4107,10 +4178,17 @@ test("MONEY TEST: pre-fix command string swallows a real broken binary's stderr;
     testWriteFile(fakeLsofPath, `#!/bin/bash\necho "fake-lsof: distinctive-marker-text" >&2\nexit 2\n`);
     _ltChmod(fakeLsofPath, 0o755);
 
+    // stdio: ["ignore","pipe","pipe"] here is purely test-harness hygiene, not part of what's
+    // under test (this test calls _bindCheckExecSync directly, not through classifyBindCheck()
+    // -- MED-1's actual fix lives in classifyBindCheck()'s own execFn call, verified by the
+    // dedicated no-leak tests further below). Without it, this test's own default-stdio
+    // execSync call would print the fake stub's stderr straight to this suite's console --
+    // exactly the kind of unlabeled leak independent review round 1 (MED-1) flagged, just in
+    // test code instead of production code.
     let preFixThrew = false;
     let preFixStderr = "UNSET";
     try {
-      _bindCheckExecSync(_preFix246BindCheck({ port: _startShTestPort, lsofPath: fakeLsofPath }), { encoding: "utf-8" });
+      _bindCheckExecSync(_preFix246BindCheck({ port: _startShTestPort, lsofPath: fakeLsofPath }), { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] });
     } catch (e) {
       preFixThrew = true;
       preFixStderr = String(e.stderr || "");
@@ -4123,7 +4201,7 @@ test("MONEY TEST: pre-fix command string swallows a real broken binary's stderr;
     let fixedThrew = false;
     let fixedStderr = "UNSET";
     try {
-      _bindCheckExecSync(fixedCmd, { encoding: "utf-8" });
+      _bindCheckExecSync(fixedCmd, { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] });
     } catch (e) {
       fixedThrew = true;
       fixedStderr = String(e.stderr || "");
@@ -4131,6 +4209,127 @@ test("MONEY TEST: pre-fix command string swallows a real broken binary's stderr;
     assert.ok(fixedThrew, "the fake lsof stub exits 2 -- fixed command must also throw");
     assert.match(fixedStderr, /distinctive-marker-text/,
       `fixed command must preserve the real stub's stderr; got ${JSON.stringify(fixedStderr)}`);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// Independent review round 1 (MED-2), real subprocess via a REAL /bin/dash (this project's own
+// documented Linux /bin/sh -- Debian/Ubuntu/Raspberry Pi OS): proves the OLD `ss -tlnp | grep`
+// pipe shape genuinely masks a missing binary's real exit status under a real shell (not an
+// injected error object), and that buildBindCheckCommand()'s fixed (no-pipe) shape restores it.
+// Skips (does not fail) on a host without /bin/dash -- the phrase-based unit test above already
+// covers the classification logic directly and does not depend on any particular shell being
+// present.
+test("MONEY TEST 2 (linux, real /bin/dash subprocess): pre-fix 'ss | grep' pipe masks a missing binary's real exit status; buildBindCheckCommand's fixed (no-pipe) shape restores it (MED-2)", () => {
+  if (!testExistsSync("/bin/dash")) {
+    console.log("    (skipped: /bin/dash not present on this host)");
+    return;
+  }
+  // A definitely-nonexistent command name standing in for "ss is not installed" -- needs no
+  // $PATH manipulation to reproduce "not found" (matches how the darwin MONEY TEST above uses
+  // a fake absolute path rather than mutating $PATH). `grep` itself stays genuinely resolvable
+  // via the normal inherited environment, which is what makes the OLD pipe shape's masking
+  // reproducible for real: grep runs, gets no/garbage input, and exits 1 on its own -- not 127.
+  const missingCmd = "ss-definitely-not-a-real-binary-246";
+
+  const oldPipeShape = `${missingCmd} -tlnp | grep ':${_startShTestPort}'`; // pre-fix shape
+  let oldStatus = "UNSET";
+  try {
+    _bindCheckExecSync(oldPipeShape, { encoding: "utf-8", shell: "/bin/dash", stdio: ["ignore", "pipe", "pipe"] });
+    oldStatus = 0;
+  } catch (e) {
+    oldStatus = e.status;
+  }
+  assert.notEqual(oldStatus, 127,
+    `defect reproduction: grep's own exit status must mask ${missingCmd}'s real 127; got status=${oldStatus}`);
+
+  // buildBindCheckCommand()'s REAL linux output, with "ss" swapped for the same missing-command
+  // stand-in -- the only variable between old and fixed is the pipe's presence/absence, mirroring
+  // the darwin MONEY TEST's "same fake response, different script body" structure.
+  const realFixedCmd = buildBindCheckCommand({ port: _startShTestPort, platform: "linux" });
+  assert.ok(!realFixedCmd.includes("|"), `fixed linux command must not pipe through grep: ${realFixedCmd}`);
+  const fixedShape = realFixedCmd.replace(/^ss\b/, missingCmd);
+  let fixedStatus = "UNSET";
+  let fixedStderr = "";
+  try {
+    _bindCheckExecSync(fixedShape, { encoding: "utf-8", shell: "/bin/dash", stdio: ["ignore", "pipe", "pipe"] });
+    fixedStatus = 0;
+  } catch (e) {
+    fixedStatus = e.status;
+    fixedStderr = String(e.stderr || "");
+  }
+  assert.equal(fixedStatus, 127, `fixed command must surface the real 127 exit status; got ${fixedStatus}`);
+  assert.match(fixedStderr, /not found/i, `dash's real "not found" phrasing must survive; got ${JSON.stringify(fixedStderr)}`);
+});
+
+// Independent review round 1 (MED-1), real subprocess: the unit tests above inject execFn
+// directly, so they can't observe what Node's REAL execSync default actually does with a
+// child's stderr -- verified live (outside this suite, while designing this fix) that plain
+// `execSync(cmd, { encoding: "utf-8" })` inherits the child's stderr to the CALLING process's
+// own real stderr, in addition to (on the throw path) capturing it into `e.stderr` -- on BOTH
+// the success and throw paths. That directly breaks the "stays exactly as silent as before"
+// contract documented on classifyBindCheck() and the "empty" branch comment in setup.mjs: an
+// "empty" or "found" classification was NOT actually silent if the underlying tool wrote
+// anything to its own stderr along the way. Fixed by passing an explicit
+// `stdio: ["ignore","pipe","pipe"]`-equivalent option into the execFn call inside
+// classifyBindCheck() (verified live: this suppresses the inherit path while leaving `e.stderr`
+// capture on throw, and the stdout return value on success, both intact).
+//
+// This spawns a REAL child Node process that calls the REAL, unmodified classifyBindCheck()
+// with its REAL default execFn (not an injected fake) against a real fake `lsof` stub that
+// writes a distinctive marker to its own stderr, then asserts the marker does NOT appear in the
+// PARENT test process's observation of the CHILD's own stderr (captured via spawnSync, which --
+// unlike execSync -- pipes by default and does not itself leak, verified live) -- proving the
+// fix holds for the real, unmocked code path, not just for injected error objects.
+console.log("\nclassifyBindCheck MED-1 real-subprocess stdio-leak tests (issue #246, second half, independent review round 1):");
+
+function _writeBindCheckLeakProbeScript(root, { lsofPath, port }) {
+  const startShUrl = pathToFileURL(testJoin(import.meta.dirname, "scripts/lib/start-sh.mjs")).href;
+  const scriptPath = testJoin(root, "leak-probe.mjs");
+  testWriteFile(scriptPath, [
+    `import { classifyBindCheck } from ${JSON.stringify(startShUrl)};`,
+    `const result = classifyBindCheck({ port: ${JSON.stringify(port)}, platform: "darwin", lsofPath: ${JSON.stringify(lsofPath)} });`,
+    `process.stdout.write("RESULT:" + JSON.stringify(result) + "\\n");`,
+    "",
+  ].join("\n"));
+  return scriptPath;
+}
+
+test("classifyBindCheck (real subprocess, 'found' outcome): the real execFn default does NOT leak the underlying tool's stderr chatter to the caller's own stderr (MED-1 fix)", () => {
+  const root = mkdtempSync(testJoin(tmpdir(), "bind-check-leak-probe-found-"));
+  try {
+    const fakeLsofPath = testJoin(root, "fake-lsof");
+    testWriteFile(fakeLsofPath,
+      `#!/bin/bash\necho "STDERR-LEAK-PROBE-FOUND" >&2\necho "node 1 u 4u IPv4 0x0 0t0 TCP *:${_startShTestPort} (LISTEN)"\nexit 0\n`);
+    _ltChmod(fakeLsofPath, 0o755);
+
+    const scriptPath = _writeBindCheckLeakProbeScript(root, { lsofPath: fakeLsofPath, port: _startShTestPort });
+    const res = spawnSync(process.execPath, [scriptPath], { encoding: "utf-8" });
+
+    assert.ok(!res.stderr.includes("STDERR-LEAK-PROBE-FOUND"),
+      `the underlying tool's stderr must NOT leak to the calling process's own stderr; got stderr=${JSON.stringify(res.stderr)}`);
+    assert.match(res.stdout, /"kind":"found"/,
+      `expected a 'found' classification; got stdout=${JSON.stringify(res.stdout)} stderr=${JSON.stringify(res.stderr)}`);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("classifyBindCheck (real subprocess, 'empty' outcome): the real execFn default does NOT leak the underlying tool's stderr chatter, and classification stays 'empty' (MED-1 fix)", () => {
+  const root = mkdtempSync(testJoin(tmpdir(), "bind-check-leak-probe-empty-"));
+  try {
+    const fakeLsofPath = testJoin(root, "fake-lsof");
+    testWriteFile(fakeLsofPath, `#!/bin/bash\necho "STDERR-LEAK-PROBE-EMPTY" >&2\nexit 1\n`);
+    _ltChmod(fakeLsofPath, 0o755);
+
+    const scriptPath = _writeBindCheckLeakProbeScript(root, { lsofPath: fakeLsofPath, port: _startShTestPort });
+    const res = spawnSync(process.execPath, [scriptPath], { encoding: "utf-8" });
+
+    assert.ok(!res.stderr.includes("STDERR-LEAK-PROBE-EMPTY"),
+      `the underlying tool's stderr must NOT leak to the calling process's own stderr; got stderr=${JSON.stringify(res.stderr)}`);
+    assert.match(res.stdout, /"kind":"empty"/,
+      `expected an 'empty' classification (the tool's plain nonzero exit, no special phrase); got stdout=${JSON.stringify(res.stdout)} stderr=${JSON.stringify(res.stderr)}`);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
# Pull Request

## Summary

Second half of issue #246: `setup.mjs`'s Step 8 post-install bind-check swallowed the underlying
`lsof`/`ss` command's own stderr (`2>/dev/null` on both platform branches) and sat inside a bare
`catch {}` that discarded every failure identically. This PR extracts `buildBindCheckCommand()` /
`classifyBindCheck()` into `scripts/lib/start-sh.mjs` so a real tool-execution fault ("could not
run") is distinguishable, in the printed diagnostic, from a genuine empty match ("ran, found
nothing" — which stays exactly as silent as before).

**Update after independent review round 1**: an independent reviewer found two real defects in
the first version of this PR (both live-verified below, both now fixed with tests):
**MED-1** (Node's `execSync`, given no `stdio` option, leaks the child's own stderr straight to
the calling process's real stderr — even on success — which broke the "stays silent" contract
this PR itself introduced), and **MED-2** (the Linux `ss -tlnp | grep` shape masked `ss`'s own
exit status behind `grep`'s, and the could-not-run phrase list missed dash's actual "not found"
wording — `/bin/sh` on this project's own documented Linux hosts). See "Independent review round
1" below for the full live-verified writeup, fixes, and new mutation rows. Also addressed:
LOW-1 (a defensive try/catch) and both nits (see that section).

## Endpoint Class (REQUIRED)

- [x] **Not endpoint-touching** — refactor / docs / tooling that does not modify any request handler.

This PR touches only `setup.mjs` (the installer) and `scripts/lib/start-sh.mjs` (installer helper
library). It does not modify any request handler in `server.mjs`.

## Claude Code Alignment Evidence (REQUIRED)

Not applicable — see "Not endpoint-touching" above. **Does not touch `server.mjs`; no `cli.js`
citation applies** (stated explicitly per this repo's `CLAUDE.md` hard requirements).

## Type of change

- [x] Bug fix (alignment with existing `cli.js` behavior, or with the cited spec / ADR for Class B)

(No `cli.js` citation applies — this is an installer diagnostic bug fix, not a Class A/B endpoint
change. Checked "Bug fix" as the closest-fitting category; the PR template's Class A/B framing
does not have a better-fitting box for installer-only tooling fixes.)

## Judgment: load-bearing or cosmetic? (required paragraph)

**Cosmetic, independently verified — not taken on the issue's word.** I traced every assignment
to `verified` through `setup.mjs`'s entire Step 8 block before writing any code:

- `verified` starts `false`.
- It is the **only** place it is ever set: `verified = true;`, placed **immediately after** the
  bind-check's try/catch, **unconditionally** — it runs regardless of whether the bind-check
  found something, found nothing, or threw.
- The `if (res.ok) { ... } else { warn(...) }` branch that wraps the whole bind-check block is
  gated on the earlier HTTP `/health` fetch, not on the bind-check itself.
- After the outer try/catch: `if (!verified) { ...; process.exit(1); }` — the only way this path
  is reached is if `res.ok` was never true (health check failed) or the outer fetch itself
  threw/timed out. The bind-check's own outcome never reaches this branch.

So the bind-check's only externally observable effect is which of three console lines gets
printed — a `bind:` line, a `warn()` line, or nothing. Nothing downstream reads
`classifyBindCheck()`'s return value except that one call site. This is a materially **lower**
stakes situation than sibling issue #246's other half (`:293`, addressed in PR #269), which gates
whether `start.sh` spawns a **second** `server.mjs` process — an action with real consequences
(duplicate process on top of a real listener). Scoped accordingly: `classifyBindCheck()` gets a
three-way classification (`found` / `empty` / `could-not-run`) and nothing else — no netstat
privilege-gap cross-check, no `darwinListeningCheck()`-style fail-closed default, because nothing
downstream ever acts on the distinction; only a human reading the printed diagnostic does.

## Design

Extracted into `scripts/lib/start-sh.mjs` (not a new file — the established home for this exact
defect family, and it already exports `resolveBinaryPath`, which `buildBindCheckCommand()` reuses
internally rather than re-deriving):

- `buildBindCheckCommand({ port, platform, lsofPath, existsSyncFn })` — pure command-string
  builder, no execution. Never appends `2>/dev/null` on either platform branch (darwin/lsof or
  linux/`ss`) — that redirect is the literal remaining defect. **After review round 1 (MED-2)**:
  the linux branch is bare `ss -tlnp` — no `| grep` pipe (a pipe reports grep's own exit status,
  not `ss`'s; verified live under both bash and dash that a missing `ss` piped through `grep`
  exits 1, never 127).
- `ssLineMatchesPort(line, port)` (new, internal, review round 1 MED-2) — matches one `ss -tlnp`
  output line against the target port, port-matching now happening in JS instead of via `grep`.
  Splits on the LAST `:` in the local-address column (handles IPv6's own embedded colons) and
  requires an exact suffix match, not a substring — mirrors `darwinListeningCheck()`'s own
  netstat suffix-anchoring guard in JS form.
- `classifyBindCheck({ port, platform, lsofPath, existsSyncFn, execFn })` — runs the command via
  an injectable `execFn` (default: real `execSync`) and classifies the outcome into `"found"`
  (print the line), `"empty"` (unchanged — stays silent), or `"could-not-run"` (a real
  tool-execution fault — surface one `warn()` line). The empty/could-not-run boundary is
  necessarily heuristic (`execSync` collapses "tool ran, exited nonzero with nothing to say" and
  "the shell could not even start the tool" into the same thrown-error shape); classified by exit
  status 127/126 or a small set of shell-level phrases in the surfaced stderr/message text, the
  same style `scripts/upgrade.mjs`'s `mapLsofFailureToProbeValue` already uses elsewhere in this
  repo for lsof-failure classification. **After review round 1**: the `execFn` call now passes
  an explicit `stdio: ["ignore","pipe","pipe"]`-equivalent option (MED-1 — see below), and the
  phrase list now matches bare `\bnot found\b`, not only `"command not found"` (MED-2 — dash's
  actual phrasing).

`setup.mjs`'s Step 8 call site now only decides what to print based on `classifyBindCheck()`'s
returned `kind` — no command construction, no raw `execSync`, no bare `catch {}` left in
`setup.mjs` itself. `resolveBinaryPath` is no longer imported directly into `setup.mjs`; its
absolute-path preference now lives entirely inside `classifyBindCheck()`.

## Independent review round 1 — both MED findings live-reproduced before fixing, not taken on faith

I independently reproduced both findings myself before writing any fix (per this repo's own
"exercise judgment on external reviewer findings" practice — verify the fact layer independently,
then judge the fix), using this exact worktree's Node/shell:

**MED-1 (stderr leak).** Verified live with a minimal reproduction:
```
node -e '
const { execSync } = require("node:child_process");
console.log(">>> calling execSync now");
const out = execSync("echo STDOUT-VAL; echo STDERR-VAL >&2", { encoding: "utf-8" });
console.log(">>> return value was:", JSON.stringify(out));
'
```
prints `STDERR-VAL` to the real console (leaked) even though the command exits 0 and the call
never throws — confirmed on both the success path and the throw path, and confirmed that explicit
`stdio: ["pipe","pipe","pipe"]` suppresses the leak while leaving `e.stderr` capture on throw and
the stdout return value on success both intact. Confirmed the leak was real in this PR's own
suite output too: the money test's `fake-lsof: distinctive-marker-text` marker was present, bare
and unlabeled, in the pre-fix `npm test` log.
**Fix**: `classifyBindCheck()`'s `execFn` call now passes an explicit
`stdio: ["ignore","pipe","pipe"]`. New tests: 2 real-subprocess tests (`spawnSync`-launched child
Node process calling the real, unmodified `classifyBindCheck()` with its real default `execFn`
against a real fake `lsof` stub that writes a distinctive marker to its own stderr) assert the
marker never reaches the *parent* test process's own stderr, for both the `"found"` and `"empty"`
outcomes.

**MED-2 (Linux pipe masking + phrase list).** Verified live against a real `/bin/dash` (present
on this host, and — per `AGENTS.md`'s own documented Linux hosts — the actual `/bin/sh` on
Debian/Ubuntu/Raspberry Pi OS, this project's real deployment targets):
```
$ /bin/dash -c 'ssnotreal -tlnp | grep :12345'
/bin/dash: 1: ssnotreal: not found      # exit 1, NOT 127 -- grep's own exit status wins
$ /bin/dash -c 'ssnotreal -tlnp'
/bin/dash: 1: ssnotreal: not found      # exit 127 -- ss's real status, once the pipe is removed
```
So (a) the `| grep` pipe genuinely masks a missing `ss`'s real 127 behind grep's own 1, and (b)
dash's phrasing (`ssnotreal: not found`) never contains the word "command", so the pre-fix phrase
list (`/command not found|.../i`) silently missed it. I also verified the reviewer's own suggested
fallback (`set -o pipefail`) is **not viable**: `/bin/dash -c 'set -o pipefail'` fails outright
with `Illegal option -o pipefail` — adopting it would have broken the Linux bind-check on every
single run on this project's own documented Linux hosts, not just the missing-binary case.
**Fix**: dropped the `| grep` pipe entirely (`buildBindCheckCommand()`'s linux branch is now bare
`ss -tlnp`); port matching moved into JS (`ssLineMatchesPort()`, suffix-anchored, IPv6-aware);
broadened the could-not-run phrase match to `\bnot found\b`. New tests: a phrase-based
`classifyBindCheck` unit test reproducing dash's exact wording; 5 `classifyBindCheck` tests for
the new JS-side `ss -tlnp` parsing (found, empty, decoy-substring-port rejection, non-LISTEN-row
rejection, IPv6); and a real-`/bin/dash`-subprocess MONEY TEST 2 proving the OLD piped shape
masks a missing binary's real exit status while `buildBindCheckCommand()`'s fixed (no-pipe) shape
restores it — skips (does not fail) on a host without `/bin/dash`.

**LOW-1 (defensive try/catch) — addressed.** The reviewer traced that `classifyBindCheck()`
currently cannot throw under normal use (every expected failure is funneled into a returned
`kind`), so this is insurance, not a response to a live defect. Added anyway — cheap, and it means
this cosmetic diagnostic can never become load-bearing by accident if a future change to
`classifyBindCheck()` introduces an unforeseen throw path. `setup.mjs`'s Step 8 call site now
wraps the `classifyBindCheck()` call and its `if`/`else if` in its own `try { ... } catch {}`,
still ahead of the unconditional `verified = true;`.

**Nits — decisions, not silently dropped:**
- *Wiring guards scan comments too.* True — `!src.includes("ss -tlnp")` etc. would break if a
  future doc comment in `setup.mjs` happened to mention that literal string. Not fixed: doing this
  precisely would need source-position-aware parsing (distinguishing code from comments) that is
  disproportionate to the benefit for a two-line textual guard whose only job is a boundary check
  on a file this suite can never execute. Noted here as a known, accepted minor fragility.
- *User-visible change self-check was inconsistent.* Fixed below — this PR does add one new
  console line (`⚠ bind check could not run (...)`), which is user-visible even though minor and
  diagnostic-only. Checkbox and reasoning now agree.

## Tests

`setup.mjs` can never be executed by this suite (the real installer — `AGENTS.md`'s "NEVER run
setup.mjs" constraint; I did not run it anywhere in this session). All coverage goes through the
extracted functions, in `test-features.mjs`:

- **5 `buildBindCheckCommand` tests** — darwin absolute-path preference, darwin bare-name
  fallback, linux bare `ss -tlnp` shape (no pipe/grep — MED-2), and (the actual behavioral
  assertion on the original defect) a `!cmd.includes("2>/dev/null")` check on both platform
  branches.
- **7 `classifyBindCheck` tests** with an injected fake `execFn` — `"found"` with line capture,
  `"empty"` on empty output, `"empty"` on a plain `{status:1, stderr:""}` throw (the **unchanged**
  silent case — lsof/grep's own "no match" exit), `"could-not-run"` on exit 127 and exit 126, a
  `.message`-only ENOENT throw (no `.stderr`) to exercise the fallback branch, and (review round 1,
  MED-2) dash's exact `"...: not found"` phrasing (no "command" word).
- **5 `classifyBindCheck` linux ss-output-parsing tests** (review round 1, MED-2) — a LISTEN row
  on our exact port among non-matching rows, a clean no-match, a decoy port that merely *contains*
  our port's digits (suffix-anchoring), a non-LISTEN row on the exact port, and an IPv6 local
  address.
- **2 real-subprocess MED-1 no-leak tests** (review round 1) — spawn a real child Node process
  calling the real, unmodified `classifyBindCheck()` (real default `execFn`) against a real fake
  `lsof` stub that writes a distinctive marker to its own stderr; assert the marker never reaches
  the *parent* test process's own stderr, for both the `"found"` and `"empty"` outcomes.
- **2 real-subprocess MONEY TESTs** — the pure-function tests above inject the error directly, so
  they can't prove the real constructed command string behaves correctly when actually executed.
  MONEY TEST 1 (darwin) writes a real executable fake `lsof` that fails with a distinctive stderr
  marker, runs the pre-fix command string (copied verbatim from `origin/main`, matching the
  `_preFix246StartSh` precedent for the sibling `:293` fix) against it via real `execSync`,
  confirms the thrown error's `.stderr` is **empty** (reproducing the swallow), then runs
  `buildBindCheckCommand()`'s real output against the **same** stub and confirms `.stderr`
  **contains the marker**. MONEY TEST 2 (review round 1, MED-2, linux via real `/bin/dash`) proves
  the OLD `ss | grep` pipe shape masks a missing binary's real exit status while
  `buildBindCheckCommand()`'s fixed (no-pipe) shape restores it — skips, does not fail, on a host
  without `/bin/dash`.
- **2 wiring tests** (legitimate per `AGENTS.md`'s carve-out — a boundary check for
  `setup.mjs`'s own un-executable body, not a substitute for the behavioral tests above, which
  cover `classifyBindCheck()`'s actual logic): confirms `setup.mjs` imports/calls
  `classifyBindCheck()` and no longer contains the raw `-sTCP:LISTEN`/`ss -tlnp` inline
  construction or the old empty best-effort catch comment. A **second**, stricter,
  proximity-anchored wiring test (added after mutation (c) below exposed a real gap in the first
  one) confirms the `warn()` call sits specifically inside the `could-not-run` branch, not merely
  somewhere else in the file.

### RED (before implementation — importing not-yet-existing exports crashes module load)

```
file:///.../test-features.mjs:4019
import { buildBindCheckCommand, classifyBindCheck } from "./scripts/lib/start-sh.mjs";
         ^^^^^^^^^^^^^^^^^^^^^
SyntaxError: The requested module './scripts/lib/start-sh.mjs' does not provide an export named 'buildBindCheckCommand'
```

### GREEN

```
=== Results: 886 passed, 0 failed ===   (round 0, initial implementation)
=== Results: 887 passed, 0 failed ===   (+1, mutation-driven wiring-test addition)
=== Results: 896 passed, 0 failed ===   (+9, independent review round 1: MED-1/MED-2 tests)
=== Results: 896 passed, 0 failed ===   (final, after LOW-1 -- no new tests, defensive-only change)
```
Baseline on unmodified `origin/main`: 873 passed, 0 failed.

## Mutation table

Each mutation: confirmed landed via `grep`/diff before running tests, restored via `cp`
file-backup + `shasum -a 256` round-trip (never `git checkout --`), full suite reconfirmed green
before the next mutation.

| Mutation | Files touched (shasum before → after) | Named failing test(s) | Restore confirmed |
|---|---|---|---|
| (a) Reintroduce `2>/dev/null` into `buildBindCheckCommand`'s return on both platform branches | `scripts/lib/start-sh.mjs` (`a98de1d4…` → `b4581c70…`) | 6: the 2 `!includes("2>/dev/null")` tests, the darwin/linux/fallback command-shape tests, and the MONEY TEST | Yes — byte-identical `diff` + matching shasum `a98de1d4…` |
| (b) Weaken `couldNotRun` to always `false` | `scripts/lib/start-sh.mjs` (`a98de1d4…` → `93bb7214…`) | 3: the exit-127, exit-126, and `.message`-ENOENT-fallback `classifyBindCheck` tests | Yes — byte-identical `diff` + matching shasum `a98de1d4…` |
| (c) Delete the `warn()` call in `setup.mjs`'s `could-not-run` branch | `setup.mjs` (`e9f4da09…` → `9c3637c7…`) | **1** — only the proximity-anchored wiring test. **Weaker evidence, called out honestly**: neither the two pre-existing wiring tests nor any behavioral test reaches `setup.mjs`'s own call site (it can never be executed by this suite), so this mutation initially **survived both existing wiring tests** on first attempt — a real coverage gap, not an unreachable case. Fixed by adding a second, proximity-anchored wiring assertion (`bindCheck.kind === "could-not-run"` followed within 200 chars by `warn(`) rather than accepting the gap. This is still a textual/wiring check, not a behavioral one — it can prove the source is *shaped* as if `warn()` fires, not that it fires at runtime. | Yes — byte-identical `diff` + matching shasum `e9f4da09…` |
| **(d)** *(review round 1, MED-1)* Remove the `stdio` option from `classifyBindCheck()`'s `execFn` call, reverting to plain `{ encoding: "utf-8" }` | `start-sh.mjs` (`b7288dd8…` → `d98def46…`) | 2 — both real-subprocess no-leak tests (`'found'` and `'empty'` outcomes), each failing with the literal leaked marker text visible in the failure message (`got stderr="STDERR-LEAK-PROBE-FOUND\n"` / `"STDERR-LEAK-PROBE-EMPTY\n"`) | Yes — byte-identical `diff` + matching shasum `b7288dd8…` |
| **(e)** *(review round 1, MED-2)* Revert `buildBindCheckCommand()`'s linux branch to the piped `ss -tlnp \| grep ':${port}'` shape | `start-sh.mjs` (`b7288dd8…` → `99d05f03…`) | 2 — the linux command-shape test and MONEY TEST 2 (fails at its own `!includes("|")` assertion before even reaching the subprocess) | Yes — byte-identical `diff` + matching shasum `b7288dd8…` |
| **(f)** *(review round 1, MED-2)* Narrow the could-not-run phrase regex back to `command not found` only (drop `\bnot found\b`) | `start-sh.mjs` (`b7288dd8…` → `eeeb6816…`) | 1 — the dash-exact-phrasing `classifyBindCheck` unit test | Yes — byte-identical `diff` + matching shasum `b7288dd8…` |
| **(g)** *(review round 1, MED-2)* Weaken `ssLineMatchesPort()`'s suffix anchoring to a naive `.includes(String(port))` substring check | `start-sh.mjs` (`b7288dd8…` → `99255693…`) | 1 — the decoy-port suffix-anchoring `classifyBindCheck` (linux) test | Yes — byte-identical `diff` + matching shasum `b7288dd8…` |

## Scope

Does not touch `server.mjs`. Only `setup.mjs`, `scripts/lib/start-sh.mjs`, and `test-features.mjs`
changed. `resolveBinaryPath` is no longer imported directly into `setup.mjs` — the pre-existing
wiring test asserting `resolveBinaryPath(` appears in `setup.mjs` was updated to assert
`classifyBindCheck(` instead, since that assertion's premise (setup.mjs calls
`resolveBinaryPath()` directly) is no longer true by design.

Refs #233, #236, #269 — same defect family (a redirect/catch that turns a real signal into
silence), continuing the extraction-for-testability pattern `scripts/lib/install-autostart.mjs`
established.

Closes #246

## Reviewer checklist

Reviewers: this section is for you, not the author. Do not approve until every box is checked.

- [ ] Confirmed this PR is correctly marked "Not endpoint-touching" — no request handler in
      `server.mjs` is modified.
- [ ] I ran (or confirmed CI ran) `.github/workflows/alignment.yml` and it passed (n/a — no
      `server.mjs` change, but confirm the workflow still passes cleanly).
- [ ] I am not the commit author of any commit in this PR (Iron Rule 10).
- [ ] I opened `scripts/lib/start-sh.mjs` and confirmed `buildBindCheckCommand()` never appends
      `2>/dev/null` on either branch, and `classifyBindCheck()`'s three-way classification matches
      the description above.
- [ ] I opened `setup.mjs`'s Step 8 block and independently traced `verified`'s assignments,
      confirming the cosmetic-only judgment in this PR body.
- [ ] I confirmed the mutation table's claim about mutation (c) — that it is caught by a wiring
      test only, not a behavioral one — and consider that an acceptable trade-off given
      `setup.mjs` cannot be executed by this suite.
- [ ] I independently ran the MED-1 reproduction (`execSync(cmd, { encoding: "utf-8" })` leaking
      stderr to the console) and confirmed `classifyBindCheck()`'s `execFn` call now passes an
      explicit `stdio` option that suppresses it.
- [ ] I independently ran (or read) the MED-2 reproduction against a real `/bin/dash` (a missing
      `ss` piped through `grep` exits 1, not 127) and confirmed `buildBindCheckCommand()`'s linux
      branch no longer pipes through `grep`.

## Related

- `ALIGNMENT.md` Rule(s) invoked: none — not endpoint-touching.
- Authorizing ADR (Class B only): n/a.
- Related issue / prior PR: #246 (this PR), #269 (the sibling `:293` change), #233, #236 (the
  originating defect family).
- Historical lesson reference (if relevant): none.

### User-visible change self-check (铁律第五律 5.3)

- [x] This PR has user-visible changes → no README update, reasoning below (fixed after
      independent review round 1 flagged the checkbox/reasoning mismatch in the first version of
      this PR).

This adds one new console line during `node setup.mjs`'s Step 8 (`⚠ bind check could not run
(...)`, printed only when `lsof`/`ss` itself fails to execute) and preserves the existing `bind:
...` line's content unchanged. That is user-visible in the literal sense (a human running the
installer can see a new line), but it is not a documented feature, endpoint, CLI flag, or config
surface — it does not fit any category in the `release_kit:` overlay's own
`new_feature_doc_expectations` list (no new subcommand, env var, auto-sync/hook, endpoint, or
file/SPOT/schema), so no README update applies. Flagged explicitly rather than silently checking
"no user-visible changes," which was the actual defect the reviewer caught in this box.

### Privacy self-check (for PUBLIC repos) — Iron Rule adjacent

- [x] This PR does not introduce real names, nicknames, or handles that identify specific
      individuals. All references use role-based terms.
- [x] This PR does not introduce literal personal paths (`/Users/<username>/`,
      `/home/<username>/`). Uses `$HOME/` or `~/` instead.
- [x] This PR does not introduce personal machine hostnames. Uses role-based names or generic
      descriptors.
- [x] This PR does not introduce personal email addresses beyond automated placeholders like
      `noreply@<vendor>.com`.
