### PR TITLE
docs(specs): replace invented "Rule 2 carve-out" citations with ADR 0006 authority

### DIFF
--- a/docs/superpowers/specs/2026-04-25-47-sse-heartbeat-design.md
+++ b/docs/superpowers/specs/2026-04-25-47-sse-heartbeat-design.md
@@ -180,6 +180,12 @@ Historical reference: PR #43 / postmortem #44 (2026-04-22) scrubbed a prior leak
 
 `cli.js` does not itself emit SSE heartbeat frames — claude CLI speaks newline-delimited JSON to stdout, not SSE. SSE is an OCP-owned translation layer. Per `ALIGNMENT.md` Rule 2 / `AGENTS.md` ("OCP forwards, observes, and multiplexes traffic that cli.js already emits"): heartbeats are a translation-layer response-shaping concern, not a new endpoint and not a behavior mimicry. The PR body will state this explicitly in the `cli.js` citation checkbox and reference this design doc.
 
+> **Correction (2026-08-01, per issue #282).** The paragraph above cites `ALIGNMENT.md` Rule 2 as the reason heartbeat frames are in scope. Rule 2 ("No Invention") is a prohibition — it does not authorize anything — and `ALIGNMENT.md:17` additionally scopes Rules 1–5 to Class A (`cli.js`-mirror) surface only. This design was never Class A surface, so Rule 2 was never the applicable rule in either direction.
+>
+> This document was drafted before ADR 0006 (dated 2026-05-20). The `/v1/chat/completions` streaming path this design extends is Class B.1 (`ALIGNMENT.md` § "Current Class B inventory"); its protocol authority is OpenAI's published `/v1/chat/completions` specification (https://platform.openai.com/docs/api-reference/chat/create) plus ADR 0006 — not `cli.js`, and not Rule 2. Under that authority the reasoning in this section still holds: OpenAI's spec does not forbid an SSE comment frame, which conforming SSE parsers are specified to ignore, so the feature remains in scope as an additive, opt-in response-shaping behavior.
+>
+> The decision stands as shipped in v3.12.0 ("Streaming heartbeat" — see CHANGELOG). Only the cited authority was wrong.
+
 ## IDR (Iron Rule 11) disposition
 
 Single PR. Scope is one feature (SSE heartbeat) × one layer (streaming response formatting) × one severity (minor opt-in addition). Release-kit companion files (version bump, CHANGELOG, README) are bundled with the code change per the explicit Iron Rule 11 example ("版本 bump 相关的小改动 + README + CHANGELOG 可以同 PR"). The separate filings for the dangling-client bug (`server.mjs:480-489`) and any follow-up heartbeat format variants are IDR-compliant — each lands as its own PR.

--- a/docs/superpowers/specs/2026-05-07-cache-upgrade-design.md
+++ b/docs/superpowers/specs/2026-05-07-cache-upgrade-design.md
@@ -28,6 +28,12 @@ This PR pair extends the existing cache (introduced in earlier commits) without 
 
 Per Rule 1 / Rule 5: every commit body in this PR pair will state the absence of `cli.js` reference explicitly and justify scope under Rule 2's value-add carve-out for non-wire-affecting proxy operations.
 
+> **Correction (2026-08-01, per issue #282).** The sentence above justifies scope under "Rule 2's value-add carve-out." No such carve-out exists: `ALIGNMENT.md` Rule 2 (`ALIGNMENT.md:21`, "No Invention") is a prohibition with no value-add exception — verified directly against the constitution (`grep -ci 'carve.out\|value-add' ALIGNMENT.md` → 0) — and `ALIGNMENT.md:17` additionally scopes Rules 1–5 to Class A (`cli.js`-mirror) surface regardless. A prohibition cannot authorize anything, in Class A or Class B.
+>
+> This document was drafted before ADR 0006 (dated 2026-05-20, less than two weeks later), which is the taxonomy that actually governs this surface. Under it: the internal cache mechanics behind `/v1/chat/completions` (D1–D3 — per-key isolation, `cache_control` bypass, chunked replay) are Class B.1, covered by ADR 0006's authorization of that endpoint's existing surface; the additive `/cache/stats` fields that shipped with D4 (`inflight`, `requesters` — CHANGELOG v3.13.0, "Existing fields `entries`, `totalHits`, `sizeBytes` are preserved unchanged") are Class B.2, grandfathered by ADR 0006 subject to the behaviour-preserving bar at `ALIGNMENT.md:114`.
+>
+> D1–D4 stand as shipped in v3.13.0. Only the cited authority was wrong.
+
 ---
 
 ## Key decisions (with rationale)


### PR DESCRIPTION
# Pull Request

## Summary

Two long-lived design docs under `docs/superpowers/specs/` cite `ALIGNMENT.md` Rule 2 as an authorization for a change. Rule 2 is a prohibition (`ALIGNMENT.md:21`) — it cannot authorize anything — and `ALIGNMENT.md:17` additionally scopes Rules 1–5 to Class A, which neither document's change was. This is the same category error PR #281 removed from `CLAUDE.md`, `AGENTS.md`, `README.md`, the PR template, and the ADR index; these two were deliberately left for a separate PR because they are historical design records, not instruction files, and editing them is a different layer under Iron Rule 11. Each gets a correction note appended (original text preserved) naming the authority that actually governs the surface: ADR 0006 (Class A/B taxonomy).

## Endpoint Class (REQUIRED)

- [x] **Not endpoint-touching** — both changed files are historical design docs under `docs/superpowers/specs/`. No request handler is modified. `server.mjs` is untouched. `ALIGNMENT.md` is untouched (supreme document, its own amendment procedure, not engaged here).

## Verification

**The invented clause does not exist.** `2026-05-07-cache-upgrade-design.md:29` cited "Rule 2's value-add carve-out." Checked directly against the constitution:

```
$ grep -ci 'carve.out\|value-add' ALIGNMENT.md
0
```

Rule 2 (`ALIGNMENT.md:21`) is titled "No Invention" and reads: *"OCP must not introduce endpoints, headers, request fields, or response fields that are not present in `cli.js`."* No carve-out, no value-add exception, no authorization language of any kind.

**The second instance.** `2026-04-25-47-sse-heartbeat-design.md:181` cites `ALIGNMENT.md` Rule 2 / `AGENTS.md` as the reason SSE heartbeat frames (an addition to the `/v1/chat/completions` streaming response) are in scope. Same category error — a prohibition cited as permission.

**Repo-wide sweep for every other Rule 2 citation** (not just the two the issue named):

| Location | Usage | Verdict |
|---|---|---|
| `ALIGNMENT.md:21`, `:150` | Rule 2's own definition / Class B rule-mapping table | Source of truth — not a citation elsewhere |
| `AGENTS.md:48`, `CLAUDE.md:49,68`, `.github/PULL_REQUEST_TEMPLATE.md:27,59` | "Rule 2 is a prohibition, not an authorization" | Correct — PR #281 already made this correction |
| `CHANGELOG.md:338,388,398,420,459` | "Rule 2 not engaged" / "Rule 2 spirit" (SPOT motivation for a mechanical refactor, not a Class B invention claim) | Correct — declines to invoke Rule 2 as authority |
| `docs/adr/0006-openai-shim-scope.md` (×5) | Analyzes why a strict Rule 2 reading blocks PR #99; the ADR's own rationale, not a citation of Rule 2 as authorization elsewhere | Correct |
| `docs/adr/0003-models-json-spot.md:65` | "per `ALIGNMENT.md` Rule 2 it is out of scope" | Correct — prohibition used as a prohibition |
| `docs/adr/0008-tui-warm-pane-pool.md:189` | Names ADR 0007 + ADR 0008 as the authority, references Rule 2 only as which Class-B-mapped citation slot is being discharged | Correct |
| `docs/runbooks/615-canary.md:120` | "the response is to drop the Anthropic provider rather than escalate spoofing" — Rule 2 cited as the reason *not* to invent spoof-escalation behavior | Correct |
| `docs/superpowers/plans/shipped/2026-04-25-47-sse-heartbeat-plan.md` (×2) | Same underlying pattern (Rule 2 cited as authorization) | **Same defect, but out of scope** — `AGENTS.md` designates `docs/superpowers/plans/shipped/` as archive ("don't propose changes against shipped plans — they're history"); it is the literal record of what the PR body/commit said at the time, not a design authority document. Left untouched. |
| `docs/superpowers/specs/2026-05-07-cache-upgrade-design.md:29` | "Rule 2's value-add carve-out" | **Defect — fixed in this PR** |
| `docs/superpowers/specs/2026-04-25-47-sse-heartbeat-design.md:181` | "Per `ALIGNMENT.md` Rule 2 ... heartbeats are ... not a new endpoint" | **Defect — fixed in this PR** |

**True count: 2 documents require correction** (matches the issue). One additional instance of the same pattern exists in the archived shipped-plan doc, explicitly out of scope per `AGENTS.md`'s own archival policy — noted for completeness, not touched.

## What changed, and why that authority

Neither document's underlying decision is in question, only the authority cited:

- **`cache-upgrade-design.md`** — the internal cache mechanics behind `/v1/chat/completions` (per-key isolation, `cache_control` bypass, chunked replay) are Class B.1, covered by ADR 0006's authorization of that endpoint's existing surface. The additive `/cache/stats` fields that shipped with this design (`inflight`, `requesters` — CHANGELOG v3.13.0: *"Existing fields `entries`, `totalHits`, `sizeBytes` are preserved unchanged"*) are Class B.2, grandfathered by ADR 0006 subject to the behaviour-preserving bar at `ALIGNMENT.md:114`.
- **`sse-heartbeat-design.md`** — the streaming path this design extends is Class B.1 (`/v1/chat/completions`); its protocol authority is OpenAI's published `/v1/chat/completions` specification plus ADR 0006, not `cli.js` and not Rule 2.

Both documents were drafted before ADR 0006 existed (dated 2026-05-20; the cache doc is dated 2026-05-07, the heartbeat doc 2026-04-25) — the same structural gap that motivated ADR 0006's own creation, originally triggered by PR #99's `response_format` review. Both decisions shipped (v3.12.0, v3.13.0 per CHANGELOG) and both correction notes say so explicitly: **the decision stands, only the cited authority was wrong.**

One observation for the record, not acted on here since it is outside this issue's scope: the `/cache/stats` additive fields (`inflight`, `requesters`) were shipped citing no separate ADR beyond the general grandfather provision, whereas ADR 0008's comparable additive `/health` `pool` sub-object later got its own dedicated ADR even while arguing it met the same behaviour-preserving bar. Whether the cache-stats addition should have followed that same path is a live-code compliance question, not a spec-authority-citation question — flagging it, not resolving it here.

## Type of change

- [x] Documentation / governance

## Related

- `ALIGNMENT.md` Rule(s) invoked: Rule 2 (Class B mapping), `ALIGNMENT.md:17`, `ALIGNMENT.md:114`
- Authorizing ADR (Class B only): ADR 0006
- Related issue / prior PR: #282, refs #281, refs #193
- Historical lesson reference: same category error #281 addressed in the governance-instruction layer; this PR is the design-record layer, filed separately per Iron Rule 11 as #282 itself specifies

### User-visible change self-check (铁律第五律 5.3)

- [x] This PR has no user-visible changes → stated "no user-visible change" in summary above

### Privacy self-check (for PUBLIC repos)

- [x] No real names, nicknames, or handles identifying specific individuals — role-based terms only.
- [x] No literal personal paths.
- [x] No personal machine hostnames.
- [x] No personal email addresses beyond automated placeholders.

## Reviewer checklist (for the independent reviewer)

- [ ] Confirm the diff touches only the two named files under `docs/superpowers/specs/` — no request handler modified.
- [ ] Confirm `server.mjs` and `ALIGNMENT.md` are absent from this diff.
- [ ] Open `ALIGNMENT.md` and independently verify: (a) Rule 2 (`ALIGNMENT.md:21`) contains no carve-out or value-add exception — `grep -ci 'carve.out\|value-add' ALIGNMENT.md` returns 0; (b) `ALIGNMENT.md:17` scopes Rules 1–5 to Class A; (c) `ALIGNMENT.md:114` is the grandfather-provision sentence cited for the cache doc's `/cache/stats` fields.
- [ ] Open ADR 0006 and confirm it actually supports the B.1/B.2 classifications asserted in each correction note.
- [ ] I am not the commit author (Iron Rule 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gbqUZ8HfBZpjjbzQ85oH8
