### PR TITLE
chore(release): v3.29.1 — the UTF-8 P0, and a CHANGELOG heading a merge silently reverted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v3.29.1 — 2026-08-06
+
 ### Fixed
 
 - **UTF-8 was silently corrupted whenever a character straddled a chunk boundary (#359, P0).** All four request-body readers accumulated with `body += chunk`, which coerces each `Buffer` to a string **independently**. A multi-byte character whose bytes arrive in two chunks is decoded as replacement characters *before* the pieces are joined, so the join can never repair it: `你好世界` became `\uFFFD\uFFFD\uFFFD好世界`. Each of the four readers now calls `req.setEncoding("utf8")`, which installs a `StringDecoder` on the stream so an incomplete trailing sequence is held until the next chunk completes it. Sites: `PATCH /settings`, `POST /v1/chat/completions`, `POST /api/keys`, `PATCH /api/keys/:id/quota`.
@@ -15,6 +17,10 @@
 
 ### Changed
 
+- **`listKeys` redacts in SQL, so raw key material never enters process memory (#295).** External contribution by @anupamme. The preview is now computed by the query (`substr(key,1,8)||'...'||substr(key,-4)`) and the full `key` column is no longer SELECTed, so `GET /api/keys`, the dashboard and `ocp keys` get identical output while the secret never reaches Node. Behaviour-preserving on a grandfathered B.2 endpoint: JSON property *order* changes, and all three consumers read by name — verified at `server.mjs:3679`, `dashboard.html:224`, `ocp:594`.
+  - **Review found the three-layer test design is load-bearing, not redundant.** A mutation the author did not write — a full-key leak hidden *inside* `substr(key,1,36)` — is invisible to the SQL-shape test by construction (its regex strips exactly the region the leak hides in) and invisible to the `db.prepare` spy. Only the byte-equality test against a real key catches it.
+  - After this change **no query in `keys.mjs` selects the raw `key` column at all** — `validateKey` and `findKey` already selected only `id, name`, so `listKeys` was the last read-path door.
+
 - **The ADR 0012 additive-field audit now reads the wire instead of the CHANGELOG (#346).** The sweep in `CLAUDE.md`'s `release_kit.governance_audits` used to grep the CHANGELOG for ADR 0012's condition-5 marker. It missed a **compliant** spelling three times running — sentence-initial capital (#338), markdown link (#344 first pass), bold wrapped *around* the reference (#344 second pass) — every one caught by a human reviewer and none by the mechanism. Its own written stopping rule ("if a THIRD compliant spelling is missed, stop widening") had fired, so this replaces it rather than widening it a fourth time.
   - **The spelling was the symptom; reading prose to learn what shipped was the disease.** Every version of that grep, including a hypothetically perfect one, could only see additions whose author *wrote the marker*. A field added with no marker returned "none this cycle" — a positive-looking result for the case the audit was least able to see, and the exact shape of the four pre-#288 additions that motivated ADR 0012 in the first place.
   - **New mechanism: a per-release record of each grandfathered Class B.2 endpoint's real response key set.** `scripts/b2-key-snapshot.mjs` boots a real `server.mjs`, probes **all 16 endpoint+method pairs** across the 12 Class B.2 rows in `ALIGNMENT.md` § "Current Class B inventory", and records each response's recursive **key paths** plus its status and content-type into `docs/governance/b2-response-keys.json`. `npm test` fails on any difference, naming every added and removed key path and stating which authorization each kind needs. The snapshot's git history is the per-release record: `git log -p docs/governance/b2-response-keys.json`.
@@ -27,6 +33,8 @@
   - **The marker grep is kept as a secondary cross-check**, unchanged and still deliberately missing a known compliant spelling so the gap stays visible. Its incompleteness is no longer load-bearing: a marker it misses now surfaces from the key-set diff instead.
   - **Found while building it, recorded rather than fixed here, now tracked as #355:** nothing in `server.mjs` ever writes the `sessions` Map (declared at `server.mjs:965`; **0 occurrences of `sessions.set(` and 0 of `sessions.get(`** — only `.delete` and `.clear`), so `/health`'s and `/sessions`'s `sessions[]` are empty on every request. The blast radius is wider than one empty array: `/status`'s `activeSessions` and `stats.sessionHits` / `sessionMisses` are permanently constant too, and `CLAUDE_SESSION_TTL` is a documented env var whose only effect is timing a GC sweep whose loop body cannot execute. The snapshot recording `sessions[]` as an empty key set is the first mechanism that would catch a writer being added.
   - **No `server.mjs` change**, so no endpoint class is declared: this PR adds test and governance surface only.
+
+## v3.29.0 — 2026-08-05
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,31 @@ This project's overlay per iron rule v1.4's 5.5. Machine-checkable declaration.
 release_kit:
   version_source: package.json
   changelog: CHANGELOG.md
+  changelog_convention: |
+    INSERT the new version heading BELOW a retained empty `## Unreleased`.
+    Do NOT rename `## Unreleased` in place.
+
+    Renaming in place is what caused v3.29.0's release notes to be relabelled
+    `## Unreleased` by a later merge — #354's branch predated the rename and
+    carried its own older copy of that line, so it won. Measured, holding base
+    and feature branch fixed and varying only this convention:
+
+      rename-in-place  -> exit 0, CLEAN merge; the feature entry files
+                          SILENTLY into the just-shipped section
+      insert-below     -> exit 1, CONFLICT; a human resolves it
+
+    The cure is not that entries land in the right section. It is that git can
+    no longer silently file into a SHIPPED one, because the release commit and
+    the feature branch now contend for the same region.
+
+    So: after a release, a CHANGELOG conflict on an open branch is the EXPECTED
+    outcome, not a nuisance. A clean auto-merge on a branch whose entry predates
+    the release is the symptom, not the happy path.
+
+    Coverage is partial and the boundary was measured: a branch created AFTER
+    the release lands its entry inside `## Unreleased` correctly; a branch that
+    ALREADY EXISTED still needs its entry moved BY HAND on merge-forward,
+    because git merges by context lines, not by section semantics.
   release_channel:
     type: github-release
     tag_format: v{semver}
@@ -203,9 +228,15 @@ release_kit:
         whichever grep flags the releaser happens to use. That recomputation is what
         produced both of #338's defects.
       baseline: |
-        As of v3.29.0 the cumulative ADR 0012 count is 2, both on /health:
-          instanceName                  (#327)
-          auth.consecutiveInconclusive  (#324)
+        As of v3.29.1 the cumulative ADR 0012 count is 2, both on /health:
+          instanceName                  (#327)   added in v3.29.0
+          auth.consecutiveInconclusive  (#324)   added in v3.29.0
+
+        v3.29.1: NONE THIS CYCLE. Recorded rather than omitted, per the report:
+        clause above — a releaser reading only the count cannot otherwise tell a
+        cycle that was audited and added nothing from a cycle nobody audited.
+        The B.2 key-set snapshot also matched unchanged, which is the stronger
+        of the two signals: it would have caught a field added with no marker.
 
         RECONCILED AGAINST THE WIRE when the snapshot was first recorded (#346): both
         key paths are present in docs/governance/b2-response-keys.json's "GET /health"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-claude-proxy",
-  "version": "3.29.0",
+  "version": "3.29.1",
   "description": "OCP (Open Claude Proxy) — use your Claude Pro/Max subscription as an OpenAI-compatible API for any IDE. Works with Cline, OpenCode, Aider, Continue.dev, OpenClaw, and more.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Cuts **v3.29.1**, and repairs a CHANGELOG structure that a merge silently reverted.

## Why a patch release now rather than batching

**#364 fixed a P0 that corrupts the operator's own traffic.** `body += chunk` decoded each `Buffer` separately, so a UTF-8 character split across a chunk boundary became replacement characters — `你好世界` → `���好世界` — on the default production path, with no exception and no log line. It is merged to `main` but **production is still running v3.29.0, which has it**. Every day unreleased is corruption exposure on non-ASCII prompts.

The other three commits are safe to ship alongside: a security improvement (#329, keys never enter process memory on the `listKeys` path), a governance tool that does not run in production (#354), and a provably comment-only change (#349).

## The thing that made this more than a version bump

**`## v3.29.0 — 2026-08-05` had been replaced by `## Unreleased`.**

`d02e91e` (PR #354) did it. That branch predated the release commit that dated the heading, so it carried its own older copy of the line and won on merge. The four post-tag entries then accumulated into that same section.

**Same class as #339's duplicate `auth:` key** — a branch written against pre-change code silently reintroducing the pre-change line on merge, somewhere nothing errors. One file over.

Effect: in `main`, v3.29.0's release notes were labelled "Unreleased" and mixed with four entries that shipped after it. The published GitHub Release is generated from the tag and was never wrong; only the file was.

### Rebuilt, with byte equality as the acceptance criterion

Not re-dated — that would have relabelled v3.29.0's content as v3.29.1 and lost the v3.29.0 notes entirely.

```
v3.29.0 section and everything below it
  vs  git show v3.29.0:CHANGELOG.md
  →  BYTE-IDENTICAL
```

And the two sections diffed before surgery: **26 lines added, 0 deleted** — proving #354 replaced the heading without swallowing content. 774 → 776 lines.

## release_kit walk

- **version_source** — 3.29.0 → 3.29.1. Four remaining `3.29.0` strings are historical references to the audit baseline, not version fields; each checked individually.
- **changelog** — `## Unreleased` → `## v3.29.1 — 2026-08-06`, and `## v3.29.0 — 2026-08-05` restored above the v3.29.0 body.
- **resource_lists** — models 7/7 in the README table; API Endpoints 15 rows / 15 distinct / no duplicates; no new env var (the only added `process.env` reference is `PATH`, in a test fixture).
- **governance_audits** — ADR 0012 sweep with the tolerant pattern, scoped to the v3.29.1 section: raw hits **0**, field entries **0** → **none this cycle**. Cumulative unchanged at **2**.

  **The clause's anchored baseline is updated to say so.** A releaser reading only a count cannot distinguish a cycle that was audited and added nothing from one nobody audited — which is the omission the clause exists to prevent.

  **The B.2 key-set snapshot (#346, new this cycle) also matched unchanged.** That is the stronger of the two signals: it sees a field added with *no* marker, which no version of the grep can.

## Evidence

```
=== Results: 1059 passed, 0 failed ===
✓ integration (#346): every grandfathered B.2 endpoint's response key set matches the checked-in snapshot
```

## Sequencing note for whoever merges next

**This PR should land before #350 and #351.** Both resolved CHANGELOG conflicts against the *broken* structure — #350's author reported that main "had folded its `## v3.29.0` heading into `## Unreleased`" and that their first resolution misfiled a section. Merging this first gives them a correct structure to rebase onto; merging them first puts their entries into the mislabelled section and this repair has to be redone.

## Reviewer checklist

- [ ] **Class: not endpoint-touching.** Three files: a version field, CHANGELOG structure, and the `governance_audits` baseline. Confirm `server.mjs` is absent from the diff — note that `git diff --stat origin/main` will *not* be a reliable check if main moves; use `$(git merge-base origin/main HEAD)`.
- [ ] **Re-run the byte-equality check yourself.** `git show v3.29.0:CHANGELOG.md | sed -n '3,$p'` against everything from `## v3.29.0` down in this branch. This is the one claim where being wrong loses a release's notes.
- [ ] Confirm the v3.29.1 section contains **only** the four post-tag entries and nothing that belongs to v3.29.0.
- [ ] Re-run the ADR 0012 sweep scoped to the v3.29.1 section and confirm 0 — then confirm the baseline text records that rather than omitting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gbqUZ8HfBZpjjbzQ85oH8
