### PR TITLE
fix(ocp): route eight more silent-failure sites through _curl_or_die (#278)

### DIFF
--- a/ocp
+++ b/ocp
@@ -316,7 +316,12 @@ cmd_logs() {
   local n=${1:-20}
   local level=${2:-error}
   local data
-  data=$(curl -sf --max-time 10 "$PROXY/logs?n=$n&level=$level") || { echo "Error: proxy unreachable" >&2; return 1; }
+  # Issue #278 (#273's own deferred follow-up): routed through `_curl_or_die` (#261/#267/#273)
+  # like the other captured-assignment sites, so a curl-exec failure (curl missing from $PATH,
+  # permission denied, corrupted binary) is no longer misreported as "proxy unreachable" — same
+  # drop-in shape, `|| return 1` preserved (this function is reached via ocp's outer dispatch, not
+  # a top-level exit-on-failure path).
+  data=$(_curl_or_die "proxy unreachable" curl -sf --max-time 10 "$PROXY/logs?n=$n&level=$level") || return 1
   echo "$data" | python3 -c "
 import sys, json
 d = json.loads(sys.stdin.read())
@@ -351,7 +356,8 @@ EOF
 
 cmd_models() {
   local data
-  data=$(curl -sf --max-time 5 "$PROXY/v1/models") || { echo "Error: proxy unreachable" >&2; return 1; }
+  # Issue #278 (same shape as cmd_logs above, see its comment).
+  data=$(_curl_or_die "proxy unreachable" curl -sf --max-time 5 "$PROXY/v1/models") || return 1
   echo "$data" | python3 -c "
 import sys, json
 d = json.loads(sys.stdin.read())
@@ -371,7 +377,8 @@ EOF
 
 cmd_sessions() {
   local data
-  data=$(curl -sf --max-time 5 "$PROXY/sessions") || { echo "Error: proxy unreachable" >&2; return 1; }
+  # Issue #278 (same shape as cmd_logs above, see its comment).
+  data=$(_curl_or_die "proxy unreachable" curl -sf --max-time 5 "$PROXY/sessions") || return 1
   echo "$data" | python3 -c "
 import sys, json
 d = json.loads(sys.stdin.read())
@@ -395,7 +402,8 @@ EOF
 
 cmd_clear() {
   local result
-  result=$(curl -sf --max-time 5 -X DELETE "$PROXY/sessions") || { echo "Error: proxy unreachable" >&2; return 1; }
+  # Issue #278 (same shape as cmd_logs above, see its comment).
+  result=$(_curl_or_die "proxy unreachable" curl -sf --max-time 5 -X DELETE "$PROXY/sessions") || return 1
   # The DELETE above already ran (the clear itself, if the proxy answered, already happened) —
   # only the count formatting can still fail python3-absent/malformed, so the fallback below
   # says so explicitly rather than implying the clear itself didn't happen (issue #242).
@@ -459,7 +467,10 @@ else:
     revoke)
       if [[ -z "${2:-}" ]]; then echo "Usage: ocp keys revoke <name|id>"; return 1; fi
       local result
-      result=$(_curl -sf --max-time 5 -X DELETE "$PROXY/api/keys/$2") || { echo "Error: proxy unreachable or unauthorized" >&2; return 1; }
+      # Issue #278 (same shape as cmd_logs above, see its comment) — kept on `_curl` (not bare
+      # curl): `_curl` adds the admin-key auth header via `_AUTH_ARGS`, dropping it here would
+      # silently break authenticated revoke requests.
+      result=$(_curl_or_die "proxy unreachable or unauthorized" _curl -sf --max-time 5 -X DELETE "$PROXY/api/keys/$2") || return 1
       echo "$result" | python3 -c "
 import sys, json
 d = json.loads(sys.stdin.read())
@@ -483,7 +494,9 @@ else:
       # unreachable proxy still gets its own accurate message), then let python3's failure route
       # through the shared `_pyfail` helper (raw JSON preserved, not swallowed by `2>/dev/null`).
       local data
-      data=$(_curl -sf --max-time 5 "$PROXY/api/keys") || { echo "Error: proxy unreachable or key management not available" >&2; return 1; }
+      # Issue #278 (same shape as cmd_logs above, see its comment) — kept on `_curl` (not bare
+      # curl): dropping it here would silently break authenticated list requests.
+      data=$(_curl_or_die "proxy unreachable or key management not available" _curl -sf --max-time 5 "$PROXY/api/keys") || return 1
       echo "$data" | python3 -c "
 import sys, json
 d = json.loads(sys.stdin.read())
@@ -561,13 +574,22 @@ cmd_connect() {
   echo ""
 
   # Step 1: Test connectivity via /health
+  #
+  # Issue #278: this used to be `curl ... 2>/dev/null`, a TRUE silence (unlike the seven other
+  # sites this issue fixes, which at least let bash's own diagnostic through unredirected) — a
+  # curl-exec failure here (curl missing from $PATH on the machine running `ocp connect`) reported
+  # "Cannot reach $base_url/health" with zero evidence the LOCAL curl binary, not the REMOTE peer,
+  # was the actual fault. Routed through `_curl_or_die` (#261/#267/#273) like the other seven, with
+  # one difference: `_curl_or_die`'s plain "Error: <label>" doesn't carry this function's own
+  # "Make sure OCP is running..." hint, and that hint would be WRONG advice on the local-fault
+  # branch (a missing local curl has nothing to do with whether the remote OCP is running) — so
+  # the hint is folded into the label itself, which only ever surfaces on the genuine-network-
+  # failure branch. Also fixes an independent, previously-uncalled-out defect found while doing
+  # this: neither original `echo` had `>&2`, so the diagnostic landed on STDOUT — unlike every one
+  # of this issue's other seven sites and unlike `_curl_or_die`'s own stderr convention.
   echo "  Checking connectivity..."
   local health_json
-  health_json=$(curl -sf --max-time 10 "$base_url/health" 2>/dev/null) || {
-    echo "  ✗ Cannot reach $base_url/health"
-    echo "    Make sure OCP is running on $host and bound to 0.0.0.0 (LAN mode)."
-    return 1
-  }
+  health_json=$(_curl_or_die "Cannot reach $base_url/health — make sure OCP is running on $host and bound to 0.0.0.0 (LAN mode)" curl -sf --max-time 10 "$base_url/health") || return 1
   echo "  ✓ Connected"
   echo ""
 
@@ -943,7 +965,8 @@ cmd_settings() {
   if [[ -z "${1:-}" ]]; then
     # GET — show all settings
     local data
-    data=$(curl -sf --max-time 5 "$PROXY/settings") || { echo "Error: proxy unreachable" >&2; return 1; }
+    # Issue #278 (same shape as cmd_logs above, see its comment).
+    data=$(_curl_or_die "proxy unreachable" curl -sf --max-time 5 "$PROXY/settings") || return 1
     echo "$data" | python3 -c "
 import sys, json
 d = json.loads(sys.stdin.read())

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -12440,6 +12440,184 @@ test("#273 stream parity: cmd_health 'proxy unreachable' guard writes to stderr,
   assert.equal(r.stdout, "", `cmd_health: stdout must stay clean of the error text; got: ${JSON.stringify(r.stdout)}`);
 });
 
+// ═════════════════════════════════════════════════════════════════════════════
+// Issue #278: the seven sites #273 itself named as its own deferred follow-up ("Seven further
+// sites ... print 'proxy unreachable' for a local fault but do not swallow bash's own message ...
+// Lower priority" — #273's own text), plus an eighth, higher-severity site found during #273's
+// own site survey (cmd_connect's health probe). All eight route through the existing
+// `_curl_or_die` helper (#261/#267/#273) — no new mechanism, same drop-in shape, `|| return 1`
+// preserved everywhere (never `exit 1` — `_curl_or_die`'s own doc comment shows `|| exit 1` only
+// as cmd_usage's own documented top-level-exit special case, not a template for functions reached
+// from ocp's outer dispatch and expected to `return`).
+//
+// Independent confirmation of the issue's own severity ranking (cmd_connect ranked ABOVE the
+// other seven), checked directly against the unmodified `ocp` source before writing these tests
+// rather than trusting the issue text: sites 1-7 below already write "Error: proxy
+// unreachable..." with `>&2` (real stderr) — a curl-exec failure at any of them still prints TWO
+// lines: bash's own "command not found"/"Permission denied" diagnostic (curl's stderr was never
+// redirected away) alongside the wrong "proxy unreachable" headline. Wrong and confusing, but the
+// true signal is visible somewhere on a real terminal. `cmd_connect`'s health probe was different
+// in KIND, not degree: `curl ... 2>/dev/null` discarded curl's own stderr outright, so a curl-exec
+// failure there produced exactly ONE line — "✗ Cannot reach $base_url/health" — with zero trace
+// of the real cause on either stream. That is total information loss vs. a confusing-but-visible
+// mislabel, which independently confirms the issue's ranking rather than merely asserting it.
+// Also found while confirming this (not previously called out anywhere): that same "✗ Cannot
+// reach ..." / "Make sure OCP is running ..." pair used plain `echo` with no `>&2` at all — the
+// diagnostic landed on STDOUT, unlike every one of the other seven sites and unlike
+// `_curl_or_die`'s own stderr convention. Routing this site through `_curl_or_die` fixes that too,
+// as a side effect of the fix rather than a separate change.
+console.log("\nocp: eight more silent-failure sites route through _curl_or_die (#278, generalizes #261's repro):");
+
+test("#278 cmd_logs: curl missing from $PATH must be reported as a local fault, not 'proxy unreachable'", () => {
+  const r = _bwHarnessRun({ args: ["logs"], curlAbsent: true });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(!r.stderr.includes("proxy unreachable") && !r.stdout.includes("proxy unreachable"),
+    `must NOT misattribute a missing curl binary to the proxy; stderr=${JSON.stringify(r.stderr)} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(/curl/i.test(r.stderr), `expected the message to name curl/the local command failure, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#278 control: cmd_logs with curl present but the proxy genuinely unreachable still says 'proxy unreachable'", () => {
+  const r = _bwHarnessRun({ args: ["logs"] });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(r.stderr.includes("Error: proxy unreachable"),
+    `a GENUINE network failure must still be reported as such (proves the fix does not just delete the diagnosis), got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#278 cmd_models: curl missing from $PATH must be reported as a local fault, not 'proxy unreachable'", () => {
+  const r = _bwHarnessRun({ args: ["models"], curlAbsent: true });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(!r.stderr.includes("proxy unreachable") && !r.stdout.includes("proxy unreachable"),
+    `must NOT misattribute a missing curl binary to the proxy; stderr=${JSON.stringify(r.stderr)} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(/curl/i.test(r.stderr), `expected the message to name curl/the local command failure, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#278 fold-in (exit 126 coverage): cmd_models with curl present but NOT EXECUTABLE must also be reported as a local fault, not 'proxy unreachable'", () => {
+  // Mirrors #261 fold-in B: the reviewer's own repro (`chmod 000` a real curl -> exit 126 +
+  // "Permission denied") for at least one of this issue's eight sites, so exit 126 is proven
+  // covered here too, not just exit 127 (curlAbsent).
+  const r = _bwHarnessRun({ args: ["models"], curlNotExecutable: true });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(!r.stderr.includes("proxy unreachable") && !r.stdout.includes("proxy unreachable"),
+    `must NOT misattribute a non-executable curl binary to the proxy; stderr=${JSON.stringify(r.stderr)} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(/curl/i.test(r.stderr), `expected the message to name curl/the local command failure, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#278 control: cmd_models with curl present but the proxy genuinely unreachable still says 'proxy unreachable'", () => {
+  const r = _bwHarnessRun({ args: ["models"] });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(r.stderr.includes("Error: proxy unreachable"),
+    `a GENUINE network failure must still be reported as such, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#278 cmd_sessions: curl missing from $PATH must be reported as a local fault, not 'proxy unreachable'", () => {
+  const r = _bwHarnessRun({ args: ["sessions"], curlAbsent: true });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(!r.stderr.includes("proxy unreachable") && !r.stdout.includes("proxy unreachable"),
+    `must NOT misattribute a missing curl binary to the proxy; stderr=${JSON.stringify(r.stderr)} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(/curl/i.test(r.stderr), `expected the message to name curl/the local command failure, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#278 control: cmd_sessions with curl present but the proxy genuinely unreachable still says 'proxy unreachable'", () => {
+  const r = _bwHarnessRun({ args: ["sessions"] });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(r.stderr.includes("Error: proxy unreachable"),
+    `a GENUINE network failure must still be reported as such, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#278 cmd_clear: curl missing from $PATH must be reported as a local fault, not 'proxy unreachable'", () => {
+  const r = _bwHarnessRun({ args: ["clear"], curlAbsent: true });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(!r.stderr.includes("proxy unreachable") && !r.stdout.includes("proxy unreachable"),
+    `must NOT misattribute a missing curl binary to the proxy; stderr=${JSON.stringify(r.stderr)} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(/curl/i.test(r.stderr), `expected the message to name curl/the local command failure, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#278 control: cmd_clear with curl present but the proxy genuinely unreachable still says 'proxy unreachable'", () => {
+  const r = _bwHarnessRun({ args: ["clear"] });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(r.stderr.includes("Error: proxy unreachable"),
+    `a GENUINE network failure must still be reported as such, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#278 cmd_keys revoke: curl missing from $PATH must be reported as a local fault, not 'proxy unreachable or unauthorized'", () => {
+  const r = _bwHarnessRun({ args: ["keys", "revoke", "laptop-marker"], adminKey: "test-admin-key-marker", curlAbsent: true });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(!r.stderr.includes("proxy unreachable") && !r.stdout.includes("proxy unreachable"),
+    `must NOT misattribute a missing curl binary to the proxy/auth layer; stderr=${JSON.stringify(r.stderr)} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(/curl/i.test(r.stderr), `expected the message to name curl/the local command failure, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#278 control: cmd_keys revoke with curl present but the proxy genuinely unreachable still says 'proxy unreachable or unauthorized'", () => {
+  const r = _bwHarnessRun({ args: ["keys", "revoke", "laptop-marker"], adminKey: "test-admin-key-marker" });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(r.stderr.includes("proxy unreachable or unauthorized"),
+    `a GENUINE network failure must still be reported as such, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#278 cmd_keys list: curl missing from $PATH must be reported as a local fault, not 'proxy unreachable or key management not available'", () => {
+  const r = _bwHarnessRun({ args: ["keys"], adminKey: "test-admin-key-marker", curlAbsent: true });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(!r.stderr.includes("proxy unreachable") && !r.stdout.includes("proxy unreachable"),
+    `must NOT misattribute a missing curl binary to the proxy/auth layer; stderr=${JSON.stringify(r.stderr)} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(/curl/i.test(r.stderr), `expected the message to name curl/the local command failure, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#278 control: cmd_keys list with curl present but the proxy genuinely unreachable still says 'proxy unreachable or key management not available'", () => {
+  const r = _bwHarnessRun({ args: ["keys"], adminKey: "test-admin-key-marker" });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(r.stderr.includes("proxy unreachable or key management not available"),
+    `a GENUINE network failure must still be reported as such, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#278 cmd_settings (GET): curl missing from $PATH must be reported as a local fault, not 'proxy unreachable'", () => {
+  const r = _bwHarnessRun({ args: ["settings"], curlAbsent: true });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(!r.stderr.includes("proxy unreachable") && !r.stdout.includes("proxy unreachable"),
+    `must NOT misattribute a missing curl binary to the proxy; stderr=${JSON.stringify(r.stderr)} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(/curl/i.test(r.stderr), `expected the message to name curl/the local command failure, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#278 control: cmd_settings (GET) with curl present but the proxy genuinely unreachable still says 'proxy unreachable'", () => {
+  const r = _bwHarnessRun({ args: ["settings"] });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(r.stderr.includes("Error: proxy unreachable"),
+    `a GENUINE network failure must still be reported as such, got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+// ── cmd_connect: the eighth, higher-severity site. Unlike the seven above, the pre-fix code
+// actively discarded curl's own stderr via `2>/dev/null` (a true silence, not just a
+// mislabeling), AND targets a REMOTE host ($base_url, built from the user's own `ocp connect
+// <host-ip>` argument) rather than $PROXY. 192.0.2.1 is a TEST-NET-1 documentation address (RFC
+// 5737) — never a real host — and no --port is passed, so cmd_connect's own pre-existing default
+// (3456) applies unmodified; this test file introduces no new port literal.
+console.log("\nocp cmd_connect: the eighth, higher-severity site — was a TRUE silence via 2>/dev/null (#278):");
+
+test("#278 cmd_connect: curl missing from $PATH must be reported as a local fault, not 'Cannot reach ...' — and must NOT carry the 'make sure OCP is running' hint (wrong advice for a local fault)", () => {
+  const r = _bwHarnessRun({ args: ["connect", "192.0.2.1"], curlAbsent: true });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(!r.stderr.includes("Cannot reach") && !r.stdout.includes("Cannot reach"),
+    `must NOT misattribute a missing curl binary to the remote host; stderr=${JSON.stringify(r.stderr)} stdout=${JSON.stringify(r.stdout)}`);
+  assert.ok(/curl/i.test(r.stderr), `expected the message to name curl/the local command failure, got stderr=${JSON.stringify(r.stderr)}`);
+  assert.ok(!r.stderr.includes("make sure OCP is running") && !r.stdout.includes("make sure OCP is running"),
+    `a local curl fault must NOT carry the 'make sure OCP is running on <host>' hint — that advice ` +
+    `is wrong when the real cause is a missing local curl binary, not a down remote peer; ` +
+    `stderr=${JSON.stringify(r.stderr)} stdout=${JSON.stringify(r.stdout)}`);
+});
+
+test("#278 control: cmd_connect with curl present but the remote genuinely unreachable still surfaces 'Cannot reach ... make sure OCP is running ...'", () => {
+  const r = _bwHarnessRun({ args: ["connect", "192.0.2.1"] });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.ok(r.stderr.includes("Cannot reach") && r.stderr.includes("make sure OCP is running"),
+    `a GENUINE network failure must still surface the original diagnosis + hint (proves the fix ` +
+    `does not just delete it), got stderr=${JSON.stringify(r.stderr)}`);
+});
+
+test("#278 cmd_connect: the diagnostic now goes to stderr, not stdout (previously neither echo had '>&2' — a positive side effect of routing through _curl_or_die)", () => {
+  const r = _bwHarnessRun({ args: ["connect", "192.0.2.1"] });
+  assert.notEqual(r.status, 0, `expected a nonzero exit; status=${r.status}`);
+  assert.equal(r.stdout.includes("Cannot reach"), false, `the diagnostic must not land on stdout; got stdout=${JSON.stringify(r.stdout)}`);
+});
+
 console.log("\nRestart-unit resolution (issue #233 defect 1) — macOS lsof exit-code handling:");
 
 // Background: `lsof -nP -iTCP:<port> -sTCP:LISTEN` EXITS 1 with EMPTY stdout when nothing


### PR DESCRIPTION
## Summary

Addresses the seven sites #273 itself named as its own deferred follow-up ("Seven further sites ... print 'proxy unreachable' for a local fault but do not swallow bash's own message ... Lower priority" — #273's own text: `cmd_logs`, `cmd_models`, `cmd_sessions`, `cmd_clear`, `cmd_keys revoke`, `cmd_keys` list, `cmd_settings` GET) plus an eighth, higher-severity site found during #273's own site survey: `cmd_connect`'s health probe.

Does not touch `server.mjs`; no `cli.js` citation required — this PR only changes the `ocp` bash CLI wrapper (a Class-B-adjacent client script, not a network-facing endpoint handler) and its test coverage in `test-features.mjs`.

## Endpoint Class

- [x] **Not endpoint-touching** — refactor of the `ocp` bash CLI's local error-diagnosis logic. No request handler in `server.mjs` is modified; every site here calls the SAME URL/method/headers/body as before, unchanged on the wire. `ocp` is a client of the endpoints listed in `ALIGNMENT.md`'s Class B inventory (`/logs`, `/v1/models`, `/sessions`, `/api/keys*`, `/settings`, `/health`), not the endpoint implementation itself.

## The eight sites

All eight share the shape `<expr>=$(curl ... "$PROXY/<path>") || { echo "Error: <label>" [>&2]; return 1; }` and could not tell "curl itself never ran" (local shell/exec fault — curl missing from `$PATH`, permission denied, a corrupted binary) apart from "curl ran and the request genuinely failed" (network down, proxy not listening) — both produced the same "proxy unreachable"-shaped text.

1. `cmd_logs` (`ocp:319` pre-fix)
2. `cmd_models` (`ocp:354` pre-fix)
3. `cmd_sessions` (`ocp:374` pre-fix)
4. `cmd_clear` (`ocp:398` pre-fix)
5. `cmd_keys revoke` (`ocp:462` pre-fix) — uses the `_curl` wrapper (admin-key auth header), kept on `_curl`, not swapped to bare `curl`
6. `cmd_keys` list (`ocp:486` pre-fix) — also `_curl`, kept
7. `cmd_settings` GET (`ocp:946` pre-fix)
8. `cmd_connect`'s health probe (`ocp:566` pre-fix)

Sites 1–7 already wrote their "Error: proxy unreachable..." text with `>&2` (real stderr) — a curl-exec failure at any of them still printed bash's own diagnostic (curl's stderr was never redirected away) alongside the wrong headline: confusing, but the true signal was visible somewhere. Site 8 was categorically worse: `curl -sf --max-time 10 "$base_url/health" 2>/dev/null` **discarded** curl's own stderr outright, so a curl-exec failure there produced exactly one line — `✗ Cannot reach $base_url/health` — with zero trace of the real cause on either stream.

## Independent confirmation of the issue's own severity ranking

The issue text ranks `cmd_connect` above the other seven. Verified this directly against the unmodified `ocp` source before writing any test, rather than trusting the issue's assertion: grepped all eight sites and confirmed sites 1–7 use `>&2` (so bash's own "command not found"/"Permission denied" diagnostic still reaches the real terminal, just alongside a wrong "proxy unreachable" headline — a mislabel, not a silence), while site 8's `2>/dev/null` produces total information loss on a curl-exec failure. Total silence is a strictly worse failure mode than a confusing-but-recoverable mislabel, which independently confirms the ranking rather than merely repeating it.

**A previously-uncalled-out second defect found at site 8 while doing this:** neither of `cmd_connect`'s original two `echo` lines (`  ✗ Cannot reach ...` / `    Make sure OCP is running ...`) had `>&2` at all — the diagnostic landed on **stdout**, unlike every one of the other seven sites and unlike `_curl_or_die`'s own stderr convention. Not previously named anywhere (not in #273, not in #278's own issue text). Fixed as a side effect of routing this site through `_curl_or_die`, called out here rather than left as a silent behavior change.

## Fix

All eight routed through the existing `_curl_or_die` helper (#261/#267/#273) — no new mechanism, same drop-in shape (`<expr>=$(_curl_or_die "<label>" curl ...) || return 1`). `return 1` preserved at every site, never `exit 1` — `_curl_or_die`'s own doc comment shows `|| exit 1` only as `cmd_usage`'s own documented top-level-exit special case, not a template for functions reached through `ocp`'s outer dispatch and expected to `return` to their caller.

**`cmd_connect` judgment call:** `_curl_or_die`'s plain `"Error: <label>"` doesn't fit this function's two-line "✗ .../    Make sure ..." UX, and folding in the hint verbatim would put the "Make sure OCP is running on $host..." advice on BOTH branches — wrong on the local-fault branch, where the real cause has nothing to do with whether the remote OCP is running. Fix: fold the hint into the label string itself, so it only ever surfaces on the genuine-network-failure branch:

```
health_json=$(_curl_or_die "Cannot reach $base_url/health — make sure OCP is running on $host and bound to 0.0.0.0 (LAN mode)" curl -sf --max-time 10 "$base_url/health") || return 1
```

The local-fault branch instead gets only `_curl_or_die`'s own "could not run curl (...) — this is a local shell/environment fault, not a proxy problem" text — never the "make sure OCP is running" hint. Tested explicitly (see below).

## Evidence — RED then GREEN

Baseline on `origin/main` (`8d8b4d6`), verified before writing any test: **873 passed, 0 failed**.

**RED** (18 new tests added, `ocp` unmodified): **880 passed, 11 failed** — exactly the expected 11 (the 7 non-`cmd_connect` money tests + the `cmd_models` exit-126 fold-in + all 3 `cmd_connect` tests, since the pre-fix `cmd_connect` code fails the stdout/stderr-routing assertions too, not just the misattribution ones):

```
✗ #278 cmd_logs: curl missing from $PATH must be reported as a local fault, not 'proxy unreachable': must NOT misattribute a missing curl binary to the proxy; stderr="Error: proxy unreachable\n" stdout=""
✗ #278 cmd_models: curl missing from $PATH must be reported as a local fault, not 'proxy unreachable': must NOT misattribute a missing curl binary to the proxy; stderr="Error: proxy unreachable\n" stdout=""
✗ #278 fold-in (exit 126 coverage): cmd_models with curl present but NOT EXECUTABLE must also be reported as a local fault, not 'proxy unreachable': must NOT misattribute a non-executable curl binary to the proxy; stderr="bash: .../bin/curl: Permission denied\nError: proxy unreachable\n" stdout=""
✗ #278 cmd_sessions: curl missing from $PATH must be reported as a local fault, not 'proxy unreachable': must NOT misattribute a missing curl binary to the proxy; stderr="Error: proxy unreachable\n" stdout=""
✗ #278 cmd_clear: curl missing from $PATH must be reported as a local fault, not 'proxy unreachable': must NOT misattribute a missing curl binary to the proxy; stderr="Error: proxy unreachable\n" stdout=""
✗ #278 cmd_keys revoke: curl missing from $PATH must be reported as a local fault, not 'proxy unreachable or unauthorized': must NOT misattribute a missing curl binary to the proxy/auth layer; stderr="Error: proxy unreachable or unauthorized\n" stdout=""
✗ #278 cmd_keys list: curl missing from $PATH must be reported as a local fault, not 'proxy unreachable or key management not available': must NOT misattribute a missing curl binary to the proxy/auth layer; stderr="Error: proxy unreachable or key management not available\n" stdout=""
✗ #278 cmd_settings (GET): curl missing from $PATH must be reported as a local fault, not 'proxy unreachable': must NOT misattribute a missing curl binary to the proxy; stderr="Error: proxy unreachable\n" stdout=""
✗ #278 cmd_connect: curl missing from $PATH must be reported as a local fault, not 'Cannot reach ...' — and must NOT carry the 'make sure OCP is running' hint (wrong advice for a local fault): must NOT misattribute a missing curl binary to the remote host; stderr="" stdout="OCP Connect\n...\n  ✗ Cannot reach http://192.0.2.1:3456/health\n    Make sure OCP is running on 192.0.2.1 and bound to 0.0.0.0 (LAN mode).\n"
✗ #278 control: cmd_connect with curl present but the remote genuinely unreachable still surfaces 'Cannot reach ... make sure OCP is running ...': a GENUINE network failure must still surface the original diagnosis + hint (proves the fix does not just delete it), got stderr=""
✗ #278 cmd_connect: the diagnostic now goes to stderr, not stdout (previously neither echo had '>&2' — a positive side effect of routing through _curl_or_die): the diagnostic must not land on stdout; got stdout="OCP Connect\n...\n  ✗ Cannot reach http://192.0.2.1:3456/health\n    Make sure OCP is running on 192.0.2.1 and bound to 0.0.0.0 (LAN mode).\n"
```

**GREEN (final):** **891 passed, 0 failed**. All 18 new tests pass.

## Mutation testing

Every mutation applied to the live `ocp` file, `grep`-confirmed to have landed before running the suite, verified via `shasum -a 256` before and after every restore (restored via `cp` from a pre-mutation backup, never `git checkout --`, so the file's uncommitted state was never at risk of being silently discarded). Backup deleted after use, not committed.

| # | Site | Mutation | Result | Named test(s) that fail | Verdict |
|---|---|---|---|---|---|
| 1 | `cmd_logs` | Revert to the original bare-curl shape | 890 passed, 1 failed | `#278 cmd_logs: curl missing from $PATH...` | Killed, no collateral |
| 2 | `cmd_models` | Revert to the original bare-curl shape (`2>&1` variant) | 889 passed, 2 failed | `#278 cmd_models: curl missing from $PATH...`, `#278 fold-in (exit 126 coverage): cmd_models...` | Killed, no collateral — one mutation caught both the 127 and 126 money tests |
| 3 | `cmd_sessions` | Revert to the original bare-curl shape | 890 passed, 1 failed | `#278 cmd_sessions: curl missing from $PATH...` | Killed, no collateral |
| 4 | `cmd_clear` | Revert to the original bare-curl shape | 890 passed, 1 failed | `#278 cmd_clear: curl missing from $PATH...` | Killed, no collateral |
| 5 | `cmd_keys revoke` | Revert to the original bare-`_curl` shape | 890 passed, 1 failed | `#278 cmd_keys revoke: curl missing from $PATH...` | Killed, no collateral |
| 6 | `cmd_keys` list | Revert to the original bare-`_curl` shape | 890 passed, 1 failed | `#278 cmd_keys list: curl missing from $PATH...` | Killed, no collateral |
| 7 | `cmd_settings` GET | Revert to the original bare-curl shape | 890 passed, 1 failed | `#278 cmd_settings (GET): curl missing from $PATH...` | Killed, no collateral |
| 8 | `cmd_connect` | Revert to the original 3-line `2>/dev/null` shape | 888 passed, 3 failed | all 3 `#278 cmd_connect...`/`#278 control: cmd_connect...` tests | Killed, no collateral |

Every mutation was killed by exactly its own site's test(s), with zero collateral damage to any other test in the 891-test suite (confirmed by the passed-count arithmetic: 891 minus the number of tests killed equals the passed count in every row). No survivors — no gaps to disclose.

## No new port literals

`test-features.mjs` and `ocp` are both CI-exempt from the port-literal SPOT check, but none were added anyway: `cmd_connect`'s test drives `["connect", "192.0.2.1"]` with no `--port` flag, so `cmd_connect`'s own pre-existing default (`port=3456`, untouched production code) applies — the only place "3456" appears in this diff's additions is inside an explanatory comment, not a new literal. `192.0.2.1` is a TEST-NET-1 documentation address (RFC 5737), not a real host.

## Full suite

`npm test`: **891 passed, 0 failed** (final, post-restore, pre-push).

## Judgment calls for the reviewer

1. `cmd_connect`'s label wording (`"Cannot reach $base_url/health — make sure OCP is running on $host and bound to 0.0.0.0 (LAN mode)"`) drops the original `✗ ` glyph prefix and the two-line indentation styling, in favor of `_curl_or_die`'s uniform `"Error: <label>"` format. Functionally equivalent, visually different from every other `cmd_connect` step's own `✗`/`✓` bullet convention — flagging in case the maintainer prefers preserving the glyph.
2. `cmd_connect`'s stdout→stderr change (previously-uncalled-out defect, described above) is a second, independent fix bundled into the same commit as the primary `2>/dev/null`-removal fix, since both live on the identical line and splitting them into two commits/PRs for one single-line change seemed like over-splitting under Iron Rule 11 rather than genuine layer separation. Flagging in case the maintainer would prefer it split out.
3. Independent review (Iron Rule 10) has **not** been performed as part of this PR — this was implemented solo end-to-end. Per this repo's own hard requirement, a fresh-context reviewer must read the diff and confirm before merge; this PR should not be merged until that happens.

## Related

- `ALIGNMENT.md` Rule(s) invoked: none (not endpoint-touching; `server.mjs` untouched)
- Authorizing ADR (Class B only): n/a
- Related issue / prior PR: generalizes #261's own repro; refs #267; refs #273 (the PR that named these seven sites as its own deferred follow-up)
- Historical lesson reference: n/a

### User-visible change self-check (铁律第五律 5.3)

- [x] This PR has user-visible changes (CLI diagnostic-message text on local-fault paths) but is not a new documented feature/flag/endpoint per the release_kit's `new_feature_doc_expectations` list (no new CLI subcommand, env var, endpoint, or schema — only the wording/routing of an existing error path on eight existing commands) → no README update required. Matches the precedent set by the same-shaped diagnostic-wording PRs against this helper (see #279, see #267, see #273), none of which touched README either.

### Privacy self-check (for PUBLIC repos)

- [x] This PR does not introduce real names, nicknames, or handles that identify specific individuals.
- [x] This PR does not introduce literal personal paths (`/Users/<username>/`, `/home/<username>/`).
- [x] This PR does not introduce personal machine hostnames.
- [x] This PR does not introduce personal email addresses beyond the automated `Co-Authored-By: Claude <noreply@anthropic.com>` trailer.

Closes #278
