### PR TITLE
test(harness): ticket FIFO for the suite lock — oldest waiter acts, stale tickets swept (#416 fairness)

### DIFF
--- a/test-features.mjs
+++ b/test-features.mjs
@@ -57,18 +57,53 @@ function suiteLockOwnerRecord() {
 // and that directory is rename()d onto the lock path. rename is atomic, so the lock path either
 // does not exist or exists complete with its owner record — there is no window in which a
 // claimant can read "lock present, owner absent" and break a lock taken microseconds ago.
+function _lockTicketDir(dir) { return dir + ".tickets"; }
+function _lockTicketName() {
+  // Arrival-ordered: epoch ms padded, then pid, then the nonce. Sorting the names sorts by arrival.
+  return "ticket-" + String(Date.now()).padStart(15, "0") + "-" + process.pid + "-" + SUITE_LOCK_NONCE;
+}
+function _lockSweepStaleTickets(dir) {
+  // A crashed contender leaves its ticket behind forever; it would sit at the head of the queue
+  // and stall everyone. Sweep tickets whose owner pid is ESRCH-gone (same conservative signal the
+  // stale-lock break uses: a reused pid reads as alive -> livelock, never corruption).
+  let names = [];
+  try { names = _lockReaddirSync(_lockTicketDir(dir)); } catch { return; }
+  for (const n of names) {
+    const pid = Number(n.split("-")[2]);
+    if (!Number.isInteger(pid)) continue;
+    try { process.kill(pid, 0); } catch (e) {
+      if (e.code === "ESRCH") { try { _lockRmSync(join(_lockTicketDir(dir), n), { force: true }); } catch {} }
+    }
+  }
+}
+
 function suiteLockAcquire(dir) {
+  let myTicket = null;
   for (;;) {
     const tmpDir = dir + ".tmp-" + process.pid + "-" + SUITE_LOCK_NONCE;
     try {
       _lockMkdirSync(tmpDir, { recursive: true });
       _lockWriteFileSync(join(tmpDir, "owner.json"), JSON.stringify(suiteLockOwnerRecord()));
       _lockRenameSync(tmpDir, dir);
-      return;
+      if (myTicket) { try { _lockRmSync(myTicket, { force: true }); } catch {} }
+      return myTicket;
     } catch (e) {
       try { _lockRmSync(tmpDir, { recursive: true, force: true }); } catch {}
       if (e.code !== "EEXIST" && e.code !== "ENOTEMPTY") throw e; // rename onto a held lock
     }
+    // Fairness (issue #416 "Fairness"): the plain retry loop is a lottery — one contender waited
+    // ~40 min. Register a ticket once, then only the OLDEST ticket acts each cycle; everyone else
+    // sleeps. This is FIFO-by-arrival, not a strict ticket queue, and it is a throughput property
+    // only — never correctness.
+    if (!myTicket) {
+      _lockMkdirSync(_lockTicketDir(dir), { recursive: true });
+      myTicket = join(_lockTicketDir(dir), _lockTicketName());
+      _lockWriteFileSync(myTicket, "");
+    }
+    _lockSweepStaleTickets(dir);
+    let oldest = null;
+    try { oldest = _lockReaddirSync(_lockTicketDir(dir)).sort()[0]; } catch {}
+    if (oldest !== undefined && !myTicket.endsWith(oldest)) { _lockSleep(500); continue; }
     // Stale-break by ATOMIC RENAME-STEAL (review F3): rename the lock to a private name FIRST,
     // then inspect the renamed owner. A check-then-act here (read owner -> pid-gone -> rm) races:
     // a claimant that re-acquired between the read and the rm gets its LIVE lock deleted and two
@@ -98,8 +133,13 @@ function suiteLockPidGone(owner) {
   if (!owner || !Number.isInteger(owner.pid)) return true;
   try { process.kill(owner.pid, 0); return false; } catch (e) { return e.code === "ESRCH"; }
 }
-suiteLockAcquire(SUITE_LOCK_DIR);
-process.on("exit", () => { try { _lockRmSync(SUITE_LOCK_DIR, { recursive: true, force: true }); } catch {} });
+const _mySuiteTicket = suiteLockAcquire(SUITE_LOCK_DIR);
+process.on("exit", () => {
+  try { _lockRmSync(SUITE_LOCK_DIR, { recursive: true, force: true }); } catch {}
+  // Only OUR ticket, never the whole ticket dir: wiping it would re-order every waiting contender
+  // on every release, which is exactly the lottery this exists to remove.
+  if (_mySuiteTicket) { try { _lockRmSync(_mySuiteTicket, { force: true }); } catch {} }
+});
 
 
 // The scaffolding that used to live here CLAIMED to use "a test database to avoid corrupting
@@ -25927,5 +25967,31 @@ test("#327 part 4: a multi-instance host's plan reports each sibling with its ow
   assert.ok(report.some((l) => l.includes("(cd /opt/ocp-wifibot && ./ocp update)")),
     "the sibling's OWN tree and update command must be printed — report, never cross-identity act");
   assert.ok(!report.some((l) => l.includes("(tree unknown)")), "workingTree is in the record; an unknown tree would be a regression");
+});
+
+
+test("#416 fairness: a stale ticket (owner pid ESRCH-gone) is swept, so a crashed contender cannot stall the queue", () => {
+  const dir = lt416TmpDir();
+  const dead = spawnSync(process.execPath, ["-e", ""]);
+  const staleName = "ticket-000000000000001-" + dead.pid + "-dead";
+  _lockMkdirSync(_lockTicketDir(dir), { recursive: true });
+  _lockWriteFileSync(join(_lockTicketDir(dir), staleName), "");
+  _lockSweepStaleTickets(dir);
+  const remaining = _lockReaddirSync(_lockTicketDir(dir));
+  assert.deepEqual(remaining, [],
+    `a ticket whose owner is ESRCH-gone must be swept, or it sits at the queue head and stalls everyone: ${JSON.stringify(remaining)}`);
+  try { _lockRmSync(dir, { recursive: true, force: true }); } catch {}
+});
+
+test("#416 fairness: a LIVE owner's ticket is NOT swept (a reused-pid read is conservative, never corrupting)", () => {
+  const dir = lt416TmpDir();
+  const liveName = "ticket-000000000000001-" + process.pid + "-live";
+  _lockMkdirSync(_lockTicketDir(dir), { recursive: true });
+  _lockWriteFileSync(join(_lockTicketDir(dir), liveName), "");
+  _lockSweepStaleTickets(dir);
+  const remaining = _lockReaddirSync(_lockTicketDir(dir));
+  assert.deepEqual(remaining, [liveName],
+    `a LIVE owner's ticket must survive the sweep; got ${JSON.stringify(remaining)}`);
+  try { _lockRmSync(dir, { recursive: true, force: true }); } catch {}
 });
 

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -103,7 +103,10 @@ function suiteLockAcquire(dir) {
     _lockSweepStaleTickets(dir);
     let oldest = null;
     try { oldest = _lockReaddirSync(_lockTicketDir(dir)).sort()[0]; } catch {}
-    if (oldest !== undefined && !myTicket.endsWith(oldest)) { _lockSleep(500); continue; }
+    // F1 (review): a readdir failure must FAIL SAFE — proceed to attempt, never sleep forever.
+    // A tie attempt on an unreadable queue is at worst a temporary lottery, which is strictly
+    // better than a deadlock on a free lock.
+    if (oldest && !myTicket.endsWith(oldest)) { _lockSleep(500); continue; }
     // Stale-break by ATOMIC RENAME-STEAL (review F3): rename the lock to a private name FIRST,
     // then inspect the renamed owner. A check-then-act here (read owner -> pid-gone -> rm) races:
     // a claimant that re-acquired between the read and the rm gets its LIVE lock deleted and two
@@ -25980,6 +25983,7 @@ test("#416 fairness: a stale ticket (owner pid ESRCH-gone) is swept, so a crashe
   const remaining = _lockReaddirSync(_lockTicketDir(dir));
   assert.deepEqual(remaining, [],
     `a ticket whose owner is ESRCH-gone must be swept, or it sits at the queue head and stalls everyone: ${JSON.stringify(remaining)}`);
+  try { _lockRmSync(_lockTicketDir(dir), { recursive: true, force: true }); } catch {}
   try { _lockRmSync(dir, { recursive: true, force: true }); } catch {}
 });
 
@@ -25992,6 +25996,7 @@ test("#416 fairness: a LIVE owner's ticket is NOT swept (a reused-pid read is co
   const remaining = _lockReaddirSync(_lockTicketDir(dir));
   assert.deepEqual(remaining, [liveName],
     `a LIVE owner's ticket must survive the sweep; got ${JSON.stringify(remaining)}`);
+  try { _lockRmSync(_lockTicketDir(dir), { recursive: true, force: true }); } catch {}
   try { _lockRmSync(dir, { recursive: true, force: true }); } catch {}
 });
 


### PR DESCRIPTION
# Summary

**#416's Fairness note, the last increment**: the plain retry loop is a lottery — the issue measured one contender waiting ~40 minutes. This adds a ticket queue on top of `suiteLockAcquire`:

- A waiter registers a **ticket** once (`ticket-<epoch-ms padded>-<pid>-<nonce>` — sorting the names sorts by arrival); only the **oldest** ticket attempts the acquire/stale-steal each cycle, everyone else sleeps.
- **Stale tickets are swept** each cycle: a ticket whose owner pid is ESRCH-gone (the same conservative signal the stale-lock break uses) is removed, so a crashed contender cannot sit at the queue head forever. A live owner's ticket survives (reused-pid reads as alive → livelock, never corruption).
- The exit handler removes **only its own ticket**, never the whole ticket dir — wiping it would re-order every waiter on every release, the exact lottery this removes.

## Honest statement of reach

The FIFO ordering itself is not deterministically testable without two live contender processes (a two-process race test is the next increment if wanted). The two tests pin the **sweep**, which is the one correctness-adjacent piece: a crashed waiter must not stall the queue, and a live waiter must survive. This is a **throughput** property, never correctness — stated in the code comment as the issue itself frames it.

**Baseline: 1241 passed / 0 failed** (the +2 over main's 1239 is these tests).

## Class

**Not endpoint-touching** — `test-features.mjs` only.

## Reviewer

I am the author and cannot self-approve (Iron Rule 10).
