### PR TITLE
fix(upgrade): report sibling instances instead of acting across identities (#327 part 4)

### DIFF
--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -1441,9 +1441,14 @@ export async function runUpgrade(opts = {}) {
   // updating both). Each sibling gets its OWN update command printed, to run as its owner.
   if (Array.isArray(doctor.units) && doctor.units.length > 1) {
     for (const u of doctor.units) {
-      const label = u.instanceName === null ? "primary" : `instance ${JSON.stringify(u.instanceName)}`;
-      const tree = u.workingTree || "(tree unknown)";
-      plan.push(`[multi-instance] ${u.name} (${label}) at ${tree} — update separately: (cd ${tree} && ./ocp update)`);
+      // Labels match doctor's own vocabulary: null = no declaration, "" = the primary, else the name.
+      const label = u.instanceName === null ? "no OCP_INSTANCE_NAME declared" : (u.instanceName === "" ? "primary" : `instance ${JSON.stringify(u.instanceName)}`);
+      if (u.workingTree) {
+        plan.push(`[multi-instance] ${u.name} (${label}) at ${u.workingTree} — update it from its own tree: (cd ${u.workingTree} && ./ocp update)`);
+      } else {
+        // No tree known -> NO paste-able command (a "cd (tree unknown)" trap is worse than no command).
+        plan.push(`[multi-instance] ${u.name} (${label}) — tree unknown, update it from its own install tree`);
+      }
     }
   }
 

--- a/scripts/upgrade.mjs
+++ b/scripts/upgrade.mjs
@@ -1435,6 +1435,18 @@ export async function runUpgrade(opts = {}) {
   const kind = doctor.next_action.kind;
   plan.push(`[doctor] from=${doctor.current_version} to=${doctor.latest_version} kind=${kind}`);
 
+  // #327 part 4: report sibling instances, never act across identities. This update touches ONLY
+  // the instance it was invoked from — a sibling under another Unix identity cannot be written here
+  // (the isolation that motivates a second instance is exactly what prevents one process from
+  // updating both). Each sibling gets its OWN update command printed, to run as its owner.
+  if (Array.isArray(doctor.units) && doctor.units.length > 1) {
+    for (const u of doctor.units) {
+      const label = u.instanceName === null ? "primary" : `instance ${JSON.stringify(u.instanceName)}`;
+      const tree = u.workingTree || "(tree unknown)";
+      plan.push(`[multi-instance] ${u.name} (${label}) at ${tree} — update separately: (cd ${tree} && ./ocp update)`);
+    }
+  }
+
   // Issue #260: --target is a PIN ("do not put me on anything else"), not a preference. noop,
   // restart, and fresh_install have no mechanism to redirect what they do onto a specific
   // version: noop does nothing, restart re-serves the CURRENT tree exactly as-is, and

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -25872,3 +25872,26 @@ test("#327 part 5: runDoctor's --json result carries the structured per-host uni
   assert.strictEqual(byName["ocp.service"].instanceName, null, "an absent directive is null");
 });
 
+
+test("#327 part 4: a multi-instance host's plan reports each sibling with its own update command", async () => {
+  const result = await runUpgrade({
+    dryRun: true, yes: true,
+    mockDoctor: {
+      ready_to_upgrade: true, next_action: { kind: "upgrade" },
+      current_version: "v3.29.1", latest_version: "v3.29.2",
+      units: [
+        { name: "ocp.service", port: 3456, instanceName: null, workingTree: "/home/opc/ocp" },
+        { name: "ocp-wifibot.service", port: 3457, instanceName: "wifibot", workingTree: "/opt/ocp-wifibot" },
+      ],
+    },
+  });
+  assert.equal(result.executed, false, "dry-run premise: nothing may execute");
+  const report = result.plan.filter((l) => l.includes("[multi-instance]"));
+  assert.equal(report.length, 2, `each sibling gets its own report line; got ${JSON.stringify(report)}`);
+  assert.ok(report.some((l) => l.includes("ocp-wifibot.service") && l.includes("(instance \"wifibot\")")),
+    "the sibling's declared identity must be named, not conflated with the primary");
+  assert.ok(report.some((l) => l.includes("(cd /opt/ocp-wifibot && ./ocp update)")),
+    "the sibling's OWN tree and update command must be printed — report, never cross-identity act");
+  assert.ok(!report.some((l) => l.includes("(tree unknown)")), "workingTree is in the record; an unknown tree would be a regression");
+});
+


### PR DESCRIPTION
# Summary

**#327 part 4, first increment** — per the decision recorded on the issue (report, do not act across identities). `runUpgrade`'s doctor pre-flight now reads `doctor.units` (the structured inventory from part 5, #425) and, on a multi-instance host, pushes one `[multi-instance]` plan line per sibling: its name, its declared identity (primary vs instance name), its **own tree**, and its own update command — to run as that instance's owner.

Nothing is executed across identities. The isolation that motivates a second instance (Unix `User=`, the /opt unprivileged tree) is exactly what prevents one process from updating both — so the update prints, never runs.

## Test

`runUpgrade` with `mockDoctor.units` (a primary + a declared `wifibot` sibling) asserts: two report lines, the sibling's declared identity is named, its own tree and `(cd /opt/ocp-wifibot && ./ocp update)` command are printed, and no `(tree unknown)` placeholder (workingTree is in the record). `dryRun: true` — nothing executes.

**Baseline: 1239 passed / 0 failed** (the +1 over main's 1238 is this test).

## Follow-up increments (not here)

- Per-instance **version probing** (each unit's port → /health) so the report can say which siblings are behind.
- **Same-user exec** (the decision allows exec for same-user instances) — needs the sibling's Unix owner, which the inventory does not yet carry.

## Class

**Not endpoint-touching** — `scripts/upgrade.mjs` + `test-features.mjs` only.

## Reviewer

I am the author and cannot self-approve (Iron Rule 10).
