### PR TITLE
fix(upgrade): the recovery note takes the facts, not the scope-derived tag (#392)

### DIFF
--- a/scripts/lib/restart-unit.mjs
+++ b/scripts/lib/restart-unit.mjs
@@ -988,9 +988,9 @@ export function planRestart(owner, opts = {}) {
         `"${opts.expectedUnit}"'s config in the first place (scripts/lib/snapshot.mjs). ${secondUnitClause}`
       );
       if (owner.platform === "darwin") {
-        return { action: "launchd", warnings, cmds: launchdCmds(opts) };
+        return { action: "launchd", mismatched: owner.mismatched, warnings, cmds: launchdCmds(opts) };
       }
-      return { action: "user-unit", warnings, cmds: [{ cmd: `systemctl --user restart -- ${opts.expectedUnit}`, label: "restart" }] };
+      return { action: "user-unit", mismatched: owner.mismatched, warnings, cmds: [{ cmd: `systemctl --user restart -- ${opts.expectedUnit}`, label: "restart" }] };
     }
     throw new Error(
       `restart aborted: nothing is currently listening on the OCP port, so there is nothing to ` +
@@ -1075,7 +1075,7 @@ export function planRestart(owner, opts = {}) {
   }
 
   if (owner.kind === "launchd") {
-    return { action: "launchd", warnings, cmds: launchdCmds(opts) };
+    return { action: "launchd", mismatched: owner.mismatched, warnings, cmds: launchdCmds(opts) };
   }
 
   if (owner.kind === "system-unit") {
@@ -1091,7 +1091,7 @@ export function planRestart(owner, opts = {}) {
       // OPTION rather than the restart argument. UNIT_NAME_RE already rejects a leading "-" —
       // this is defense in depth at the actual shell-out boundary, the same posture MED-5 took
       // for shell-metacharacter injection.
-      return { action: "system-unit", warnings, cmds: [{ cmd: `systemctl restart -- ${owner.unit}`, label: "restart" }] };
+      return { action: "system-unit", mismatched: owner.mismatched, warnings, cmds: [{ cmd: `systemctl restart -- ${owner.unit}`, label: "restart" }] };
     }
     if (!opts.sudoAuthorized) {
       throw new Error(
@@ -1103,14 +1103,14 @@ export function planRestart(owner, opts = {}) {
         `instead would repeat issue #215.`
       );
     }
-    return { action: "system-unit", warnings, cmds: [{ cmd: `sudo systemctl restart -- ${owner.unit}`, label: "restart" }] };
+    return { action: "system-unit", mismatched: owner.mismatched, warnings, cmds: [{ cmd: `sudo systemctl restart -- ${owner.unit}`, label: "restart" }] };
   }
 
   if (owner.kind === "user-unit") {
     if (!UNIT_NAME_RE.test(owner.unit)) {
       throw new Error(`restart aborted: resolved unit name "${owner.unit}" failed validation — refusing to shell out with it.`);
     }
-    return { action: "user-unit", warnings, cmds: [{ cmd: `systemctl --user restart -- ${owner.unit}`, label: "restart" }] };
+    return { action: "user-unit", mismatched: owner.mismatched, warnings, cmds: [{ cmd: `systemctl --user restart -- ${owner.unit}`, label: "restart" }] };
   }
 
   throw new Error(`restart aborted: unrecognized owner.kind "${owner.kind}"`);

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -1080,16 +1080,22 @@ export function restoreRetryBudget(action, { attempts, backoffMs }) {
 //
 // Extracted rather than fixed twice: both ladders render this sentence, and a two-copy fix is how
 // #352's LOW-1 came to be fixed on one path and left asserted on the other for four days.
-export function restartOwnerRecoveryNote(action) {
+// #392: the note takes the FACTS, not the action tag. `action === "user-unit"` used to claim
+// "the unit OCP installs, Restart=always" — but user-unit is assigned from the cgroup SCOPE alone,
+// not authorship; a discovered user-scope unit that is NOT OCP's own gets the same tag. The claim
+// is now made only when the resolved unit is the expected one (`!mismatched`); a mismatched
+// user-unit gets the same honest "discovered, policy unknown" wording system-unit already had.
+export function restartOwnerRecoveryNote({ action, mismatched = false }) {
   if (action === "launchd") {
     return `If the bootout succeeded the job is unloaded and nothing will start it on its own — `
       + `the bootout's exit status is discarded (\`|| true\`), so that is not confirmed here.`;
   }
-  if (action === "user-unit") {
+  if (action === "user-unit" && !mismatched) {
     return `This is the unit OCP installs, configured Restart=always, so systemd may bring it back `
       + `by itself — but it has not within the probe budget.`;
   }
-  // `system-unit`, and any shape a future planRestart adds. Named as unknown rather than assumed.
+  // `system-unit`, a mismatched `user-unit`, and any shape a future planRestart adds. Named as
+  // unknown rather than assumed.
   return `This unit was discovered rather than installed by OCP, so its Restart= policy is not `
     + `known here; it may or may not come back on its own.`;
 }
@@ -2027,7 +2033,7 @@ async function runFullUpgrade({ doctor, opts }) {
             // #372 / #381 F4: "nothing will start it on its own" was asserted for BOTH shapes here
             // (#352's LOW-1 fixed only the rollback path), and the two-way fix that replaced it was
             // still a two-way split over a THREE-value domain. Per shape, from one shared helper.
-            + `${restartOwnerRecoveryNote(restartPlan.plan.action)} `
+            + `${restartOwnerRecoveryNote({ action: restartPlan.plan.action, mismatched: restartPlan.plan.mismatched })} `
             + `Bring it back with: ${recoveryCmds}  `
             + `Then, and only then, consider the working tree: it may be at the new version, and \`ocp update --rollback\` restores from the snapshot.` }
       );
@@ -2960,7 +2966,7 @@ async function runRollback(opts) {
           // LOW-1, now via the shared helper (#381 F4): the two-way form this replaces asserted
           // `Restart=always` for `system-unit` too, which OCP never installs and whose Restart=
           // directive it never reads.
-          + `${restartOwnerRecoveryNote(restartPlan.plan.action)} `
+          + `${restartOwnerRecoveryNote({ action: restartPlan.plan.action, mismatched: restartPlan.plan.mismatched })} `
           + `Bring it back with: ${recoveryCmds}  `
           + `The working tree is ALREADY rolled back to ${meta.fromVersion || meta.fromCommit} — do not run \`ocp update --rollback\` again; `
           + `the only thing missing is a running service.` }

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -12212,22 +12212,29 @@ test("#381 F4: the `will anything restart it?` note is per plan shape over all T
   // system-unit; the `else` asserted `Restart=always` for BOTH non-launchd shapes. The cited
   // authority (`install-autostart.mjs`) writes only the USER unit — a `system-unit` comes from
   // `resolveOwningUnit`, an arbitrary unit whose Restart= directive OCP never reads.
-  const user = restartOwnerRecoveryNote("user-unit");
-  const system = restartOwnerRecoveryNote("system-unit");
-  const launchd = restartOwnerRecoveryNote("launchd");
+  const user = restartOwnerRecoveryNote({ action: "user-unit", mismatched: false });
+  const userMismatched = restartOwnerRecoveryNote({ action: "user-unit", mismatched: true });
+  const system = restartOwnerRecoveryNote({ action: "system-unit", mismatched: true });
+  const launchd = restartOwnerRecoveryNote({ action: "launchd" });
 
   assert.notEqual(user, system,
     "the two systemd shapes must not render the same sentence — that is the defect");
   assert.match(user, /Restart=always/, "OCP installs this one and knows its policy");
   assert.ok(!/Restart=always/.test(system),
     `OCP never reads a discovered unit's Restart= directive; got ${JSON.stringify(system)}`);
+  // #392: a mismatched user-unit is NOT OCP's own — the SCOPE-derived tag used to claim it was.
+  // It must get the same honest "discovered, policy unknown" wording system-unit already had.
+  assert.equal(userMismatched, system,
+    `a mismatched user-unit must claim no more than a discovered unit does; got ${JSON.stringify(userMismatched)}`);
+  assert.ok(!/Restart=always/.test(userMismatched),
+    `a mismatched user-unit is not OCP's own, so Restart=always is a claim nobody verified; got ${JSON.stringify(userMismatched)}`);
   assert.match(system, /not\s+known|discovered/i, `it must say so; got ${JSON.stringify(system)}`);
   assert.ok(!/Restart=always/.test(launchd), `launchd has no such directive; got ${JSON.stringify(launchd)}`);
   // The launchd claim is hedged because the resolved bootout's exit status is discarded (`|| true`)
   // and this note only renders when a restart command already failed.
   assert.match(launchd, /If the bootout succeeded/, `got ${JSON.stringify(launchd)}`);
   // An unrecognised shape must fall to the "not known" answer, never to a claim.
-  assert.equal(restartOwnerRecoveryNote("some-future-shape"), system,
+  assert.equal(restartOwnerRecoveryNote({ action: "some-future-shape" }), system,
     "an unknown shape must claim no more than a discovered one does");
 });
 


### PR DESCRIPTION
# Summary

`restartOwnerRecoveryNote(action)` claimed **"This is the unit OCP installs, configured Restart=always"** for every `user-unit` — but `user-unit` is assigned from the **cgroup SCOPE alone** (`restart-unit.mjs`: `kind: cgroupResult.scope === "system" ? "system-unit" : "user-unit"`), not authorship. A discovered user-scope unit that is NOT OCP's own got the same claim, in the one hint that only renders when a restart command has already failed (#392).

## The fix

The note now takes **the facts, not the tag**:

```js
restartOwnerRecoveryNote({ action, mismatched = false })
```

- `user-unit` + `!mismatched` → the Restart=always claim (true: the resolved unit is OCP's own).
- `user-unit` + `mismatched` → the same honest "discovered, policy unknown" wording `system-unit` already had.
- `launchd` / unknown → unchanged.

`planRestart`'s six returns now carry `mismatched: owner.mismatched`, and both `ocp update` call sites pass it. The helper's table test gains the mismatched-user-unit row: it must equal the discovered-unit wording and carry no `Restart=always`.

## Class

**Not endpoint-touching** — `scripts/upgrade.mjs` + `scripts/lib/restart-unit.mjs` + `test-features.mjs` only; no `server.mjs`, no response shape.

## Test

`node --check` clean; full suite running. The table test is a pure-function unit test; a mutation that drops the `!mismatched` condition reddens the new row (userMismatched must equal system, not user).

## Reviewer

I am the author and cannot self-approve (Iron Rule 10).
