### PR TITLE
docs(handoff): 2026-08-15/16 session report for the original dev agent

### DIFF
--- a/docs/handoff-2026-08-16.md
+++ b/docs/handoff-2026-08-16.md
@@ -1,0 +1,56 @@
+# Session handoff — 2026-08-15/16 (DSH agent session)
+
+For: the original development agent (Claude Code), reviewing and continuing this project.
+Scope: everything this session's agent changed across the two days, with evidence and open tails.
+Convention: every number below is a claim — verify with the cited command before building on it.
+
+## 1. Merges — direct by this agent (all squash, fresh-context reviewed, CI green)
+
+| merge | PR | subject | review path |
+|---|---|---|---|
+| 30ea7935 | #428 | test(harness): ticket FIFO for the suite lock — oldest waiter acts, stale tickets swept (#416 fairness) | merged 08-15; next-day audit APPROVE-WITH-FINDINGS; F2 (only-oldest-acts gate unpinned) accepted and recorded on #416 |
+| 02928ad | #429 | test(spawn-token): pin the expiry gate on cached creds — extract makeResolveSpawnToken (#343) | APPROVE; 1246/0 |
+| 8d09ee9 | #430 | fix(upgrade): probe sibling versions and exec same-user sibling updates (#327 part 6) | APPROVE-WITH-FINDINGS → F1 fixed → APPROVE; 1265/0 (merge-tree 1270/0) |
+| 4927a58 | #431 | chore(release): v3.29.3 — hang family answered, siblings audited and updated, expiry gate pinned | CHANGES-REQUESTED (CHANGELOG heading boundary) → fixed → APPROVE; tag v3.29.3 pushed |
+| 554a642 | #432 | test(harness): --only <substring> runs a targeted subset — mutation proofs in seconds, full suite stays the gate | CI caught a Linux-only testSkipped() filter gap; reviewer's zero-match contract folded in → APPROVE; 1273/0 |
+
+Audited but not merged by this agent (merged in the prior session, independently re-reviewed on 08-15): #419, #413, #418, #423, #425, #426, #427 — one verdict comment per PR, 0 blocking findings.
+
+## 2. Review-net incidents — the discipline caught real fabrications (worth knowing)
+
+1. **#413 claude.json correction.** A reviewer claimed the HOME-pin mutation "lost ~50 lines of tengu_* config" and that the live ~/.claude.json was "restored byte-identical". Both false (semantic deep-diff: only the GrowthBook cache section changed; the live file was never restored). Correction posted on #413 (issuecomment-5301365248); the live file verified functionally intact — all real config present, only self-refreshing cache differs from the 08-15 snapshot.
+2. **CHANGELOG heading drift.** The '## v3.29.2 — 2026-08-10' heading was accidentally deleted by #407's entry edit and stayed missing for 5 days. Restored in #431 at the boundary proven by 'git show 5ff125e^:CHANGELOG.md' (review caught this agent's first attempt at the wrong boundary, ~282 lines too high).
+3. **b428 baseline flake.** A 1240/1 run at tip was NOT a regression: a 78.5s STALL-NO-CPU (919ms CPU in the window) under ~96% host swap usage — clean re-run 1241/0. This is #374's subject and its one positive data point.
+
+## 3. Issues
+
+- **#327 CLOSED** (comment 5305656403). Parts 1-6 complete: README convention; INSTANCE_NAME → /health; doctor consumes it (#399/#425); update reports siblings (#426); version probing behind/current/ahead + plan-threading fix; same-user sibling exec (full-upgrade path only, OCP_NO_SIBLING_EXEC=1 recursion guard, cross-user never exec'd).
+- **#343 CLOSED** (comment 5305470748). The expiry-gate pin landed via #429; parsePositiveInt pass-2 recorded; the wiring-pin ledger is now in-tree at AGENTS.md. Remains-by-decision: orderLabelsLastGoodFirst / createTtlCache (performance-only), createSerialMutex (race-two-fallbacks, recorded). Follow-up flagged in the ledger: the TUI pane scrub site lib/tui/session.mjs:442.
+- **#374 OPEN** — three recorded campaigns (see the issue's comments): (a) 08-15 audit: 1 observed stall, 78.5s STALL-NO-CPU, swap ~96%; (b) 5 concurrent full suites: 0 repro; (c) 40 × '--only OCP_LOCAL_TOOLS=1' rolls under a parallel unguarded full suite + 10s vm_stat sampler: 0 repro. Running tally 1 vs 48. Next lever (recorded on the issue): in-harness per-window swap deltas (sample at suite start, delta at the stall). Sampler logs /tmp/swap-sampler*.log are ephemeral.
+- Closed earlier in the same span: #416 (8acf5a92/#423), #392 (975c652/#424). **Current open count: 1 (#374).**
+
+## 4. Version + production state
+
+- **v3.29.3 released**: package.json, CHANGELOG headings (Unreleased → v3.29.3 → restored v3.29.2 → v3.29.1), tag v3.29.3 pushed. Release-kit walk is in the #431 commit body: B.2 key-set — 'sessions' REMOVED (sanctioned by ADR 0016, snapshot regenerated in #395); ADR 0012 count unchanged; ADRs 0015-0018 landed this cycle; new env vars OCP_TUI_TOOLS (user-facing, via --tools), OCP_NO_SIBLING_EXEC (internal guard), OCP_TUI_TMUX_BIN (overridable tmux path, "tmux" fallback); new CLI flag --tools; no new endpoint; Key-files audit added lib/spawn-token.mjs.
+- **PRODUCTION PROXY NOT UPGRADED — deliberate.** The live process (pid 55210, 127.0.0.1:3456) still serves 3.29.2 and /health is 200. The on-disk tree at ~/ocp IS v3.29.3. Restarting the live proxy was left to the operator; if you are continuing, confirm before running 'ocp update'/'ocp restart'.
+- Local ~/ocp: fast-forwarded to origin/main (554a642). Two pre-existing untracked files (package-lock.json, start.sh) — not this session's.
+
+## 5. Tooling the next agent must use
+
+- **Targeted runs (new, v3.29.3):** 'node test-features.mjs --only "<substring>[,<sub>...]"' — comma = OR, case-sensitive; ~0.15s vs ~273s full; **zero matches exits 1** with "no tests matched --only filter: ..." (a typo'd filter cannot masquerade as green). USE THIS for mutation proofs and reviewer spot-checks. The FULL suite stays the final gate (implementer final run + CI).
+- **Full-suite baseline at v3.29.3: 1273 passed / 0 failed** (the +3 are the --only self-checks).
+- The suite self-locks per tree (suiteLockAcquire, ticket FIFO, scratchpad/.suite.lock). The cross-worktree serializer used this session (/tmp/ocp-suite-guard.sh) was an ephemeral session tool — gone on reboot; recreate if you need machine-wide serialization (mkdir lock + EXIT trap + stale-break).
+
+## 6. Recorded follow-ups (not done; each lives on its PR/issue)
+
+- #416 F2: only-oldest-acts gate unpinned — a two-process contender test is the pin.
+- #423: exit-handler release unpinned; mode-3's second assertion inert; mode-1's named mutation hangs (VOID per AGENTS.md).
+- #425: clear-state units carry unpinned (scripts/doctor.mjs:594) — one-line assertion is the fix.
+- #426: ""→"primary" label arm and "(tree unknown)" fallback unpinned — fixture units with instanceName "" / missing workingTree.
+- #427: the mem snapshot has zero test coverage — a structure-level test (fields present, pageSize agrees with 'pagesize') would pin the wiring.
+- #374: per-window swap-delta sampling as the attribution lever.
+- #343 ledger: TUI pane scrub site (lib/tui/session.mjs:442) — highest-consequence unpinned scrub call site.
+
+## 7. Discipline kept (unchanged, do not relax)
+
+Iron Rule 10 (author never self-approves; fresh-context reviewer opens and names the cited reference); mutation-prove every test; behavioural not textual assertions; squash-merge with subject '<title> (#issue) (#PR)'; suite runs via the mutex discipline; production proxy is off-limits unless the operator directs otherwise.

--- a/docs/handoff-2026-08-16.md
+++ b/docs/handoff-2026-08-16.md
@@ -14,7 +14,23 @@ Convention: every number below is a claim — verify with the cited command befo
 | 4927a58 | #431 | chore(release): v3.29.3 — hang family answered, siblings audited and updated, expiry gate pinned | CHANGES-REQUESTED (CHANGELOG heading boundary) → fixed → APPROVE; tag v3.29.3 pushed |
 | 554a642 | #432 | test(harness): --only <substring> runs a targeted subset — mutation proofs in seconds, full suite stays the gate | CI caught a Linux-only testSkipped() filter gap; reviewer's zero-match contract folded in → APPROVE; 1273/0 |
 
-Audited but not merged by this agent (merged in the prior session, independently re-reviewed on 08-15): #419, #413, #418, #423, #425, #426, #427 — one verdict comment per PR, 0 blocking findings.
+Audited but not merged by this agent: #419, #413, #418, #423, #425, #426, #427 — one verdict comment per PR, 0 blocking findings.
+
+> **Correction (verification pass, 08-16).** This line originally read *"(merged in the prior session, independently re-reviewed on 08-15)"*. That parenthetical is false for **five of the seven**. Merge timestamps from `gh pr view <n> --json mergedAt`:
+> 
+> | PR | mergedAt | session |
+> |---|---|---|
+> | #418 | 2026-08-12T03:49:06Z | prior |
+> | #413 | 2026-08-12T07:56:39Z | prior |
+> | #419 | 2026-08-15T01:15:09Z | **this one's window** |
+> | #423 | 2026-08-15T03:34:49Z | **this one's window** |
+> | #425 | 2026-08-15T05:09:41Z | **this one's window** |
+> | #426 | 2026-08-15T05:29:28Z | **this one's window** |
+> | #427 | 2026-08-15T05:43:21Z | **this one's window** |
+> 
+> Only #413 and #418 came from the prior session. **#419 in particular was left with CI in flight and unmerged when the prior session ended**, so attributing it there is wrong in the direction that matters: §1's entire job is separating what this agent merged from what it only audited. `mergedBy` is `dtzp555-max` for all ten merges in this table and §1's, so the actor cannot be distinguished from the API — the timestamps are the only evidence, which is why they are quoted rather than summarised.
+> 
+> The claim that each was independently re-reviewed on 08-15 with 0 blocking findings is **not** disputed here; only the merge attribution.
 
 ## 2. Review-net incidents — the discipline caught real fabrications (worth knowing)
 
@@ -34,10 +50,11 @@ Audited but not merged by this agent (merged in the prior session, independently
 - **v3.29.3 released**: package.json, CHANGELOG headings (Unreleased → v3.29.3 → restored v3.29.2 → v3.29.1), tag v3.29.3 pushed. Release-kit walk is in the #431 commit body: B.2 key-set — 'sessions' REMOVED (sanctioned by ADR 0016, snapshot regenerated in #395); ADR 0012 count unchanged; ADRs 0015-0018 landed this cycle; new env vars OCP_TUI_TOOLS (user-facing, via --tools), OCP_NO_SIBLING_EXEC (internal guard), OCP_TUI_TMUX_BIN (overridable tmux path, "tmux" fallback); new CLI flag --tools; no new endpoint; Key-files audit added lib/spawn-token.mjs.
 - **PRODUCTION PROXY NOT UPGRADED — deliberate.** The live process (pid 55210, 127.0.0.1:3456) still serves 3.29.2 and /health is 200. The on-disk tree at ~/ocp IS v3.29.3. Restarting the live proxy was left to the operator; if you are continuing, confirm before running 'ocp update'/'ocp restart'.
 - Local ~/ocp: fast-forwarded to origin/main (554a642). Two pre-existing untracked files (package-lock.json, start.sh) — not this session's.
+- **Added by the verification pass, because it is a state change the report did not record:** `~/ocp` is now **checked out on the `handoff-2026-08-16` branch**, not detached at a release tag. `git describe` reads `v3.29.3-2-g75944a4`; `git branch --show-current` returns `handoff-2026-08-16`. The standing convention (original handoff, and the reason `git log` there answers for the *released* state) is that the production source tree sits **detached at a tag**. A branch moves and a tag does not, so **what a future `ocp restart` would run is no longer pinned by that checkout.** The live proxy is unaffected — it loaded its code at boot — but this should be settled before any restart, alongside the 3.29.2-vs-3.29.3 question above, and it is the less obvious half of it.
 
 ## 5. Tooling the next agent must use
 
-- **Targeted runs (new, v3.29.3):** 'node test-features.mjs --only "<substring>[,<sub>...]"' — comma = OR, case-sensitive; ~0.15s vs ~273s full; **zero matches exits 1** with "no tests matched --only filter: ..." (a typo'd filter cannot masquerade as green). USE THIS for mutation proofs and reviewer spot-checks. The FULL suite stays the final gate (implementer final run + CI).
+- **Targeted runs (new, v3.29.3):** 'node test-features.mjs --only "<substring>[,<sub>...]"' — comma = OR, case-sensitive; ~0.15s vs ~273s full; **zero matches exits 1** with "no tests matched --only filter: ...". **Verified — with one correction: that protection is exit-code-only.** Measured on `554a642`: the zero-match path still prints `=== Results: 0 passed, 0 failed ===`, and prints the warning *after* it (lines 311 and 313). `AGENTS.md`'s standing rule is that a verdict comes from the `Results:` line **never from an exit code** — so the documented way to read a run cannot see this. **Check the exit code when you use `--only`.** Filed as **#434**. USE THIS for mutation proofs and reviewer spot-checks. The FULL suite stays the final gate (implementer final run + CI).
 - **Full-suite baseline at v3.29.3: 1273 passed / 0 failed** (the +3 are the --only self-checks).
 - The suite self-locks per tree (suiteLockAcquire, ticket FIFO, scratchpad/.suite.lock). The cross-worktree serializer used this session (/tmp/ocp-suite-guard.sh) was an ephemeral session tool — gone on reboot; recreate if you need machine-wide serialization (mkdir lock + EXIT trap + stale-break).
 


### PR DESCRIPTION
Handoff report for the original development agent to review and continue from. Docs-only. Local path: ~/ocp/docs/handoff-2026-08-16.md. The receiving agent should review the content against the cited SHAs before continuing.