### PR TITLE
chore(release): v3.28.0 — forced tool_choice refused, launchd domain probe, curl fault attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v3.28.0 — 2026-08-03
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -583,10 +583,10 @@ Top-level files a contributor or operator may need to know:
 | `models.json` | Single source of truth for model IDs, aliases, context windows. See ADR 0003. |
 | `ocp` / `ocp-connect` | User-facing CLI wrappers (server-side / client-side respectively). |
 | `dashboard.html` | Static dashboard served from `/dashboard`. |
-| `lib/constants.mjs` | Shared constants (default port, loopback host, local proxy URL) — one definition for `server.mjs`, the CLIs and the tests. |
+| `lib/constants.mjs` | Shared constants (default port, loopback host, local proxy URL) — one definition for `server.mjs`, `setup.mjs`, the `scripts/` helpers and `lib/tui/`. The bash CLIs cannot import it and carry a keep-in-sync note instead. |
 | `lib/env.mjs` | Fail-closed positive-integer parsing for the numeric env caps (body size, image bytes, …). |
 | `lib/multimodal.mjs` | OpenAI `image_url` content parts → Anthropic image blocks for `claude -p --input-format stream-json`. See § "Images / Multimodal (Vision)". |
-| `lib/net.mjs` | `isLoopbackBind()` — whether a bind address is reachable from another host. Gates TUI mode (`OCP_TUI_ALLOW_LAN`) and the `OCP_LOCAL_TOOLS` boot check, both of which fail closed on a non-loopback bind. |
+| `lib/net.mjs` | `isLoopbackBind()` — true only for addresses that **cannot** be reached from another host; anything else (`0.0.0.0`, `::`, a concrete LAN/Tailscale IP) counts as network-exposed. Gates TUI mode (`OCP_TUI_ALLOW_LAN`) and the `OCP_LOCAL_TOOLS` boot check, both of which fail closed on a non-loopback bind. |
 | `lib/prompt.mjs` | Pure system-prompt assembly: operator append, per-model truncation budget, wrapper selection. See ADR 0011. |
 | `lib/spawn-auth.mjs` | Pure primitives for `-p` spawn-token resolution and HOME isolation (serial mutex, TTL cache, expiry, label ordering). |
 | `lib/structured-output.mjs` | OpenAI `response_format` helpers — detection, JSON-Schema validation, payload extraction. Class B.1, ADR 0006. |

--- a/README.md
+++ b/README.md
@@ -583,6 +583,15 @@ Top-level files a contributor or operator may need to know:
 | `models.json` | Single source of truth for model IDs, aliases, context windows. See ADR 0003. |
 | `ocp` / `ocp-connect` | User-facing CLI wrappers (server-side / client-side respectively). |
 | `dashboard.html` | Static dashboard served from `/dashboard`. |
+| `lib/constants.mjs` | Shared constants (default port, loopback host, local proxy URL) — one definition for `server.mjs`, the CLIs and the tests. |
+| `lib/env.mjs` | Fail-closed positive-integer parsing for the numeric env caps (body size, image bytes, …). |
+| `lib/multimodal.mjs` | OpenAI `image_url` content parts → Anthropic image blocks for `claude -p --input-format stream-json`. See § "Images / Multimodal (Vision)". |
+| `lib/net.mjs` | `isLoopbackBind()` — whether a bind address is reachable from another host. Gates TUI mode (`OCP_TUI_ALLOW_LAN`) and the `OCP_LOCAL_TOOLS` boot check, both of which fail closed on a non-loopback bind. |
+| `lib/prompt.mjs` | Pure system-prompt assembly: operator append, per-model truncation budget, wrapper selection. See ADR 0011. |
+| `lib/spawn-auth.mjs` | Pure primitives for `-p` spawn-token resolution and HOME isolation (serial mutex, TTL cache, expiry, label ordering). |
+| `lib/structured-output.mjs` | OpenAI `response_format` helpers — detection, JSON-Schema validation, payload extraction. Class B.1, ADR 0006. |
+| `lib/tool-support.mjs` | `classifyToolRequest()` — which `tools` / `tool_choice` / `function_call` shapes OCP must refuse. See ADR 0013. |
+| `lib/tui/` | Subscription-pool (TUI) mode internals: warm-pane pool, semaphore, session, stream, transcript. |
 | `scripts/sync-openclaw.mjs` | Idempotent OpenClaw registry sync invoked by `ocp update`. See ADR 0004. |
 | `scripts/lib/service-mode.mjs` | Pure decision layer for `setup.mjs`'s auto-start step — first install vs. `--reconfigure-only` (issue #226). |
 | `scripts/lib/install-autostart.mjs` | Injectable `installAutoStart()` — setup.mjs's auto-start install (legacy-unit migration, unit write, enable/start/bootstrap), extracted so tests can observe real run/fs calls instead of asserting on source text (issue #226). |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-claude-proxy",
