### PR TITLE
docs(adr): record maintainer ratification of ADR 0010

### DIFF
--- a/docs/adr/0010-health-verdict-semantics.md
+++ b/docs/adr/0010-health-verdict-semantics.md
@@ -1,15 +1,15 @@
 # ADR 0010 — `/health` and `/status` verdict semantics (what `degraded` means)
 
 **Date:** 2026-08-01
-**Status:** Proposed — implemented, awaiting maintainer sign-off
+**Status:** Accepted
 
-> Per `AGENTS.md` § "ADR writing protocol (Category A)", an ADR is drafted, shown to the
-> maintainer, and only then accepted. This one was authored by an agent alongside the
-> implementation and has **not** been reviewed by the maintainer yet, so it must not claim
-> otherwise. The code it describes is independently reviewed and verified; what is pending is
-> sign-off on the *semantics* — specifically what `degraded` is allowed to mean, since
-> `ocp update`'s post-flight check and human operators both read it.
-**Deciders:** pending — proposed by an implementing agent, not yet ratified
+> **Ratified 2026-08-02 by the project maintainer.** This ADR was drafted by an
+> implementing agent and initially recorded itself as Accepted before anyone had read it; that
+> was corrected to Proposed, and the maintainer has now signed off explicitly. What was ratified
+> is the Decision section below, unchanged since it was first shown. The Consequences section
+> carries a later in-place correction (issue #289) to its consumer enumeration — that correction
+> is agent-authored analysis, not part of what was ratified.
+**Deciders:** project maintainer (ratified 2026-08-02)
 **Related:** issue #232; ADR 0006 (Class A/B taxonomy + the B.2 grandfather provision); ADR 0007 (precedent for amending a grandfathered B.2 endpoint's response); `ALIGNMENT.md` § "Current Class B inventory"
 
 ---


### PR DESCRIPTION
The maintainer has signed off on ADR 0010. This records it.

## Why this is a PR rather than a silent edit

ADR 0010 originally shipped with `Status: Accepted` and `Deciders: project maintainer` — written by the implementing agent, before the maintainer had read a word of it. That was caught at merge time and corrected to `Proposed — awaiting maintainer sign-off`, with a note explaining that an ADR asserting a decision nobody made is the same "claims more than the process established" defect this repo spent the week removing from code.

The sign-off has now happened, so leaving it marked provisional would be its own inaccuracy in the opposite direction.

## What is and is not covered by the signature

Scoped deliberately, because the file changed after it was shown:

- **Ratified:** the Decision section, byte-identical to what was presented — Decision-block hash `692aceca3864abcf` at merge (`ad0eef4`) and on `main` today.
- **Not ratified:** the Consequences section's in-place correction block added under #289, which audited the original consumer enumeration and found three errors in it. That is agent-authored analysis. The header note says so explicitly, so a future reader does not read the signature as covering text the maintainer never saw.

No behaviour change. `server.mjs` untouched. Documentation-only, to an ADR's own status metadata. Suite green at 941.

Refs #232, #289.