### PR TITLE
test(harness): pin the suite lock's loop — two-process contender, live-lock survival, exit release (#416 F2, #423 F2/F3)

### DIFF
--- a/test-features.mjs
+++ b/test-features.mjs
@@ -26097,6 +26097,12 @@ test("#416 mode 1: a lock whose owner pid is ESRCH-gone is broken and re-acquire
       `a stale lock (dead pid ${deadPid}) must be broken and re-acquired by THIS process — got ${JSON.stringify(owner)}`);
   } finally {
     try { _lockRmSync(dir, { recursive: true, force: true }); } catch {}
+    // The ticket dir is a SIBLING path (`dir + ".tickets"`), not a child, so removing `dir` never
+    // reached it and this test leaked one directory into scratchpad/ per suite run (#437 review F6,
+    // which also measured the leak as mode 1's ALONE — mode 5 pre-creates an EMPTY lock dir, which
+    // rename() replaces on iteration 1, so it never tickets and leaks 0). Same cleanup the fairness
+    // tests below already do.
+    try { _lockRmSync(_lockTicketDir(dir), { recursive: true, force: true }); } catch {}
   }
 });
 
@@ -26522,23 +26528,38 @@ test("#416 fairness: a LIVE owner's ticket is NOT swept (a reused-pid read is co
 //     could not fail, because nothing in that body attempted a break.
 //   * the exit-handler release (#423 audit F3). Measured: removing it left the suite at 1237/0.
 //
-// THE SECOND PROCESS IS THE REAL SUITE. `node test-features.mjs --only <a filter that matches no
-// test>` in a scratch cwd runs the real module-level suiteLockAcquire against that cwd's
-// `scratchpad/.suite.lock` and runs no test at all — measured 0.08 s wall on this host. That is
-// AGENTS.md's "use a second instance, never a miniature copy" (#402): re-implementing the acquire
-// loop inside the test would pass while the real one was broken, which is the whole failure this
-// section exists to catch.
+// THE SECOND PROCESS IS THE REAL SUITE. `node test-features.mjs --only <one trivially fast test>`
+// in a scratch cwd runs the real module-level suiteLockAcquire against that cwd's
+// `scratchpad/.suite.lock`, runs exactly that one test, and exits. That is AGENTS.md's "use a
+// second instance, never a miniature copy" (#402): re-implementing the acquire loop inside the
+// test would pass while the real one was broken, which is the whole failure this section exists
+// to catch.
 //
-// RECURSION IS CLOSED BY CONSTRUCTION, TWICE. The child is always given a filter that matches no
-// test name, AND it is given OCP_SUITE_LOCK_CHILD=1, which is the condition these three tests are
-// registered under. Either alone suffices; neither is a prohibition a future edit can violate by
-// forgetting it, because a child that ran these tests would have to both match the filter and
-// clear the env guard.
+// WHY THE FILTER NAMES A REAL TEST RATHER THAN MATCHING NOTHING (#437 review F3). The first
+// version pointed the child at a deliberately unmatchable filter and waited for the
+// `=== Results: 0 passed, 0 failed ===` line. That line is printed only because of the defect
+// #434 reports — the zero-match path emits a results line before its warning — and #434's leading
+// candidate fix DELETES it. These tests would then have broken silently: the child would still
+// exit 1, still register zero tests, still leave its scratch dir behind, and only the line the
+// parent waits on would be gone. Waiting on `Results: 1 passed, 0 failed` from an ordinary run
+// depends on no behaviour that is scheduled to change, and it is a strictly stronger signal —
+// it says a test ran AND passed, where the old one said only that the runner reached its summary.
+// If the named test below is ever renamed, every assertion here fails with the filter quoted in
+// its message, so the coupling announces itself rather than going quiet.
+//
+// RECURSION IS CLOSED BY CONSTRUCTION, TWICE, and both were verified independently sufficient by
+// the #437 review. The child is given a filter naming ONE test that is not any of these three,
+// AND it is given OCP_SUITE_LOCK_CHILD=1, which turns these three into counted skips. Neither is
+// a prohibition a future edit can violate by forgetting it.
 //
 // The child's stdout/stderr are PIPED, never inherited: `.github/workflows/flake-hunt.yml`
 // histograms `✗` lines on the suite's stdout, and a child's output on the parent's stream would
 // be read as the parent's result.
-const LT_LOCK_CHILD_FILTER = "__ocp_suite_lock_child_matches_no_test__";
+// One real test, chosen for being the cheapest in this section (a spawnSync of `node -e ""` and one
+// assert) and for sitting next to the code under test, so a reader of the lock section sees the
+// coupling without leaving it. The expected line below is what makes the choice checkable.
+const LT_LOCK_CHILD_FILTER = "#416 mode 2";
+const LT_LOCK_CHILD_DONE = "=== Results: 1 passed, 0 failed ===";
 const LT_LOCK_SUITE_PATH = fileURLToPath(import.meta.url);
 // Generous, because it is only ever paid on failure: this host has recorded 78–120 s whole-process
 // stalls (#374), and a timeout tuned to the 0.08 s happy path would report one of those as a lock
@@ -26583,9 +26604,18 @@ function lt416Tickets(lockDir) {
   try { return _lockReaddirSync(_lockTicketDir(lockDir)).sort(); } catch { return []; }
 }
 
-if (!process.env.OCP_SUITE_LOCK_CHILD) {
+// A COUNTED skip, not a silent non-registration (#437 review F5). The first version wrapped these
+// three in `if (!process.env.OCP_SUITE_LOCK_CHILD)`, so in a contender child they simply did not
+// exist — and this repo's standing position (#366) is that an unregistered test and a passing one
+// are the same green tick unless the skip is counted and named.
+function lockTest(name, fn) {
+  if (process.env.OCP_SUITE_LOCK_CHILD) {
+    return testSkipped(name, "this process IS a contender child spawned by the lock tests (OCP_SUITE_LOCK_CHILD=1); running them here would recurse");
+  }
+  return test(name, fn);
+}
 
-test("#416 F2: only the OLDEST ticket acts — a real contender holds off a lock it is otherwise entitled to break", async () => {
+lockTest("#416 F2: only the OLDEST ticket acts — a real contender holds off a lock it is otherwise entitled to break", async () => {
   const base = lt416ChildDir();
   const lockDir = join(base, "scratchpad", ".suite.lock");
   // A lock the contender IS entitled to break: its owner pid is definitively gone (ESRCH), which
@@ -26616,30 +26646,38 @@ test("#416 F2: only the OLDEST ticket acts — a real contender holds off a lock
     assert.ok(owner && owner.pid === dead.pid,
       `a contender that is not the oldest ticket must not act — not even on an ESRCH-breakable lock. ` +
       `Expected the stale owner (pid ${dead.pid}) untouched; got ${JSON.stringify(owner)}`);
-    // THE POSITIVE CONTROL, and that is all it is — read this before treating it as a second
-    // pinned claim. Release the queue and the contender must get in: without this half, "the lock
-    // was not broken" above is equally satisfied by a contender that could never acquire under any
-    // circumstances, which is the shape AGENTS.md warns about (a negative predicate satisfied by an
-    // empty world).
+    // THE POSITIVE CONTROL — and, correcting what this comment said when it shipped, a claim with
+    // rows of its own. Release the queue and the contender must get in: without this half, "the
+    // lock was not broken" above is equally satisfied by a contender that could never acquire under
+    // any circumstances, which is the shape AGENTS.md warns about.
     //
-    // It has no mutation row of its own and cannot have one. Every mutation that closes the gate
-    // permanently — the only way to break this half — also blocks `#416 mode 1` above, which calls
-    // suiteLockAcquire IN-PROCESS on a NON-EMPTY stale lock and therefore must go through the
-    // ticket path. Measured: `if (oldest && !myTicket.endsWith(oldest))` -> `if (oldest)` produced
-    // no `=== Results:` line in 7 minutes, which per AGENTS.md is VOID, not red. The wait below is
-    // bounded and throws so that THIS test would report a named failure; the pre-existing test that
-    // hangs first is what makes the run unusable.
+    // The shipped version claimed no mutation could redden this half, on the grounds that closing
+    // the gate permanently also hangs `#416 mode 1`. THAT WAS AN OVER-GENERALISATION FROM ONE
+    // MUTATION, found by the #437 review, and the correction is worth more than the claim was:
+    // mode 1's in-process acquire evaluates the gate EXACTLY ONCE — iteration 1, one ticket present
+    // — and returns on iteration 2. So any defect that first manifests on iteration >= 2 is
+    // invisible to it, and two such mutations redden this assertion while mode 1 stays green:
+    //
+    //   MA6  `if (!myTicket) {` -> `if (true) {`   a fresh ticket every cycle, so `myTicket` is
+    //        never the oldest again once the queue drains
+    //   MA7  `sort()[0]` -> `sort().reverse()[0]`  FIFO becomes LIFO
+    //
+    // Only "gate closed from iteration 1" hangs, and that is one member of the family, not the
+    // family. Recorded here because "no row is possible" is the most dangerous exception to this
+    // repo's rule that a claim of guaranteed behaviour must cite the mutation that proves it, and
+    // it has to be earned by more than one attempt.
     _lockRmSync(olderTicket, { force: true });
     await lt416Until(() => c.exited !== null, "the contender to acquire and finish once its ticket is the oldest");
-    assert.ok(c.out.includes("=== Results:"),
-      `once oldest, the contender must get through acquire and run to completion; its stdout carried no results line: ${JSON.stringify(c.out.slice(-400))}`);
+    assert.ok(c.out.includes(LT_LOCK_CHILD_DONE),
+      `once oldest, the contender must get through acquire and RUN TO COMPLETION — expected ${JSON.stringify(LT_LOCK_CHILD_DONE)} ` +
+      `from --only ${JSON.stringify(LT_LOCK_CHILD_FILTER)}; its stdout ended: ${JSON.stringify(c.out.slice(-400))}`);
   } finally {
     try { c.child.kill("SIGKILL"); } catch {}
     try { _lockRmSync(base, { recursive: true, force: true }); } catch {}
   }
 });
 
-test("#423 F2: a LIVE owner's lock is not broken by a real contender, whatever the record's cwd says", async () => {
+lockTest("#423 F2: a LIVE owner's lock is not broken by a real contender, whatever the record's cwd says", async () => {
   const base = lt416ChildDir();
   const lockDir = join(base, "scratchpad", ".suite.lock");
   // Live owner (this process), and a cwd deliberately unlike the contender's — the combination
@@ -26655,20 +26693,41 @@ test("#423 F2: a LIVE owner's lock is not broken by a real contender, whatever t
     // on disk plus the settle window below means steal attempts have happened and been declined.
     await lt416Until(() => lt416Tickets(lockDir).length === 1, "the contender to publish its ticket");
     await lt416Sleep(LT_LOCK_SETTLE_MS);
-    const owner = suiteLockReadOwner(lockDir);
-    assert.ok(owner && owner.nonce === "live-other-cwd" && owner.pid === process.pid,
+    // THE STEAL WINDOW, and why this is a retry rather than a single read (#437 review F4). A
+    // contender's steal renames the lock aside, inspects the moved record, and renames it back —
+    // roughly 200 us inside every 500 ms cycle. A single read therefore has a MEASURED ~1-in-2,400
+    // chance of landing in that window and seeing no record at all. That flake used to fail with
+    // text BYTE-IDENTICAL to MA3's genuine red (both report `null`), which is the worst property a
+    // flake can have: indistinguishable from the finding it would be mistaken for.
+    //
+    // It cannot be told apart by VALUE, so it is told apart by DURATION. The window closes in
+    // microseconds; a lock that was actually broken never comes back. Re-reading across ~200 ms
+    // turns the flake into a pass and leaves a genuine break failing — with its own message, which
+    // is the second half of the fix: the two are no longer the same sentence.
+    let owner = suiteLockReadOwner(lockDir);
+    for (let i = 0; i < 20 && owner === null; i++) { await lt416Sleep(10); owner = suiteLockReadOwner(lockDir); }
+    assert.ok(owner !== null,
+      `the lock record was ABSENT across 20 reads spanning ~200ms. The steal window closes in ~200us, ` +
+      `so this is a lock that is GONE, not one momentarily renamed aside — a live owner's lock was broken.`);
+    assert.ok(owner.nonce === "live-other-cwd" && owner.pid === process.pid,
       `a LIVE owner's lock must survive every steal attempt — cwd is provenance, never a licence. ` +
-      `Got ${JSON.stringify(owner)}`);
-    // No second assertion that the contender is still waiting: it would add no reachable failure
-    // the line above does not already have (a contender that got in necessarily replaced this
-    // record), and one mutation reddening two claims in one body leaves the second unproven.
+      `The lock is now held by someone else: ${JSON.stringify(owner)}`);
+    // AND THE NEGATIVE ABOVE ONLY MEANS SOMETHING IF THE CONTENDER WAS STILL TRYING (#437 review
+    // F2). Measured there: a contender that dies right after publishing its ticket leaves this
+    // record untouched for the most boring reason available, and the test went GREEN inside a 6/2
+    // run. Placed AFTER the two assertions deliberately — a mutation that lets the contender in
+    // (MA3) makes it exit, so a premise placed first would swallow MA3's red and re-report it under
+    // this message instead.
+    assert.equal(c.exited, null,
+      `premise: the contender must still be RUNNING for "the lock survived" to be evidence of anything — ` +
+      `it exited ${JSON.stringify(c.exited)}, so the lock survived a contender that was no longer contending`);
   } finally {
     try { c.child.kill("SIGKILL"); } catch {}
     try { _lockRmSync(base, { recursive: true, force: true }); } catch {}
   }
 });
 
-test("#423 F3: the exit handler releases the lock — a finished run leaves no lock behind", async () => {
+lockTest("#423 F3: the exit handler releases the lock — a finished run leaves no lock behind", async () => {
   const base = lt416ChildDir();
   const lockDir = join(base, "scratchpad", ".suite.lock");
   const c = lt416Contender(base); // uncontended: nothing else holds this path
@@ -26677,8 +26736,10 @@ test("#423 F3: the exit handler releases the lock — a finished run leaves no l
     // Two premises, because "no lock dir" is exactly what a child that never took one leaves.
     // The results line is only reachable PAST the module-level acquire, and `scratchpad/` exists
     // only because the acquire's populate-then-publish mkdir -p'd its temp dir into it.
-    assert.ok(c.out.includes("=== Results:"),
-      `premise: the child must have run past the module-level acquire; stdout: ${JSON.stringify(c.out.slice(-400))}`);
+    assert.ok(c.out.includes(LT_LOCK_CHILD_DONE),
+      `premise: the child must have run past the module-level acquire and completed its one test — ` +
+      `expected ${JSON.stringify(LT_LOCK_CHILD_DONE)} from --only ${JSON.stringify(LT_LOCK_CHILD_FILTER)}; ` +
+      `stdout ended: ${JSON.stringify(c.out.slice(-400))}`);
     assert.ok(_lockExistsSync(join(base, "scratchpad")),
       "premise: the child's acquire must have created the scratchpad dir its lock lives in");
     assert.ok(!_lockExistsSync(lockDir),
@@ -26690,6 +26751,4 @@ test("#423 F3: the exit handler releases the lock — a finished run leaves no l
     try { _lockRmSync(base, { recursive: true, force: true }); } catch {}
   }
 });
-
-}
 

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -14,7 +14,7 @@ import { makeResolveSpawnToken } from "./lib/spawn-token.mjs";
 import { createHash } from "node:crypto";
 import { strict as assert } from "node:assert";
 import { join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { pathToFileURL, fileURLToPath } from "node:url";
 import { execFileSync, spawnSync } from "node:child_process";
 import { homedir } from "node:os";
 import { AsyncLocalStorage } from "node:async_hooks";
@@ -63,7 +63,7 @@ function _onlyMatches(name) {
 // Fairness (ticket/FIFO) is a separate increment on top of this; the plain retry loop is the
 // lotter-shaped base the issue measured (one contender waited ~40 min).
 // Class: not endpoint-touching — harness code; touches no server.mjs / lib/.
-import { mkdirSync as _lockMkdirSync, writeFileSync as _lockWriteFileSync, renameSync as _lockRenameSync, rmSync as _lockRmSync, readFileSync as _lockReadFileSync, readdirSync as _lockReaddirSync } from "node:fs";
+import { mkdirSync as _lockMkdirSync, writeFileSync as _lockWriteFileSync, renameSync as _lockRenameSync, rmSync as _lockRmSync, readFileSync as _lockReadFileSync, readdirSync as _lockReaddirSync, existsSync as _lockExistsSync } from "node:fs";
 import { hostname as _lockHostname } from "node:os";
 
 const SUITE_LOCK_DIR = join(process.cwd(), "scratchpad", ".suite.lock");
@@ -26115,8 +26115,13 @@ test("#416 mode 3: a live owner with a different cwd is NOT broken (cwd is prove
     // claimant would run and assert the pid is treated as alive regardless of the cwd mismatch.
     assert.ok(before && !suiteLockPidGone(before),
       `a live owner (pid ${process.pid}) must not be considered gone just because cwd differs`);
-    assert.equal(suiteLockReadOwner(dir).nonce, "other",
-      "the lock must still belong to the live owner — cwd mismatch must not have broken it");
+    // The line that used to sit here — re-reading the owner and asserting the nonce is still
+    // "other", captioned "cwd mismatch must not have broken it" — is DELETED rather than kept
+    // (#423 review F2). Nothing in this body ever attempted a break, so it could not fail: a
+    // design that broke EVERY lock on EEXIST regardless of liveness reddened nothing. That claim
+    // is real and now has a body that can fail it, one that runs a second process against a live
+    // lock: "#423 F2: a LIVE owner's lock is not broken by a real contender". Deleted rather
+    // than re-captioned per AGENTS.md's remedy for an assertion a broader one implies.
   } finally {
     try { _lockRmSync(dir, { recursive: true, force: true }); } catch {}
   }
@@ -26502,4 +26507,189 @@ test("#416 fairness: a LIVE owner's ticket is NOT swept (a reused-pid read is co
   try { _lockRmSync(_lockTicketDir(dir), { recursive: true, force: true }); } catch {}
   try { _lockRmSync(dir, { recursive: true, force: true }); } catch {}
 });
+
+
+// ── #416 F2 / #423 F2 + F3: the acquire LOOP, under real contention ────────────────────────────
+// The mode rows above pin the lock's DECISION HELPERS and the sweep rows pin the queue's
+// maintenance. Three claims survived both, and all three are properties of the LOOP rather than of
+// a helper — which is why nothing single-threaded reached them:
+//
+//   * only-oldest-acts (#416 F2, recorded on the issue when 30ea7935 merged: "the only-oldest-acts
+//     gate has no live two-process contender test"). Calling suiteLockAcquire in-process to test
+//     it is not an option: a contender that is not the oldest loops forever, and per AGENTS.md a
+//     run with no `=== Results:` line is VOID, not red.
+//   * a LIVE lock is never broken (#423 audit F2). The mode-3 row asserted this with a line that
+//     could not fail, because nothing in that body attempted a break.
+//   * the exit-handler release (#423 audit F3). Measured: removing it left the suite at 1237/0.
+//
+// THE SECOND PROCESS IS THE REAL SUITE. `node test-features.mjs --only <a filter that matches no
+// test>` in a scratch cwd runs the real module-level suiteLockAcquire against that cwd's
+// `scratchpad/.suite.lock` and runs no test at all — measured 0.08 s wall on this host. That is
+// AGENTS.md's "use a second instance, never a miniature copy" (#402): re-implementing the acquire
+// loop inside the test would pass while the real one was broken, which is the whole failure this
+// section exists to catch.
+//
+// RECURSION IS CLOSED BY CONSTRUCTION, TWICE. The child is always given a filter that matches no
+// test name, AND it is given OCP_SUITE_LOCK_CHILD=1, which is the condition these three tests are
+// registered under. Either alone suffices; neither is a prohibition a future edit can violate by
+// forgetting it, because a child that ran these tests would have to both match the filter and
+// clear the env guard.
+//
+// The child's stdout/stderr are PIPED, never inherited: `.github/workflows/flake-hunt.yml`
+// histograms `✗` lines on the suite's stdout, and a child's output on the parent's stream would
+// be read as the parent's result.
+const LT_LOCK_CHILD_FILTER = "__ocp_suite_lock_child_matches_no_test__";
+const LT_LOCK_SUITE_PATH = fileURLToPath(import.meta.url);
+// Generous, because it is only ever paid on failure: this host has recorded 78–120 s whole-process
+// stalls (#374), and a timeout tuned to the 0.08 s happy path would report one of those as a lock
+// defect. A timeout throws, which `test()` reports as a named failure — never a hang.
+const LT_LOCK_WAIT_MS = 60000;
+// Three of the loop's 500 ms poll cycles. Not a coin flip: every mutation these tests are aimed at
+// acts in the contender's FIRST iteration, microseconds after it publishes the ticket this window
+// starts from.
+const LT_LOCK_SETTLE_MS = 1500;
+
+function lt416ChildDir() {
+  const base = lt416TmpDir();
+  _lockMkdirSync(base, { recursive: true });
+  return base;
+}
+// A real contender: the suite itself, in `cwd`, running no test.
+function lt416Contender(cwd) {
+  const child = _ltSpawn(process.execPath, [LT_LOCK_SUITE_PATH, "--only", LT_LOCK_CHILD_FILTER], {
+    cwd, stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, OCP_SUITE_LOCK_CHILD: "1" },
+  });
+  const state = { out: "", exited: null, child };
+  child.stdout.on("data", (d) => { state.out += d; });
+  child.stderr.on("data", () => {});
+  child.on("exit", (code, signal) => { state.exited = { code, signal }; });
+  return state;
+}
+const lt416Sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+async function lt416Until(pred, what) {
+  const t0 = Date.now();
+  for (;;) {
+    let v = false;
+    try { v = pred(); } catch { v = false; }
+    if (v) return v;
+    if (Date.now() - t0 > LT_LOCK_WAIT_MS) {
+      throw new Error(`timed out after ${LT_LOCK_WAIT_MS}ms waiting for ${what}`);
+    }
+    await lt416Sleep(25);
+  }
+}
+function lt416Tickets(lockDir) {
+  try { return _lockReaddirSync(_lockTicketDir(lockDir)).sort(); } catch { return []; }
+}
+
+if (!process.env.OCP_SUITE_LOCK_CHILD) {
+
+test("#416 F2: only the OLDEST ticket acts — a real contender holds off a lock it is otherwise entitled to break", async () => {
+  const base = lt416ChildDir();
+  const lockDir = join(base, "scratchpad", ".suite.lock");
+  // A lock the contender IS entitled to break: its owner pid is definitively gone (ESRCH), which
+  // is the one condition the stale-break commits on. With the gate removed nothing else stands
+  // between the contender and this lock, so the gate is the only variable in the experiment.
+  const dead = spawnSync(process.execPath, ["-e", ""]);
+  _lockMkdirSync(lockDir, { recursive: true });
+  _lockWriteFileSync(join(lockDir, "owner.json"), JSON.stringify({
+    pid: dead.pid, nonce: "stale", startedAt: Date.now() - 60000, host: "x", cwd: "y",
+  }));
+  // An OLDER ticket owned by THIS process — alive, so the sweep must keep it. Built by the real
+  // _lockTicketName() rather than a hand-written string, so the ordering under test is the
+  // production ordering.
+  _lockMkdirSync(_lockTicketDir(lockDir), { recursive: true });
+  const olderTicket = join(_lockTicketDir(lockDir), _lockTicketName());
+  _lockWriteFileSync(olderTicket, "");
+
+  const c = lt416Contender(base);
+  try {
+    // POSITIVE EVIDENCE FIRST (AGENTS.md: never trust a negative predicate without one). Two
+    // tickets means the contender reached the acquire loop and registered. Without this, "the
+    // lock was not broken" is equally satisfied by a child that never started.
+    await lt416Until(() => lt416Tickets(lockDir).length === 2, "the contender to publish its ticket");
+    assert.equal(join(_lockTicketDir(lockDir), lt416Tickets(lockDir)[0]), olderTicket,
+      "premise: OUR ticket must be the older of the two, or this test proves nothing about ordering");
+    await lt416Sleep(LT_LOCK_SETTLE_MS);
+    const owner = suiteLockReadOwner(lockDir);
+    assert.ok(owner && owner.pid === dead.pid,
+      `a contender that is not the oldest ticket must not act — not even on an ESRCH-breakable lock. ` +
+      `Expected the stale owner (pid ${dead.pid}) untouched; got ${JSON.stringify(owner)}`);
+    // THE POSITIVE CONTROL, and that is all it is — read this before treating it as a second
+    // pinned claim. Release the queue and the contender must get in: without this half, "the lock
+    // was not broken" above is equally satisfied by a contender that could never acquire under any
+    // circumstances, which is the shape AGENTS.md warns about (a negative predicate satisfied by an
+    // empty world).
+    //
+    // It has no mutation row of its own and cannot have one. Every mutation that closes the gate
+    // permanently — the only way to break this half — also blocks `#416 mode 1` above, which calls
+    // suiteLockAcquire IN-PROCESS on a NON-EMPTY stale lock and therefore must go through the
+    // ticket path. Measured: `if (oldest && !myTicket.endsWith(oldest))` -> `if (oldest)` produced
+    // no `=== Results:` line in 7 minutes, which per AGENTS.md is VOID, not red. The wait below is
+    // bounded and throws so that THIS test would report a named failure; the pre-existing test that
+    // hangs first is what makes the run unusable.
+    _lockRmSync(olderTicket, { force: true });
+    await lt416Until(() => c.exited !== null, "the contender to acquire and finish once its ticket is the oldest");
+    assert.ok(c.out.includes("=== Results:"),
+      `once oldest, the contender must get through acquire and run to completion; its stdout carried no results line: ${JSON.stringify(c.out.slice(-400))}`);
+  } finally {
+    try { c.child.kill("SIGKILL"); } catch {}
+    try { _lockRmSync(base, { recursive: true, force: true }); } catch {}
+  }
+});
+
+test("#423 F2: a LIVE owner's lock is not broken by a real contender, whatever the record's cwd says", async () => {
+  const base = lt416ChildDir();
+  const lockDir = join(base, "scratchpad", ".suite.lock");
+  // Live owner (this process), and a cwd deliberately unlike the contender's — the combination
+  // #416 mode 3 names, now driven through the acquire loop instead of through the helper alone.
+  _lockMkdirSync(lockDir, { recursive: true });
+  _lockWriteFileSync(join(lockDir, "owner.json"), JSON.stringify({
+    pid: process.pid, nonce: "live-other-cwd", startedAt: Date.now() - 1000,
+    host: _lockHostname(), cwd: "/somewhere/else/entirely",
+  }));
+  const c = lt416Contender(base);
+  try {
+    // The contender publishes its ticket immediately BEFORE its first steal attempt, so a ticket
+    // on disk plus the settle window below means steal attempts have happened and been declined.
+    await lt416Until(() => lt416Tickets(lockDir).length === 1, "the contender to publish its ticket");
+    await lt416Sleep(LT_LOCK_SETTLE_MS);
+    const owner = suiteLockReadOwner(lockDir);
+    assert.ok(owner && owner.nonce === "live-other-cwd" && owner.pid === process.pid,
+      `a LIVE owner's lock must survive every steal attempt — cwd is provenance, never a licence. ` +
+      `Got ${JSON.stringify(owner)}`);
+    // No second assertion that the contender is still waiting: it would add no reachable failure
+    // the line above does not already have (a contender that got in necessarily replaced this
+    // record), and one mutation reddening two claims in one body leaves the second unproven.
+  } finally {
+    try { c.child.kill("SIGKILL"); } catch {}
+    try { _lockRmSync(base, { recursive: true, force: true }); } catch {}
+  }
+});
+
+test("#423 F3: the exit handler releases the lock — a finished run leaves no lock behind", async () => {
+  const base = lt416ChildDir();
+  const lockDir = join(base, "scratchpad", ".suite.lock");
+  const c = lt416Contender(base); // uncontended: nothing else holds this path
+  try {
+    await lt416Until(() => c.exited !== null, "the uncontended run to finish");
+    // Two premises, because "no lock dir" is exactly what a child that never took one leaves.
+    // The results line is only reachable PAST the module-level acquire, and `scratchpad/` exists
+    // only because the acquire's populate-then-publish mkdir -p'd its temp dir into it.
+    assert.ok(c.out.includes("=== Results:"),
+      `premise: the child must have run past the module-level acquire; stdout: ${JSON.stringify(c.out.slice(-400))}`);
+    assert.ok(_lockExistsSync(join(base, "scratchpad")),
+      "premise: the child's acquire must have created the scratchpad dir its lock lives in");
+    assert.ok(!_lockExistsSync(lockDir),
+      `a run that finished must leave no lock behind: ${lockDir} still exists. Without the release ` +
+      `the next run reclaims it only via the ESRCH stale-break, and a REUSED pid reads as alive — ` +
+      `which is a livelock on a lock nobody holds.`);
+  } finally {
+    try { c.child.kill("SIGKILL"); } catch {}
+    try { _lockRmSync(base, { recursive: true, force: true }); } catch {}
+  }
+});
+
+}
 

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -26815,15 +26815,50 @@ lockTest("#423 F2: a LIVE owner's lock is not broken by a real contender, whatev
     // text BYTE-IDENTICAL to MA3's genuine red (both report `null`), which is the worst property a
     // flake can have: indistinguishable from the finding it would be mistaken for.
     //
-    // It cannot be told apart by VALUE, so it is told apart by DURATION. The window closes in
-    // microseconds; a lock that was actually broken never comes back. Re-reading across ~200 ms
-    // turns the flake into a pass and leaves a genuine break failing — with its own message, which
-    // is the second half of the fix: the two are no longer the same sentence.
+    // It cannot be told apart by VALUE, so it is told apart by WHETHER THE CONTENDER IS STILL
+    // RUNNING — not, as the first fix did, by a wall-clock budget.
+    //
+    // That first fix re-read 20 times across ~200 ms. It worked, and the #437 review measured its
+    // margin honestly (maximum CONTIGUOUS absence 1 ms idle, still 1 ms under 12 CPU loaders — 200x).
+    // But its residual was labelled reasoned-not-measured, and the residual was a **#374-class stall
+    // landing between the two renames**, which is the one host condition this repo knows it has. So
+    // the file would have been arguing against itself: LT_LOCK_WAIT_MS five lines up is 60 s
+    // precisely because "a timeout tuned to the 0.08 s happy path would report one of those as a
+    // lock defect", and a 200 ms budget here is exactly such a tuning.
+    //
+    // `c.exited` removes the assumption rather than sizing it. The steal window can only be open
+    // while a contender is RUNNING — it is bounded by two renames inside one live process — so:
+    //   contender alive  + record absent -> the window, however long the host stretches it: re-read
+    //   contender exited + record absent -> the lock was broken and then released: fail
+    // It is also FASTER on the real defect. Under MA3 the contender acquires, runs and exits in
+    // ~600 ms, so by this read at T+1500 ms it is already gone and the loop exits on its first
+    // condition check — where the wall-clock form burned 200 ms of retries first.
+    //
+    // The LT_LOCK_WAIT_MS backstop below is not a discriminator, it is a "this cannot happen"
+    // bound: absent record AND live contender for a full minute is neither the window nor a break,
+    // and it must surface as a named failure rather than a hang.
     let owner = suiteLockReadOwner(lockDir);
-    for (let i = 0; i < 20 && owner === null; i++) { await lt416Sleep(10); owner = suiteLockReadOwner(lockDir); }
+    const readStart = Date.now();
+    while (owner === null && c.exited === null) {
+      if (Date.now() - readStart > LT_LOCK_WAIT_MS) {
+        throw new Error(`the lock record stayed absent for ${LT_LOCK_WAIT_MS}ms while the contender was ` +
+          `STILL RUNNING — that is neither the steal window (bounded by two renames) nor a break ` +
+          `(which releases on exit), so the premise of this test no longer holds`);
+      }
+      await lt416Sleep(10);
+      owner = suiteLockReadOwner(lockDir);
+    }
     assert.ok(owner !== null,
-      `the lock record was ABSENT across 20 reads spanning ~200ms. The steal window closes in ~200us, ` +
-      `so this is a lock that is GONE, not one momentarily renamed aside — a live owner's lock was broken.`);
+      `the lock record is ABSENT and the contender has EXITED (${JSON.stringify(c.exited)}). The steal ` +
+      `window is only open while a contender is running, so this is a lock that was BROKEN and then ` +
+      `released on exit — not one momentarily renamed aside.`);
+    // NO MEASURED ROW REACHES THIS ONE, and that is worth saying rather than leaving a reader to
+    // assume otherwise (#437 review O1). Every mutation tried lands on the assertion above instead:
+    // the contender releases on exit within ~150 ms, so by this read at T+1500 ms the record is
+    // absent rather than replaced. The branch is NOT unreachable in principle — a contender that
+    // broke the lock and still HELD it at read time would satisfy the line above and only fail
+    // here — so it stays. It is the "unproven but load-bearing" case, not the "covered" case, and
+    // today's #438 finding is what a branch that reads as covered actually costs.
     assert.ok(owner.nonce === "live-other-cwd" && owner.pid === process.pid,
       `a LIVE owner's lock must survive every steal attempt — cwd is provenance, never a licence. ` +
       `The lock is now held by someone else: ${JSON.stringify(owner)}`);


### PR DESCRIPTION
# Pull Request

## Summary

Pins the three claims the suite mutex shipped **unpinned** — all three properties of the acquire
**loop** rather than of a helper, which is why nothing single-threaded reached them:

| claim | recorded as | why it survived the existing rows |
|---|---|---|
| only the **oldest ticket acts** | #428 audit **F2**, measured as `m428c`: *"only-oldest-acts gate deleted → **1241/0 — no red** … the FIFO-ordering property therefore rides on review, not on a reddening mutation"*; recorded on #416 as *"the only-oldest-acts gate has no live two-process contender test"* | calling `suiteLockAcquire` in-process to test it loops forever, and a run with no `=== Results:` line is **VOID**, not red |
| a **live lock is never broken** | #423 audit **F2**: *"mode 3's second assertion is inert … A mutation that breaks every existing lock … would redden nothing"* | the assertion re-read the owner record in a body that never attempted a break |
| the **exit-handler release** | #423 audit **F3**: measured `m423f` at **1237/0 — no red** | nothing observed a finished run's leftovers |

**The second process is the real suite.** `node test-features.mjs --only "#416 mode 2"` in a scratch
cwd runs the real module-level `suiteLockAcquire` against that cwd's `scratchpad/.suite.lock`, runs
that one test, and exits — **measured 0.06–0.08 s**. That is `AGENTS.md`'s *"use a second instance,
never a miniature copy"* (#402): a re-implemented acquire loop inside the test would pass while the
real one was broken, which is precisely the failure this section exists to catch.

**Recursion is closed by construction, twice**, and the #437 review verified each guard sufficient
on its own. The child gets a filter naming one test that is none of these three, **and**
`OCP_SUITE_LOCK_CHILD=1`, which turns these three into counted skips. Neither is a prohibition an
edit can violate by forgetting it. The child's stdio is **piped, never inherited** —
`flake-hunt.yml` histograms `✗` lines on the suite's stdout.

Also in this PR, and nothing else: **the inert line in `#416 mode 3` is deleted** rather than
re-captioned, per `AGENTS.md`'s remedy for an assertion a broader one implies. Its claim now has a
body that can fail it. Control **MA5** below proves the deletion did not neuter what remained.

No user-visible change.

## Grouping (Iron Rule 11 / §11.1) — why this is one PR of three, and not one of one or one of five

The five recorded follow-ups are all the same **severity** (an unpinned claim) and the same
**citation class** (not endpoint-touching), so §11.1's two absolute bars are clear and the question
is only whether a reviewer can follow the diff. The line drawn is **one upstream issue per PR**,
because that is exactly what a reviewer has to open:

- **this PR — #416/#423, the suite lock.** Harness infrastructure. Reviewing it means reasoning
  about ticket ordering, stale-break liveness and process exit.
- **#327 parts 4+5 — the CLI reporting chain** (`doctor.mjs` produces `units`, `upgrade.mjs`
  consumes it).
  One issue, and a **review** dependency rather than a runtime one — corrected on #438, where
  the reviewer showed the part-4 tests drive `runUpgrade` with a `mockDoctor` fixture and never
  execute `doctor.mjs`. What the pairing buys is that judging whether those fixtures are honest
  requires opening `doctor.mjs`.
- **#374 — the mem snapshot's wiring.** A different subject, a different reference, and a sibling
  agent is working in that area.

§11.1 authorises folding only when a defect *"was found by **this** PR's stated job"*. None of the
three groups was found by another's, so nothing here qualifies for a fold, and Rule 11's default —
split — governs. Bundling all five would ask one reviewer to hold concurrency, CLI reporting and
vm_stat parsing at once; five PRs would split a fixture from the file a reviewer has to open to
judge it, for no gain.

*(That last clause read "would split a producer from its consumer" until #438's reviewer showed the
framing was wrong — the part-4 tests use a `mockDoctor` fixture and never execute `doctor.mjs`, so
the dependency is a **review** one, not a runtime one. I corrected the paragraph above when it was
pointed out and left this clause standing one screen later: the same shape as two other findings on
these PRs, and the reason the sweep is now by enumeration. Every occurrence across all three bodies
was enumerated before this edit; this was the only stale one.)*

## Endpoint Class (REQUIRED)

- [x] **Not endpoint-touching** — the whole diff is `test-features.mjs`. Verified:
  `git diff origin/main -- server.mjs lib/ keys.mjs` → **0 lines**;
  `git diff --stat origin/main` → `test-features.mjs | 288 insertions(+), 4 deletions(-)`, one file.

## Type of change

- [x] Refactor (no wire-level behavior change) — test-only; no production file is touched.

## Mutation table — every added or changed test, in #218's format

Baseline and every mutation run under the machine-wide guard (mkdir lock shared with the sibling
agent's `scratchpad/suite-guard.sh`, trap's last statement `exit`), targeted via
`--only '#416 F2,#423 F2,#423 F3,#416 mode 3,#416 mode 1,#416 mode 5,#416 fairness'`, **exit code
checked on every run** (#434: a zero-match `--only` still prints `Results: 0 passed, 0 failed`).
Every mutation is a **whole-line** replacement with an **asserted match count of exactly 1** and the
hunk printed before the run — a dry-check that an anchor still matches cannot tell a right match
from a wrong one. Restores are from a **file backup** with `cmp`, never `git checkout -- <file>`.

| tag | mutation (whole line, count asserted = 1) | before | after | attributable red |
|---|---|---|---|---|
| — | baseline | — | **8 passed / 0 failed** (exit 0) | — |
| **MA1** | delete the only-oldest gate: `if (oldest && !myTicket.endsWith(oldest)) { _lockSleep(500); continue; }` → comment. **This is the #428 audit's `m428c`, verbatim** — the row that measured 1241/0 with no red | 8/0 | **7/1** (exit 1) | `#416 F2` — *"a contender that is not the oldest ticket must not act … Expected the stale owner (pid N) untouched; got null"* |
| **MA3** | the steal commits regardless of liveness: `if (suiteLockPidGone(suiteLockReadOwner(staleDir))) {` → `if (true) {` | 8/0 | **7/1** (exit 1) | `#423 F2` — *"the lock record is ABSENT and the contender has EXITED ({"code":0,"signal":null}) … BROKEN and then released on exit"*. Re-measured after the F4 amendment below; **3 s wall** for the whole filtered run |
| **MA4** | delete the exit-handler release: `try { _lockRmSync(SUITE_LOCK_DIR, …) } catch {}` → comment | 8/0 | **7/1** (exit 1) | `#423 F3` — *"a run that finished must leave no lock behind: …/scratchpad/.suite.lock still exists"* |
| **MA5** | **control for the mode-3 deletion** — cwd becomes a decision input in `suiteLockPidGone` (the audit's `m423c`) | 8/0 | **6/2** (exit 1) | `#416 mode 3` *and* `#423 F2`, both by name — the pre-existing row still reddens with the inert line gone |
| **MA8** | **test-side control for the new premise (review F2)** — the contender is SIGKILLed 300 ms after spawn, i.e. just after it publishes its ticket | 8/0 | **6/2** (exit 1) | `#423 F2` at the new premise — *"the contender must still be RUNNING … it exited {"code":null,"signal":"SIGKILL"}, so the lock survived a contender that was no longer contending"*; and `#416 F2`, whose contender MA8 also kills |

No unattributable red appeared in any run.

### RETRACTED: "MA2 is VOID and this half cannot have a row" was false

The first version of this PR argued that the positive-control half of `#416 F2` could have **no**
mutation row, because every mutation closing the gate permanently also hangs `#416 mode 1`. **The
#437 reviewer disproved that by building the row.** I reproduced both of theirs:

| tag | mutation | result | attributable red |
|---|---|---|---|
| **MA6** | `if (!myTicket) {` → `if (true) {` — a fresh ticket every cycle, so `myTicket` is never the oldest again once the queue drains | 8/0 → **7/1** | `#416 F2`, **at the positive-control assertion** — *"timed out after 60000ms waiting for the contender to acquire and finish once its ticket is the oldest"*. `#416 mode 1` stays **green**. |
| **MA7** | `sort()[0]` → `sort().reverse()[0]` — FIFO becomes LIFO | 8/0 → **7/1** | `#416 F2` (at the first half). `#416 mode 1` stays green. |

**The mechanism, which is the part worth keeping:** `#416 mode 1`'s in-process acquire evaluates the
gate **exactly once** — iteration 1, one ticket present — and returns on iteration 2. So any defect
that first manifests on **iteration ≥ 2** is invisible to it. I measured "gate closed from iteration
1", which does hang, and generalised it to *any* permanently-closed-gate mutation. That was one
member of a family, not the family.

Recorded prominently rather than quietly corrected, because "no row is possible" is the most
dangerous exception to this repo's rule that a claim of guaranteed behaviour must cite the mutation
that proves it: an unpinned claim excused by impossibility is worse than one admitted as such, and
the exception has to be earned by more than a single attempt. The in-code comment now carries the
correction and both rows.

### The original MA2 measurement, kept because it is still true and still useful

`if (oldest && !myTicket.endsWith(oldest))` → `if (oldest)` — a gate closed from iteration 1 —
**does** hang: measured twice, no `=== Results:` line in 2 minutes and then none in 7. That is VOID
per `AGENTS.md`, so it is still not a row.

The mechanism is real and is the same one that explains why MA6 and MA7 work: `#416 mode 1` calls
`suiteLockAcquire` **in-process** on a **non-empty** stale lock, so it must go through the ticket
path, and a gate closed on iteration 1 blocks the suite there — before any of this PR's tests are
registered. (`#416 mode 5` pre-creates an *empty* dir, which `rename()` replaces on iteration 1, so
it never tickets and never hangs; that asymmetry localises it.)

**What was wrong was the generalisation, not the measurement.** Mode 1 passes the gate once and
leaves, so it constrains only iteration 1 — and MA6/MA7 both act later. The correct statement is
narrow: *a mutation that closes the gate on iteration 1 cannot be used as a row here, because a
pre-existing in-process test hangs on it first.*

Also recorded so the next reader does not repeat it: my first diagnosis of the hang was wrong. The
initial run was killed at a 2-minute tool timeout, which left `scratchpad/.suite.lock` behind (Node
does not run `exit` handlers on SIGTERM), and that leftover looked like sufficient explanation.
Sweeping it changed nothing — the clean-tree rerun hung identically.

First diagnosis of this was wrong and is recorded so the next reader does not repeat it: the initial
run was killed at a 2-minute timeout, which left `scratchpad/.suite.lock` behind (Node does not run
`exit` handlers on SIGTERM), and the leftover looked like sufficient explanation. Sweeping it
changed nothing — the second, clean-tree run hung identically.

## Suite numbers, each against the SHA it was measured on

- Base **`7f13a13`** (`origin/main`): **1273 passed / 0 failed**.
- This branch **`aedfbd1`**: **1276 passed / 0 failed**, 2 skipped.
- Delta **+3**, re-checkable from the diff rather than from a total, per `AGENTS.md`:
  `git diff origin/main...HEAD -- test-features.mjs | grep -cE '^\+(test|ltTest)\('` → **3**, none
  removed.

Full suite is the gate; the `--only` runs above are the mutation campaign, not the verdict.

## Review findings addressed (#437, APPROVE-WITH-FINDINGS)

**F3 — the contender no longer depends on #434's defect.** Both child assertions used to wait for
`=== Results: 0 passed, 0 failed ===` from a deliberately unmatchable filter. That line exists only
because of the defect #434 reports, and **#434's leading candidate fix deletes it** — after which
these tests would have broken *silently*: the child would still exit 1, still register zero tests,
still leave its scratch dir, and only the awaited line would be gone. The filter now names one real
test and the assertions wait for `Results: 1 passed, 0 failed`, which depends on nothing scheduled
to change and is a strictly stronger signal (a test ran **and passed**, not merely that the runner
reached its summary). If that test is renamed, every assertion fails with the filter quoted in its
message. The coordinator has recorded the consumer on #434.

**F2 — `#423 F2` could pass vacuously.** A contender that dies right after publishing its ticket
leaves the owner record untouched for the most boring reason available, and the test went green.
A premise now asserts the contender is **still running**, placed *after* the two owner assertions
on purpose: a mutation that lets the contender in (MA3) makes it exit, so a premise placed first
would swallow MA3's red and re-report it under the premise's message. **MA8** is its row.

**F4 — a flake whose message was byte-identical to a real red, now separated by OUTCOME.** The steal
window (~200 µs in every 500 ms cycle, measured ~1-in-2,400) made a single read return `null` — the
same text MA3 produces. The read is now a retry, so **the flake emits no message at all and recovers
into a pass**, while a genuinely broken lock still fails with its own sentence.

**Amended again after the second review (non-blocking item 1), and the amendment is strictly
better.** The first fix retried on a **wall clock** — 20 reads across ~200 ms. It worked, and the
reviewer measured its margin properly by sampling *maximum contiguous* absence rather than the mean
(idle max **1 ms**; under 12 CPU loaders the mean doubled but the max was still **1 ms** — a **200×**
margin). But its residual was a **#374-class stall landing between the two renames**, which is the
one host condition this repo knows it has — and **the file five lines up justifies
`LT_LOCK_WAIT_MS = 60000` by saying a timeout tuned to the happy path would report such a stall as a
lock defect.** The file was arguing against its own constant.

`c.exited` removes the assumption instead of sizing it: the steal window is bounded by two renames
**inside one live process**, so *contender alive + record absent* is the window however long the
host stretches it, and *contender exited + record absent* is a break. It is also **faster on the real
defect** — under MA3 the contender is already gone by this read, so the loop exits on its first
condition check where the wall-clock form burned 200 ms first. Measured: MA3 reddens in **3 s** for
the whole filtered run. The remaining `LT_LOCK_WAIT_MS` bound is not a discriminator but a
"this cannot happen" backstop, so a hang surfaces as a named failure.

**O1 — assert 2's "held by someone else" branch is unproven, and now says so at the assertion.**
The reviewer measured why: the contender releases on exit within ~150 ms, so the parent's read at
T+1500 ms always sees absence and every mutation lands on assert 1 instead. It is **not unreachable
in principle** — a contender that broke the lock and still *held* it would satisfy assert 1 and fail
only here — so it stays, labelled as unproven-but-load-bearing rather than covered. Today's #438
finding is exactly what an unexercised branch that reads as covered costs.

**F5 — the env guard is now a counted skip.** It was an `if` wrapper, so in a contender child the
three tests did not exist; per #366 an unregistered test and a passing one are the same green tick
unless the skip is counted and named. They now go through a `lockTest()` helper that emits
`testSkipped(…)` with a reason.

**F6 — the ticket-dir leak, corrected and fixed.** The reviewer's correction to my report: it is
**mode 1 alone at 1 dir/run**, not mode 1 *and* mode 5 — mode 5 pre-creates an *empty* lock dir,
which `rename()` replaces on iteration 1, so it never tickets and leaks 0. Fixed with one line in
mode 1's `finally`, matching the fairness tests' existing cleanup. **Measured on the full runs
below**: this branch leaves **0** `lt416-*` dirs behind, while `#438`'s branch (same base, without
this fix) leaves **1** — the leak and its fix, both observed rather than argued.

This PR's own tests never contributed: they clean one scratch **cwd** recursively, and the child's
lock and ticket dir are both inside it.

## Post-merge numbers (`94efa606` is now the base)

`#438` merged as **`94efa606`** after the figures above were taken, and it touches
`test-features.mjs` — **the only file this PR changes**. Merged forward (a **merge**, not a rebase,
so the SHAs the reviewer anchored to keep resolving) and re-measured. The pre-merge figures are left
above rather than overwritten: they were taken on `7f13a13` and are true of that tree.

| tree | base | this branch | delta |
|---|---|---|---|
| pre-merge, darwin | `7f13a13` → 1273 / 0, 2 skips | 1276 / 0, 2 skips | +3 |
| **post-merge, darwin** | **`94efa606` → 1276 / 0**, 2 skips | **1279 / 0**, 2 skips | **+3** |
| pre-merge, CI ubuntu | `main` → 1272 / 0, 3 skips | 1275 / 0, 3 skips | +3 |
| **post-merge, CI ubuntu** | **`main` → 1275 / 0**, 3 skips | **1278 / 0**, 3 skips | **+3** |
| **#439 merge-forward, darwin** | **`cb9b8c26` → 1279 / 0**, 2 skips | **`04aba82` → 1282 / 0**, 2 skips | **+3** |

The last row is **two independent measurements that agree**: the reviewer trial-merged and measured
`1282 / 0 / 2` (238 s) before I pushed, and my own run under the machine-wide guard read the same.
Each earlier row is left at the base it was taken on rather than restated.

**The push is confirmable by hash rather than by re-reading the diff.** The reviewer's trial merge and
mine produce the same tree:

```
git rev-parse "origin/pin/416-423-lock-contender^{tree}"  ->  e7d1f2c337708f1d9328f077c3e5fa134fc5a83a
```

which is the tree they gated. (Quoted: `^` is a glob operator in zsh, and the same class of shell
trap as the `${SHA}:path` one that cost an hour today — an unquoted form here would have compared
against something else and read as a mismatch.)

Leak counter re-checked on the newest base: **this tree leaves 0 `lt416-*` dirs, `cb9b8c26` leaves 1.**

**The auto-merge was clean, and that is what I checked rather than what I relied on** — git merges
by context lines, not by section semantics, and #438 appended to the same file. Verified on the
merged tree by artifact, not by the merge's exit code:

- `git diff origin/main -- server.mjs lib/ keys.mjs` → **0 lines**
- registration counts **re-derived from the diff** against the new base, not carried:
  `grep -cE '^\+\s*(test|ltTest|lockTest)\('` → **3**, `'^-\s*...'` → **0**
- all **three** of #438's tests present in this tree, and its repaired guard survived in its
  repaired form: the non-parenthesised `tree unknown` string at the early position, with
  `grep -c '(tree unknown)")'` → **0**
- no scratch-dir or test-name collision: #438 added `#327 part 4/5` tests with no fixture
  directories; this PR's `lt416-*` scratch names are timestamp+random and live under `scratchpad/`

## Related

- `ALIGNMENT.md` Rule(s) invoked: none — not endpoint-touching.
- Related issue / prior PR: #416 (F2), #423 (audit F2, F3), #428, #434 (the `--only` exit-code contract).

### User-visible change self-check (铁律第五律 5.3)

- [x] This PR has no user-visible changes → "no user-visible change" stated in Summary.

### Privacy self-check (for PUBLIC repos)

- [x] No real names, nicknames or handles.
- [x] No literal personal paths. (The scratch paths in this PR are all derived from `process.cwd()`.)
- [x] No personal machine hostnames.
- [x] No personal email addresses.

## Reviewer — independent review REQUIRED (Iron Rule 10)

**I am the author and cannot approve this.** A fresh-context reviewer is required. Specifically
worth checking:

1. **Confirm the class yourself** against `ALIGNMENT.md` — do not take the diffstat's word for it.
   "Not endpoint-touching" is the cheapest class to declare and so the one most worth verifying.
2. **The recursion guard.** Two independent conditions, either sufficient. Satisfy yourself that a
   child cannot reach these bodies.
3. **MA2's VOID.** The claim is that no mutation can redden the second half of `#416 F2` while
   `#416 mode 1` calls `suiteLockAcquire` in-process on a non-empty lock. That is a claim about the
   code; it is falsifiable by exhibiting a mutation that does.
4. **The mode-3 deletion.** Confirm MA5 still reddens `#416 mode 3` by name — i.e. that the
   remaining assertion is the real gate.

## Second measurement, on the other platform (CI, ubuntu-latest)

The cheapest validity check available is two independent measurements that agree (`AGENTS.md`).

| where | base | this branch | delta |
|---|---|---|---|
| workstation, darwin | `7f13a13` → **1273 / 0**, 2 skips | `aedfbd1` → **1276 / 0**, 2 skips | **+3** |
| CI, ubuntu-latest | `main` → **1272 / 0**, 3 skips | this PR → **1275 / 0**, 3 skips | **+3** |

Same delta on both, and the skip count is unchanged — so the three child-spawning tests **run, and
pass, on Linux too**, which is the arm this workstation could not measure. The absolute totals
differ between platforms by design (`#366`'s case-fold and readdir gates skip on ext4).
