### PR TITLE
fix(doctor): expose the structured per-host unit inventory in --json (#327 part 5)

### DIFF
--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -1129,11 +1129,17 @@ export async function runDoctor(opts = {}) {
   // comment above classifyMultiUnitRisk for the full design rationale (why WARN not
   // FAIL, why grouping is by port alone, why this doesn't depend on
   // scripts/lib/restart-unit.mjs).
+  // #327 part 5: the per-host unit inventory is already derived by this check; expose it as
+  // STRUCTURED JSON (not only the human message) so an agent or `ocp update --all-instances` can
+  // enumerate declared instances without parsing prose.
+  let units = null;
   if (!opts.skipNetwork) {
     const multiUnit = detectMultiUnitBootRace(opts);
     if (multiUnit.state === "warn") {
+      units = multiUnit.units;
       push("multi_unit_boot_race", "WARN", describeMultiUnitConflict(multiUnit.groups, multiUnit.identityGroups));
     } else if (multiUnit.state === "declared") {
+      units = multiUnit.units;
       // #327. Kept under the SAME check id deliberately: this is the same check reaching
       // a verdict, and the id is a stable machine-readable handle an operator or agent may
       // already key on. INFO does not touch warn_count/fail_count, so a correctly-declared
@@ -1309,6 +1315,9 @@ export async function runDoctor(opts = {}) {
     current_version: currentVersion,
     latest_version: latestVersion,
     from_version_supported: fromSupported,
+    // #327 part 5: the structured per-host unit inventory (name/scope/port/instanceName per
+    // enabled unit), null when the check could not enumerate (skipNetwork or unknown state).
+    units,
     fail_count,
     warn_count,
     checks,

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -589,7 +589,9 @@ function describeClaim(identity) {
 // a port and all three claim the primary is genuinely two findings, and the operator
 // who fixes only the port collision still has an ambiguous host.
 function groupAndAssessConflicts(units) {
-  if (units.length < 2) return { state: "clear" };
+  // #327 part 5 (review F1): "clear" still ENUMERATED the unit — a single-install host is the
+  // most common shape, and its inventory is exactly as useful to part 4 as a multi-instance one.
+  if (units.length < 2) return { state: "clear", units };
 
   const portGroups = groupBy(units, u => u.port).filter(g => g.length >= 2);
   const identityGroups = groupBy(units, claimedInstance)
@@ -1131,12 +1133,15 @@ export async function runDoctor(opts = {}) {
   // scripts/lib/restart-unit.mjs).
   // #327 part 5: the per-host unit inventory is already derived by this check; expose it as
   // STRUCTURED JSON (not only the human message) so an agent or `ocp update --all-instances` can
-  // enumerate declared instances without parsing prose.
+  // enumerate declared instances without parsing prose. Non-null whenever the check ENUMERATED
+  // (clear/warn/declared); null only when it could not (skipNetwork or the unknown state).
   let units = null;
   if (!opts.skipNetwork) {
     const multiUnit = detectMultiUnitBootRace(opts);
     if (multiUnit.state === "warn") {
       units = multiUnit.units;
+    } else if (multiUnit.state === "clear") {
+      units = multiUnit.units; // single-install host: enumeration SUCCEEDED, so the inventory is real
       push("multi_unit_boot_race", "WARN", describeMultiUnitConflict(multiUnit.groups, multiUnit.identityGroups));
     } else if (multiUnit.state === "declared") {
       units = multiUnit.units;

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -1140,9 +1140,9 @@ export async function runDoctor(opts = {}) {
     const multiUnit = detectMultiUnitBootRace(opts);
     if (multiUnit.state === "warn") {
       units = multiUnit.units;
+      push("multi_unit_boot_race", "WARN", describeMultiUnitConflict(multiUnit.groups, multiUnit.identityGroups));
     } else if (multiUnit.state === "clear") {
       units = multiUnit.units; // single-install host: enumeration SUCCEEDED, so the inventory is real
-      push("multi_unit_boot_race", "WARN", describeMultiUnitConflict(multiUnit.groups, multiUnit.identityGroups));
     } else if (multiUnit.state === "declared") {
       units = multiUnit.units;
       // #327. Kept under the SAME check id deliberately: this is the same check reaching

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -20040,10 +20040,9 @@ test("#327: ...but the two are still DISTINGUISHABLE in the parsed model and in 
     unitShow({ id: "b.service", port: 3458, instance: "" }),
   );
   // STATE FIRST, THEN DEREFERENCE — the discipline stated in full at the SPACE test below, and
-  // applied to every test in this block that reads `result.units`. `groupAndAssessConflicts`
-  // returns `{ state: "clear" }` with NO `units`, so a regression routing this fixture there
-  // would otherwise surface as `Cannot read properties of undefined (reading 'map')`: a real
-  // detection wearing the name of a JavaScript property instead of the name of the defect.
+  // applied to every test in this block that reads `result.units`. (#327 part 5 changed `clear`
+  // to carry `units` too, so the dereference hazard below is now only the UNKNOWN state, which
+  // still has none — the discipline stays because that state remains reachable.)
   assert.equal(result.state, "warn", "premise: both units are present and both claim the primary");
   const byName = Object.fromEntries(result.units.map(u => [u.name, u]));
   assert.strictEqual(byName["a.service"].instanceName, null, "absent must be null");

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -25846,3 +25846,30 @@ test("#416 mode 2: the pid-gone decision is ESRCH-only — a rendered ps state f
     `a dead pid must read as gone even when a ps-style state renders it alive — the decision is ESRCH-only, never a rendered column (macOS pads "Z    00:02", so a fixed-width read is the failed prescription)`);
 });
 
+
+test("#327 part 5: runDoctor's --json result carries the structured per-host unit inventory", async () => {
+  // Mock the systemctl chain: one undeclared primary in the user scope, one DECLARED second
+  // instance in the system scope — the intended multi-instance host from the issue.
+  const run = (cmd) => {
+    if (cmd.includes("--user list-unit-files")) return "ocp.service enabled";
+    if (cmd.includes("list-unit-files")) return "ocp-wifibot.service enabled";
+    if (cmd.includes("systemctl --user show")) return unitShow({ id: "ocp.service", port: 3456 });
+    if (cmd.includes("systemctl show ")) return unitShow({ id: "ocp-wifibot.service", port: 3457, instance: "wifibot" });
+    throw new Error("unexpected cmd: " + cmd);
+  };
+  const result = await runDoctor({
+    mockPlatform: "linux", run, skipNetwork: false,
+    mockVersion: "v3.29.2", mockLatest: "v3.29.2",
+    // Mocked health so this never probes the live production proxy; the oauth check reads the
+    // same body via classifyAuthOk.
+    mockHealth: { status: 200, body: { version: "3.29.2", auth: { ok: true } } },
+  });
+  assert.ok(Array.isArray(result.units),
+    `the units inventory must be a structured array (null only when the check cannot enumerate); got ${JSON.stringify(result.units)}`);
+  assert.equal(result.units.length, 2, "both enabled units must be in the inventory");
+  const byName = Object.fromEntries(result.units.map(u => [u.name, u]));
+  assert.equal(byName["ocp-wifibot.service"].instanceName, "wifibot",
+    "the declared name must be in the structured record, not only in the human message");
+  assert.strictEqual(byName["ocp.service"].instanceName, null, "an absent directive is null");
+});
+


### PR DESCRIPTION
# Summary

**#327 part 5** — the foundation both independent reviews named for part 4. `doctor` already derives the per-host unit inventory internally (`detectMultiUnitBootRace`'s `units`: name / scope / platform / port / bind / `instanceName` per enabled unit) but exposed it only as a **human-formatted check message**. `runDoctor`'s full-path `--json` result now carries `units`: the same structured array, `null` when the check cannot enumerate (`skipNetwork` or the unknown state).

This is what lets an agent — or the future `ocp update --all-instances` — enumerate declared instances **without parsing prose**, which is exactly the defect part 4's report-path needs closed first.

## Test

Drives `runDoctor` with the systemctl chain mocked (one undeclared primary in the user scope, one DECLARED second instance in the system scope — the issue's intended host) and asserts the structured record: the array is present, both units are in it, the declared name survives into JSON, and the **null-vs-absent** instanceName distinction survives too. Health is mocked (`mockHealth`) so the test never probes the live production proxy.

**Baseline: 1238 passed / 0 failed** (the +1 over main's 1237 is this test).

## Part-4 decision — posted to #327, awaiting the maintainer

Part 4 (update behavior across instances) stays **out of this PR** deliberately. Both reviews landed on the same objection: *the isolation that motivates a second instance is exactly what prevents one process from updating both* — cross-user update needs sudo, the escalation the hardening removed. The decision (report-only vs cross-identity exec) belongs to the maintainer and is recorded on #327; this PR implements only the uncontroversial inventory foundation, which is safe whichever way that decision goes.

## Class

**Not endpoint-touching** — `scripts/doctor.mjs` + `test-features.mjs` only.

## Reviewer

I am the author and cannot self-approve (Iron Rule 10).