-  "version": "3.27.0",
+  "version": "3.28.0",
   "description": "OCP (Open Claude Proxy) — use your Claude Pro/Max subscription as an OpenAI-compatible API for any IDE. Works with Cline, OpenCode, Aider, Continue.dev, OpenClaw, and more.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release **v3.28.0**. Eleven changes since v3.27.0.

**Class: not endpoint-touching.** `package.json`, `CHANGELOG.md`, `README.md` only — no request handler is modified. (Per `CLAUDE.md`: a `server.mjs` change is not involved, so no class evidence is owed; requirements 2 and 3 still apply and both are satisfied below.)

## What's in it

| PR | Issue | Change |
|---|---|---|
| #322 | #311 | A **forced** `tool_choice` is refused with a 400 instead of silently answered with prose. Five spec-defined forcing forms; a bare `tools` list is untouched. ADR 0013. |
| #320 | #290 | macOS restart resolution probes **both** launchd domains, so a root LaunchDaemon is a diagnosed refusal rather than a permanent one. |
| #319 | #291 | Post-flight says **which** failure it saw instead of calling every one "unreachable". |
| #318 | #304 | `warn_count`'s 2-WARN shape covered; the second site classified rather than papered over. |
| #317 | #310 | The body cap counts **characters** — the label said "MB". At `CLAUDE_MAX_BODY_SIZE=1000` the old label rendered `max 0MB`. |
| #316 | #292, #288 | Hybrid-note citation fixed; the additive-field question decided. ADR 0012. |
| #315 | #309 | `ocp-connect` declares each model's real context window instead of a per-family guess (4 of 7 were under-declared). |
| #314 | #297 | `ocp update --target=vX.Y.Z` (equals form) parsed at the Node layer, not just the bash layer. |
| #313 | #298 | `start.sh`'s Linux bind check resolves `ss` to an absolute path — the #246 gap on the branch that actually runs in production. |
| #312 | #296, #299, #300 | The five remaining bare-`curl` probes report a local fault as a local fault. |
| — | #307 | The truncation ceiling is derived per model, so `models.json` can state true context windows. ADR 0011. |

Three ADRs land with it: **0011** (per-model prompt budget), **0012** (additive fields on grandfathered B.2), **0013** (no OpenAI tool calling). 0012 and 0013 are **Proposed** and need maintainer sign-off.

## release_kit walk

Each item in `CLAUDE.md`'s `release_kit:` overlay, checked rather than assumed:

