### PR TITLE
chore(release): v3.29.0 — live-proven spawn credential leak, /health tells the truth twice, no ADR is Proposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v3.29.0 — 2026-08-05
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -208,8 +208,7 @@ The canonical list lives in [`models.json`](./models.json) — the single source
 |----------|--------|-------------|
 | `/v1/models` | GET | List available models |
 | `/v1/chat/completions` | POST | Chat completion (streaming + non-streaming) |
-| `/health` | GET | Comprehensive health check (includes a `tui` block for TUI-mode drift/concurrency monitoring, and an `auth` block — see § "What `auth.ok` means") |
-| `/health` | GET | Comprehensive health check (includes a `tui` block for TUI-mode drift/concurrency monitoring, and `instanceName` — see § "Running more than one instance on a host") |
+| `/health` | GET | Comprehensive health check (includes a `tui` block for TUI-mode drift/concurrency monitoring, an `auth` block — see § "What `auth.ok` means" — and `instanceName` — see § "Running more than one instance on a host") |
 | `/usage` | GET | Plan usage limits + per-model stats |
 | `/status` | GET | Combined overview (usage + health) |
 | `/settings` | GET/PATCH | View or update settings at runtime |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-claude-proxy",
-  "version": "3.28.0",
+  "version": "3.29.0",
   "description": "OCP (Open Claude Proxy) — use your Claude Pro/Max subscription as an OpenAI-compatible API for any IDE. Works with Cline, OpenCode, Aider, Continue.dev, OpenClaw, and more.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What this is

The v3.29.0 release commit. `package.json` 3.28.0 → 3.29.0, the CHANGELOG's `## Unreleased` heading dated, and one duplicated README table row merged. **Not endpoint-touching** — no request handler is modified.

> **Amended after review.** The first revision reported the ADR 0012 sweep as **1 field this cycle**. The independent reviewer showed it is **2**. Details in the sweep section below — that correction is the substantive content of this update, and it went in the direction that hides things, so it is written up rather than quietly patched.

## Release content

Seven commits since v3.28.0. One is a security fix proven on a live host, not reasoned about:

| | |
|---|---|
| **#328** | OCP's own inbound credentials were passed into every spawned `claude`. On the tenant host the agent and the root instance shared one `PROXY_API_KEY`, and the `:3456` instance ran as a user with `NOPASSWD: ALL`. One benign-framed prompt walked that chain end to end. Fixed at **four spawn sites** with a **three-pass scrub** that also catches aliases and OCP-issued key shapes. |
| **#308** | `/health` reported `auth.ok: true` on hosts where no request could be served. `claude auth status` measures token **presence**, not validity — a fabricated token exits 0 with `loggedIn: true`. The probe now reports what it measured, and a completed request is conclusive evidence. ADR 0014. |
| **#324** | A stale latched rejection could block `ocp update` forever. |
| **#327** | A non-primary instance can declare itself on `/health` via `OCP_INSTANCE_NAME`. |
| **#325** | `ocp restart` that cannot start no longer leaves the service DOWN silently. |
| **#326, #333** | ADRs 0006, 0008, 0012, 0013 signed off. **No ADR in `docs/adr/` carries `Proposed` any more** — verified across all 13, which use three different status-line formats. |

## governance_audits — ADR 0012 additive-field sweep (first real run)

> **This cycle: 2 fields.** `instanceName` and `auth.consecutiveInconclusive`, both on `/health` (#327, #324).
> **Cumulative to date: 2.**

Both verified **on the live wire**, not from the CHANGELOG's own claim. A server booted on a guarded free port returns:

```
auth keys ON THE WIRE: ok, lastCheck, message, lastOutcome,
                       consecutiveFailures, consecutiveInconclusive, okSource, okAt
instanceName (top level): "probe-rig"
```

**The sweep's first run found two defects in the sweep** (filed as #338):

1. **The prescribed grep is case-sensitive.** The #324 entry opens a sentence with `**Additive under ADR 0012.**` — capital A. A literal run returns 2 and **silently drops a real field**. This is what the first revision of this PR got wrong.
2. **It counts its own prose.** Run case-insensitively it returns 3; one hit is the CHANGELOG entry *describing the sweep mechanism*, which necessarily quotes the marker string it greps for.

ADR 0012 names the cumulative integer as the load-bearing part of the audit ("a monotonically rising integer is what makes the accumulation visible at all"), so both defects corrupt exactly the number that matters — one downward, one upward. The governance text is **not** amended here; that is a different layer (Iron Rule 11).

**Within the sweep's documented blind spot, but worth naming:** `/health` also gained `okSource` and `okAt` this cycle. They carry no ADR 0012 marker, correctly — they arrive under **ADR 0014** as part of a contract change, not as additive fields. Fully authorized, differently routed, invisible to this sweep.

## release_kit walk

- **version_source** — 3.28.0 → 3.29.0; no second hardcode of the version anywhere in the tree.
- **changelog** — `## Unreleased` → `## v3.29.0 — 2026-08-05`, matching the em-dash form of all prior entries. The rewrite refused to run unless exactly one `## Unreleased` heading existed.
- **resource_lists**
  - Available Models: **7/7** `models.json` ids in the README table.
  - API Endpoints: **15 distinct paths over 20 handler arms**; README lists 15; the sets match **in both directions**. My first extractor reported 4, then 13 — both wrong, because routing here is written `req.url === "…"`, not `pathname === "…"`, and three arms are `startsWith`/regex. The reviewer caught the undercount independently. A narrow extractor finding nothing missing is a false green, and this one was narrow twice.
  - Environment Variables: `OCP_INSTANCE_NAME` at `README.md:270`, a genuine row inside the table body.
- **new_feature_doc_expectations** — one new env var, documented. No new CLI subcommand, endpoint, hook or SPOT. `docs/adr/0014-*.md` needs no Repository Layout row: the table carries a `docs/adr/` **directory** row.
- **bootstrap_quirk_policy** — none this cycle.

## README fix folded in, deliberately

The API Endpoints table carried **two** `/health` rows. #334 rewrote the row for the new `auth` block; #336 appended a second for `instanceName` instead of editing the first — so each row documented one field and **omitted the other**. Merged into one row keeping both section references.

Folded into this PR rather than deferred: the `release_kit` lists that table as a release-gated resource list, so the gate found the defect it exists to find. Shipping v3.29.0 with it would make the gate ceremonial. One deleted line, reviewable in place. Push back if you read Iron Rule 11 as forbidding it.

## Evidence

```
=== Results: 1040 passed, 0 failed ===
```
(re-run after the amendment)

## Reviewer checklist

- [ ] **Class: not endpoint-touching.** Three files: a version string, a heading, one merged table row. Confirm `server.mjs` is untouched — this is the cheapest class to declare, so the one most worth checking.
- [ ] Re-run the ADR 0012 sweep **case-insensitively** and confirm 2, not 1 and not 3.
- [ ] Confirm the merged `/health` row kept **both** section references (`What auth.ok means` and `Running more than one instance on a host`).
- [ ] Confirm no `Proposed` ADR remains — note the three status-line formats; one grep pattern under-covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gbqUZ8HfBZpjjbzQ85oH8
