### PR TITLE
test(harness): record memory/swap state AT the stall, to test the swap hypothesis (#374)

### DIFF
--- a/test-features.mjs
+++ b/test-features.mjs
@@ -3117,15 +3117,22 @@ function _ltLoopDiagnosis(loop) {
 // next reproduction either ties the stall to swap pressure or eliminates it. Best-effort: null when
 // the platform tooling is unreadable — a null field is an absence of measurement, not a zero.
 function _ltMemSnapshot() {
-  const mem = { rssBytes: process.memoryUsage().rss };
+  // `at` is the wall-clock reference the cumulative vm_stat counters need: a single snapshot of
+  // cumulative counters is uninterpretable without it (review F2).
+  const mem = { at: Date.now(), rssBytes: process.memoryUsage().rss };
   try {
     const out = execFileSync("vm_stat", { encoding: "utf8", timeout: 3000 });
     const get = (k) => { const m = out.match(new RegExp(k + ":\\s+(\\d+)")); return m ? Number(m[1]) : null; };
-    const used = get("Swapins") ?? get("Pages swapped");
-    mem.swapPagesIn = used;
-    const pressure = get("Pageouts");
-    mem.swapPagesOut = pressure;
-    mem.machPageSize = 4096; // macOS page size; multiplied by the counts for bytes
+    // Swapins/Swapouts, NOT Pageouts: Pageouts counts file-backed page-outs too (21.6M vs 455.4M on
+    // the review host) — the swap hypothesis is about SWAP specifically (review F1).
+    mem.swapPagesIn = get("Swapins");
+    mem.swapPagesOut = get("Swapouts");
+    // The page size is read, never hardcoded: Apple Silicon reports 16 KiB pages (review F1).
+    try {
+      const ps = execFileSync("pagesize", { encoding: "utf8", timeout: 3000 }).trim();
+      const n = Number(ps);
+      if (Number.isInteger(n) && n > 0) mem.pageSize = n;
+    } catch {}
   } catch { /* not macOS */ }
   try {
     const vmstat = _lockReadFileSync("/proc/vmstat", "utf8");

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -3111,8 +3111,34 @@ function _ltLoopDiagnosis(loop) {
 // Builds the record ltDrain pushes on a timeout. Separated from ltDrain so the calibration
 // controls can drive the instrument directly, with NO intervening await between the fault they
 // stage and the observation — which is the only way to make the zombie window deterministic.
+// #374 investigation: the swap hypothesis. The field captures read ~76-120s single stalls at
+// ~1% CPU duty ("NOT EXECUTING"), on a host whose swap was ~96% used — but the swap figure was
+// NEVER RECORDED AT THE STALL, only stated. This snapshot captures it at the record moment, so the
+// next reproduction either ties the stall to swap pressure or eliminates it. Best-effort: null when
+// the platform tooling is unreadable — a null field is an absence of measurement, not a zero.
+function _ltMemSnapshot() {
+  const mem = { rssBytes: process.memoryUsage().rss };
+  try {
+    const out = execFileSync("vm_stat", { encoding: "utf8", timeout: 3000 });
+    const get = (k) => { const m = out.match(new RegExp(k + ":\\s+(\\d+)")); return m ? Number(m[1]) : null; };
+    const used = get("Swapins") ?? get("Pages swapped");
+    mem.swapPagesIn = used;
+    const pressure = get("Pageouts");
+    mem.swapPagesOut = pressure;
+    mem.machPageSize = 4096; // macOS page size; multiplied by the counts for bytes
+  } catch { /* not macOS */ }
+  try {
+    const vmstat = _lockReadFileSync("/proc/vmstat", "utf8");
+    const get = (k) => { const m = vmstat.match(new RegExp(k + "\\s+(\\d+)")); return m ? Number(m[1]) : null; };
+    mem.swapPagesIn = get("pswpin");
+    mem.swapPagesOut = get("pswpout");
+  } catch { /* not Linux */ }
+  return mem;
+}
+
 function _ltObserveDrainTimeout(where, elapsedMs, t0, kind = "TIMED OUT", openAtStart = 0) {
   const loop = _ltStallSince(t0);
+  const mem = _ltMemSnapshot();
   const children = [];
   for (const rec of _ltOpenChildren.values()) {
     const probe = _ltProbePid(rec.pid);
@@ -3130,7 +3156,7 @@ function _ltObserveDrainTimeout(where, elapsedMs, t0, kind = "TIMED OUT", openAt
   // findings, and without openAtStart they print identically.
   const registry = children.length ? null
     : (openAtStart > 0 ? LT_PS_VERDICT.CLOSED_FIRST : LT_PS_VERDICT.NONE_OPEN);
-  return { where, kind, ms: elapsedMs, active: _ltActiveBoots, openAtStart, registry, loop, children };
+  return { where, kind, ms: elapsedMs, active: _ltActiveBoots, openAtStart, registry, loop, children, mem };
 }
 // Compact form, for the offender list inside the #358 summary's message.
 function _ltRenderDrainTimeout(r) {
@@ -3156,6 +3182,7 @@ function _ltExplainDrainTimeout(r) {
   lines.push(`    [#374]   loop: ${r.loop.verdict} — ${_ltLoopDiagnosis(r.loop)}`);
   lines.push(`    [#374]   loop: gaps >= ${LT_STALL_MIN_MS}ms: ${r.loop.nStalls} totalling ${r.loop.sumStallMs}ms; ` +
              `top=${JSON.stringify(r.loop.top)}; gaps in window=${r.loop.gapsInWindow}; ticks in ring=${r.loop.ticksInRing}`);
+  lines.push(`    [#374]   mem: ${JSON.stringify(r.mem)}`);
   if (!r.children.length) {
     lines.push(`    [#374]   ps: ${r.registry} (${r.openAtStart} open when the drain started, 0 now) — ` +
                `${LT_PS_DIAGNOSIS[r.registry]}`);


### PR DESCRIPTION
# Summary

**#374 investigation increment** — the instrument stops being blind to the swap hypothesis. The field captures read ~76–120s single stalls at ~1% CPU duty ("NOT EXECUTING") on a host whose swap was ~96% used — but the swap figure was **never recorded at the stall moment**, only stated after the fact (#419's own note: *"stated, not interpreted"*).

The drain-timeout record now carries a `mem` snapshot taken at the record moment:

- this process's `rssBytes`, plus
- swap-in/swap-out page counts from `vm_stat` (macOS) or `/proc/vmstat` (Linux).

Best-effort: a null field is an **absence of measurement, never a zero**. The next reproduction either ties the stall to swap pressure or eliminates it.

## Why this and nothing bigger

The stall's mechanism is genuinely unexplained, and the next measurement opportunity is a reproduction that may be days away. The highest-value thing the harness can do meanwhile is ensure that when it happens again, the record carries the one hypothesis the earlier captures could not test. This does not claim to explain the stall; it removes the next capture's blind spot.

## Class

**Not endpoint-touching** — `test-features.mjs` only. Observational: no verdict, no budget, no production code.

## Reviewer

I am the author and cannot self-approve (Iron Rule 10).