- **`resource_lists` / Available Models.** `models.json` changed this cycle — four models went `200000` → `1000000` under ADR 0011 — so README's table was diffed against the SPOT **programmatically**, not read: 7 ids, 7 rows, every `contextWindow` equal. No drift.
- **New env var** → **none this cycle.** My first pass claimed `CLAUDE_MAX_PROMPT_CHARS` was newly added; that was wrong, and the check behind it was wrong in *method*: it grepped added lines for `process.env.*`, which finds variables **referenced** on a changed line, not variables **introduced**. `CLAUDE_MAX_PROMPT_CHARS` is present at the **v3.25.0** tag. Re-checked properly: every env token appearing on an added line since v3.27.0 already existed at that tag, so the obligation is satisfied vacuously. (The release commit `0ac75cc` carries the original wrong sentence and cannot be amended; it is corrected in `51087e7`.)
- **New endpoint** → none. #311 refuses on an existing endpoint; its 400 contract went into README § "Client-tools boundary" in that PR.
- **New CLI subcommand / auto-sync / hook / bootstrap quirk** → none this cycle.
- **New file** → `lib/tool-support.mjs`. This surfaced a **standing gap**: README's Repository Layout enumerated every `scripts/lib/*` module and **not one** of the eight top-level `lib/*` modules. Adding a single row for the new file would have left seven siblings undocumented, so all nine entries are now listed.

## On the layout rows

Descriptions are taken from each module's own header comment and exports. **Two were corrected against the code before commit**, and both corrections are the point:

- `lib/net.mjs` — I first wrote "load-bearing for LAN-mode auth". It is not. `isLoopbackBind` gates **TUI mode** (`server.mjs:818`, `OCP_TUI_ALLOW_LAN`) and the **`OCP_LOCAL_TOOLS` boot check** (`server.mjs:842-847`), both fail-closed on a non-loopback bind.
- The multimodal cross-reference was written as a GitHub anchor whose exact slug I could not verify (my own shell check collapsed the double space and so could not be trusted). Replaced with plain prose, matching the table's neighbouring `See ADR 0004.` style — an unverifiable link is worse than no link.

## Verification

- `npm test` on this commit: **998 passed, 0 failed**, exit 0.
- Layout-table completeness checked programmatically: 9 `lib/` entries, 9 rows, 0 missing.
- Every row of the `tool_choice` contract table added to README in #322 was verified behaviorally against `lib/tool-support.mjs` (9 shapes, refusal + `error.param` per row) and the error body against `server.mjs:2977-2982`.

## Review outcome

Independent fresh-context reviewer (Iron Rule 10). **REQUEST CHANGES → resolved in `51087e7`.** The reviewer independently re-ran every release_kit check rather than trusting this body — parsing `models.json` against README's table, scanning for new routes/subcommands/env vars, and reading all nine new layout rows against the modules they describe.

Two P1s, both false statements this PR itself introduced:

- **`lib/net.mjs` row inverted the predicate.** It said `isLoopbackBind()` reports "whether a bind address is reachable from another host". It returns **true** for loopback — addresses that *cannot* be reached from another host. On a predicate that gates two fail-closed boot checks, a reader would have had the exposure question exactly backwards. This was one of the two rows I had already "corrected" before the first commit: I checked *where* the function is called and never checked *what it returns*. Polarity now re-verified by driving it over 8 addresses.
- **`lib/constants.mjs` row named two consumer groups that do not consume it** — "the CLIs and the tests". `test-features.mjs` imports it zero times, and `ocp`/`ocp-connect` are bash and cannot import a `.mjs` at all; `lib/constants.mjs:14` carries a keep-in-sync note for that exact reason. Real importers verified and named.

P2: the env-var provenance claim above, now corrected.

**Governance note the reviewer raised, for the maintainer:** ADRs **0012** and **0013** are `Status: Proposed`. The release does not misrepresent them — CHANGELOG and the ADR index both say "Proposed — needs maintainer sign-off". But tagging ships #322's live 400 behaviour and ADR 0012's loosened B.2 rule to users while their authorizing documents await sign-off. Merging is the natural sign-off moment: either flip both to Accepted in a follow-up, or consciously ship under Proposed. **That is a maintainer decision, not one taken here.**

## Reviewer

Independent reviewer (Iron Rule 10): confirm the diff genuinely touches no request handler — that is the class declared here, and per `CLAUDE.md` it is the cheapest class to declare and so the one most worth checking. Then confirm the version/CHANGELOG pair is consistent and spot-check any layout-row description against the module it describes.

On merge, `v3.28.0` gets tagged and `.github/workflows/release.yml` creates the GitHub Release.
