### PR TITLE
test(cli): pin #327's clear-state inventory and both unpinned report arms, and repair a guard that had gone vacuous (#425, #426)

### DIFF
--- a/test-features.mjs
+++ b/test-features.mjs
@@ -26190,6 +26190,13 @@ test("#327 part 5: a SINGLE-install host still gets an inventory — `clear` enu
   const result = await runDoctor({
     mockPlatform: "linux", skipNetwork: false,
     mockVersion: "v3.29.2", mockLatest: "v3.29.2",
+    // Carried over from the part-5 test above rather than left implicit (#438 review). With
+    // `skipNetwork: false` this is what keeps the run off the wire: the mocked body is read by the
+    // health check AND by the oauth check via classifyAuthOk, so without it this test would issue a
+    // real request to the documented default port — the LIVE production proxy on the host running
+    // the suite. `mockLatest` closes the other live surface (it skips the git fetch), and the `run`
+    // mock below THROWS on any unexpected command, so a newly-added probe fails loudly here instead
+    // of silently reading the host.
     mockHealth: { status: 200, body: { version: "3.29.2", auth: { ok: true } } },
     run: (cmd) => {
       if (cmd.includes("--user list-unit-files")) return "ocp.service enabled";

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -26181,6 +26181,34 @@ test("#327 part 5: runDoctor's --json result carries the structured per-host uni
   assert.strictEqual(byName["ocp.service"].instanceName, null, "an absent directive is null");
 });
 
+// #425 review finding 1: the CLEAR-state inventory carry (scripts/doctor.mjs, groupAndAssessConflicts'
+// `units.length < 2` return) was unpinned. The reviewer measured it: reverting that return to
+// `{ state: "clear" }` left the suite at 1239/0. It matters because a single-install host is the
+// MOST COMMON shape, so this is the branch most consumers of `--json`.units actually hit, and part
+// 4's report is built from that field. The fix the reviewer named is one assertion; this is it.
+test("#327 part 5: a SINGLE-install host still gets an inventory — `clear` enumerated successfully, so units is [that unit], never null", async () => {
+  const result = await runDoctor({
+    mockPlatform: "linux", skipNetwork: false,
+    mockVersion: "v3.29.2", mockLatest: "v3.29.2",
+    mockHealth: { status: 200, body: { version: "3.29.2", auth: { ok: true } } },
+    run: (cmd) => {
+      if (cmd.includes("--user list-unit-files")) return "ocp.service enabled";
+      if (cmd.includes("list-unit-files")) return ""; // system scope: nothing enabled -> ONE unit total
+      if (cmd.includes("systemctl --user show")) return unitShow({ id: "ocp.service", port: 3456 });
+      throw new Error("unexpected cmd: " + cmd);
+    },
+  });
+  // Premise, stated as its own assertion rather than assumed: this fixture must actually reach the
+  // CLEAR branch. `warn`/`declared` also carry units, so a fixture that drifted into one of those
+  // would satisfy everything below while testing a different branch entirely.
+  assert.ok(!result.checks.some(c => c.id === "multi_unit_boot_race"),
+    "premise: one enabled unit must reach the `clear` branch, which pushes no multi_unit check");
+  assert.ok(Array.isArray(result.units),
+    `a host with one enabled unit ENUMERATED fine — null would say "could not enumerate", which is a different and false statement; got ${JSON.stringify(result.units)}`);
+  assert.equal(result.units.length, 1, "the one enabled unit must be in the inventory");
+  assert.equal(result.units[0].name, "ocp.service", "and it must be that unit, not a placeholder");
+});
+
 
 test("#327 part 4: a multi-instance host's plan reports each sibling with its own update command", async () => {
   const result = await runUpgrade({
@@ -26200,11 +26228,91 @@ test("#327 part 4: a multi-instance host's plan reports each sibling with its ow
   assert.equal(result.executed, false, "dry-run premise: nothing may execute");
   const report = result.plan.filter((l) => l.includes("[multi-instance]"));
   assert.equal(report.length, 2, `each sibling gets its own report line; got ${JSON.stringify(report)}`);
+  // "tree unknown" WITHOUT the parentheses, and MOVED AHEAD of the two positives below.
+  //
+  // The parenthesised form this line used to grep for — `(tree unknown)` — stopped being producible
+  // when the review's F1 fix landed in 7ab0ced: the fallback branch was rewritten to emit
+  // "— tree unknown, update it from its own install tree" precisely so no `(cd (tree unknown) && …)`
+  // paste trap could be printed. The guard was not updated with it, so from that commit until this
+  // one it forbade a string no branch could emit — green for the same reason an unexecuted
+  // assertion is green. Verified before changing it: `grep -rn '(tree unknown)' scripts/ ocp
+  // server.mjs lib/` matches ONLY a comment in scripts/upgrade.mjs.
+  //
+  // The move is not tidying. The mutation that reaches this guard is inverting the branch condition
+  // (`if (u.workingTree)` -> `if (!u.workingTree)`), which sends BOTH fixture units down the
+  // fallback — and that also empties the `(cd …)` line the third assertion below looks for. Behind
+  // that assertion this guard would never execute, so it would be exactly as unprovable as the
+  // parenthesised version it replaces, and for a second, independent reason. AGENTS.md's ordering
+  // remedy for the asymmetric case.
+  assert.ok(!report.some((l) => l.includes("tree unknown")), "workingTree is in the record; an unknown tree would be a regression");
   assert.ok(report.some((l) => l.includes("ocp-wifibot.service") && l.includes("(instance \"wifibot\")")),
     "the sibling's declared identity must be named, not conflated with the primary");
   assert.ok(report.some((l) => l.includes("(cd /opt/ocp-wifibot && ./ocp update)")),
     "the sibling's OWN tree and update command must be printed — report, never cross-identity act");
-  assert.ok(!report.some((l) => l.includes("(tree unknown)")), "workingTree is in the record; an unknown tree would be a regression");
+});
+
+// #426 review finding 1: the `instanceName === ""` arm of the label ternary was unpinned — the
+// part-4 fixture drives a `null` unit and a NAMED unit, so nothing ever rendered "primary" and a
+// mutation garbling only that arm stayed green. The three arms are three DIFFERENT statements about
+// a host ("nothing was declared" / "declared itself the primary" / "declared this name"), which is
+// why the review asked for the empty-string one rather than treating it as cosmetic: conflating an
+// undeclared unit with one that explicitly claims the primary is the exact confusion #327 exists to
+// remove.
+test("#327 part 4: an instance that declared itself the PRIMARY (OCP_INSTANCE_NAME=\"\") is labelled `primary`, not conflated with an undeclared one", async () => {
+  const result = await runUpgrade({
+    // skipNetwork is not optional here: without it the sibling probe issues a real GET /health at
+    // each unit's port, and this fixture's 3456 is the documented default — the LIVE proxy on the
+    // host running the suite (#430 review F1).
+    dryRun: true, yes: true, skipNetwork: true,
+    mockDoctor: {
+      ready_to_upgrade: true, next_action: { kind: "upgrade" },
+      current_version: "v3.29.1", latest_version: "v3.29.2",
+      units: [
+        { name: "ocp.service", port: 3456, instanceName: "", workingTree: "/home/opc/ocp" },
+        { name: "ocp-wifibot.service", port: 3457, instanceName: "wifibot", workingTree: "/opt/ocp-wifibot" },
+      ],
+    },
+  });
+  assert.equal(result.executed, false, "dry-run premise: nothing may execute");
+  const report = result.plan.filter((l) => l.includes("[multi-instance]"));
+  assert.equal(report.length, 2, `premise: both units must be reported; got ${JSON.stringify(report)}`);
+  const primary = report.find((l) => l.includes("ocp.service (")) || "";
+  assert.ok(primary.includes("(primary)"),
+    `a unit that declared OCP_INSTANCE_NAME="" claims the primary and must be labelled so; got ${JSON.stringify(primary)}`);
+  assert.ok(!primary.includes("no OCP_INSTANCE_NAME declared"),
+    "an explicit empty declaration is NOT an absent one — that conflation is the thing #327 removes");
+});
+
+// #426 review finding 2: the unknown-tree fallback was pinned only by ABSENCE — the part-4 fixture
+// gives every unit a workingTree, so the branch never ran and a mutation to its wording, or its
+// deletion, stayed green. Its content is the point rather than decoration: F1 rewrote it
+// specifically so that a unit with no known tree gets NO paste-able command, because
+// `(cd (tree unknown) && ./ocp update)` is a line an operator can paste and have do something
+// wrong. That is what this asserts.
+test("#327 part 4: a unit with NO known workingTree is reported with a name and no paste-able command", async () => {
+  const result = await runUpgrade({
+    dryRun: true, yes: true, skipNetwork: true,
+    mockDoctor: {
+      ready_to_upgrade: true, next_action: { kind: "upgrade" },
+      current_version: "v3.29.1", latest_version: "v3.29.2",
+      units: [
+        { name: "ocp.service", port: 3456, instanceName: null, workingTree: "/home/opc/ocp" },
+        // The reachable shape, not a contrivance: a unit whose ExecStart is a bare `server.mjs`
+        // parses to an empty workingTree on both the systemd and the launchd path.
+        { name: "ocp-wifibot.service", port: 3457, instanceName: "wifibot", workingTree: "" },
+      ],
+    },
+  });
+  assert.equal(result.executed, false, "dry-run premise: nothing may execute");
+  const report = result.plan.filter((l) => l.includes("[multi-instance]"));
+  assert.equal(report.length, 2, `premise: both units must be reported; got ${JSON.stringify(report)}`);
+  const orphan = report.find((l) => l.includes("ocp-wifibot.service")) || "";
+  assert.ok(orphan.includes("tree unknown"),
+    `a unit whose tree could not be resolved must say so; got ${JSON.stringify(orphan)}`);
+  assert.ok(orphan.includes("(instance \"wifibot\")"),
+    "and it must still be identified — an unknown tree is not an unknown instance");
+  assert.ok(!orphan.includes("cd "),
+    `no paste-able cd command may be printed for a unit whose tree is unknown; got ${JSON.stringify(orphan)}`);
 });
 
 console.log("\n#327 part 6 — doctor.mjs unit records carry a `user` field:");


### PR DESCRIPTION
# Pull Request

## Summary

Pins the three claims #327's parts 4 and 5 shipped **unpinned**, and repairs a fourth guard that had
gone **vacuous** without anyone noticing. Test-only: no production file changes.

| claim | recorded as | why it survived |
|---|---|---|
| a **single-install host still gets an inventory** (`groupAndAssessConflicts`' `clear` return carries `units`) | #425 audit finding 1, measured as `m327d`: reverting `{ state: "clear", units }` → `{ state: "clear" }` left the suite **1239/0** | no test drove `runDoctor` into `clear` and then read `.units` |
| `instanceName === ""` renders **`primary`** | #426 audit finding 1 | the part-4 fixture has one `null` unit and one **named** unit; the third arm never ran |
| the **unknown-tree fallback**'s content | #426 audit finding 2 — *"pinned only by absence"* | every fixture unit had a `workingTree`, so the branch never ran |

The `clear`-state one is the one worth stating plainly: **a single-install host is the most common
shape**, so it is the branch most `--json` consumers actually hit, and part 4's sibling report is
built from that field.

**Fold-in (§11.1): the part-4 test's `(tree unknown)` guard could no longer fail — and, corrected by
the #438 review, it never could.**

The guard greps for the **parenthesised** form, which no branch emits: the fallback says
`— tree unknown, update it from its own install tree`, worded that way **precisely so** no
`(cd (tree unknown) && …)` paste trap could be printed. Verified:
`grep -rn '(tree unknown)' scripts/ ocp server.mjs lib/` matches **only a comment** in
`scripts/upgrade.mjs`.

My first version of this paragraph blamed a drift window — "from `7ab0ced` until this PR" — and
**that window does not exist.** The reviewer checked the ancestry and I reproduced it:

```
git merge-base --is-ancestor 7ab0ced origin/main   -> exit 1   (NOT an ancestor: a branch commit)
git log --oneline origin/main -S'(tree unknown)' -- test-features.mjs   -> b7266ef   (only commit)
git show b7266ef -- scripts/upgrade.mjs | grep 'tree unknown'
    +  plan.push(`… — tree unknown, update it from its own install tree`)      # non-parenthesised
git show b7266ef -- test-features.mjs  | grep 'tree unknown'
    +  assert.ok(!report.some((l) => l.includes("(tree unknown)")), …)          # parenthesised
```

`7ab0ced` was a branch commit; what landed on `main` is the **squash `b7266ef`**, and that single
commit carries **both** the non-parenthesised emit and the parenthesised guard. So **on `main` the
guard arrived dead. It was never live for one commit**, and the correction is in the direction that
makes this worse, not better.

The sharpest form of it: **#426's reviewer looked straight at this line and described it as
"exercising the known-tree branch" — it was already dead when they wrote that.** A guard that is
vacuous from birth *and* reads as coverage to a reviewer inspecting it directly is the strongest
instance of this class the repo has, and my first draft undersold it by inventing a window in which
it had once worked.

Folded rather than split, against all three of §11.1's conditions: the fix is one string plus a
reordering; it was found **by this PR's own stated job** (pinning that exact fallback — a gate that
finds a defect and defers it declares itself advisory); and the diff stays readable. It crosses
neither severity nor citation class.

**The guard is also moved ahead of the two positive assertions, and that is not tidying.** The
mutation that reaches it (**MB4**, inverting `if (u.workingTree)`) sends both fixture units down the
fallback, which *also* empties the `(cd …)` line the third assertion looks for. Behind that
assertion the repaired guard would never execute — exactly as unprovable as the parenthesised
version it replaces, for a second and independent reason. `AGENTS.md`'s ordering remedy for the
asymmetric case. Measured, both ways: see MB4 / MB4b below.

No user-visible change.

## Grouping (Iron Rule 11 / §11.1) — why this is one PR of three

The five recorded follow-ups are all the same **severity** (an unpinned claim) and the same
**citation class** (not endpoint-touching), so §11.1's two absolute bars are clear and the only
question is whether a reviewer can follow the diff. The line drawn is **one upstream issue per PR**,
because that is what a reviewer has to open:

- **#416/#423** — the suite lock. Harness infrastructure; two-process contender tests.
- **this PR — #327 parts 4 + 5.** One issue, and a **review dependency** — corrected from
  "producer/consumer pair", which the #438 review showed overstates it. There is no *runtime*
  dependency between these tests: the part-4 tests drive `runUpgrade` with a `mockDoctor` fixture
  and never execute `doctor.mjs` at all. What the pairing actually buys is that **judging whether
  those fixtures are honest requires opening `doctor.mjs`** — `workingTree: ""` and
  `instanceName: ""` are only worth pinning if the producer can really emit them, which is a
  question about the other half. Splitting would put the fixture in one PR and its justification in
  another. That is a real reason and a weaker one than I first claimed.
- **#374** — the mem snapshot's wiring. Different subject, different reference, and a sibling agent
  is working in that area.

§11.1 authorises folding only when a defect *"was found by **this** PR's stated job"*. That holds
for the vacuous guard above and for nothing else here.

## Endpoint Class (REQUIRED)

- [x] **Not endpoint-touching** — the whole diff is `test-features.mjs`. Verified:
  `git diff origin/main -- server.mjs lib/ keys.mjs` → **0 lines**;
  `git diff --stat origin/main` → `test-features.mjs | 116 insertions(+), 1 deletion(-)`, one file.
  Note this PR touches **no** `scripts/` file either: both #425's and #426's production fixes
  already landed (`eac9953`, `b7266ef`); what was missing was the tests.

## Type of change

- [x] Refactor (no wire-level behavior change) — test-only.

## Mutation table — every added or changed test, in #218's format

Baseline and every mutation run under the machine-wide guard, targeted via
`--only '#327 part 5,#327 part 4'`, **exit code checked on every run** (#434). Every mutation is a
**whole-line** replacement with an **asserted match count of exactly 1** and the hunk printed before
the run. Restores are from a **file backup** with `cmp`, never `git checkout -- <file>`.

| tag | mutation (file, whole line, count asserted = 1) | before | after | attributable red |
|---|---|---|---|---|
| — | baseline | — | **5 passed / 0 failed** (exit 0) | — |
| **MB1** | `scripts/doctor.mjs` — the reviewer's own `m327d`: `{ state: "clear", units }` → `{ state: "clear" }` | 5/0 | **4/1** (exit 1) | `#327 part 5: a SINGLE-install host still gets an inventory…` — *"got undefined"* |
| **MB2** | `scripts/upgrade.mjs` — the `""` arm conflated with the `null` arm (`"primary"` → `"no OCP_INSTANCE_NAME declared"`) | 5/0 | **4/1** (exit 1) | `#327 part 4: an instance that declared itself the PRIMARY…` — got `ocp.service (no OCP_INSTANCE_NAME declared)` |
| **MB3** | `scripts/upgrade.mjs` — the fallback restores F1's paste trap: `at (tree unknown) … (cd (tree unknown) && ./ocp update)` | 5/0 | **4/1** (exit 1) | `#327 part 4: a unit with NO known workingTree…` — *"no paste-able cd command may be printed"* |
| **MB4** | `scripts/upgrade.mjs` — invert the branch: `if (u.workingTree) {` → `if (!u.workingTree) {` | 5/0 | **3/2** (exit 1) | `#327 part 4: a multi-instance host's plan…` **at the repaired guard** (*"workingTree is in the record; an unknown tree would be a regression"*) **and** `#327 part 4: a unit with NO known workingTree…` |

**Every figure in that table is under `--only '#327 part 5,#327 part 4'` — five tests, so a row's
`passed + failed` is always 5.** Stating the filter because the first version of this table did not,
and got it wrong as a direct result: see below.

### Corrected: the MB4b row mixed two baselines (#438 review, blocking)

It was printed as `5/0 → 1/2`. Under a five-test filter `1 + 2 = 3`, so the row could not be what it
said — the reviewer found the cause, and it was mine: the `1/2` was measured under
`--only '#327 part 4'` (three tests, own baseline 3/0) while the `5/0` beside it came from the
two-filter baseline. **Re-measured under the table's own filter, MB4b is `3/2`, exactly like MB4.**

That matters rather than being a typo. As printed it implied MB4b was *more destructive* than MB4 —
the precise opposite of the point the row exists to make. **Both are 3/2; the only thing that
changes is which assertion reports.**

### The 2×2 the reviewer asked for, and it strengthens the case

My MB4b varied **two things at once** — the guard's string *and* its position — so it could not say
which change earned its place. The reviewer ran the missing cells; I reproduced all four
independently, MB4 held fixed in `scripts/upgrade.mjs`, each cell built by moving exactly one line
with **both anchors established by index** before any splice and the file line-count asserted
unchanged:

| variant | guard string | guard position | result | which assertion reports |
|---|---|---|---|---|
| **SHIPPED** | `tree unknown` | early | 3/2 | **the guard** — *"workingTree is in the record…"* |
| MB4d | `tree unknown` | late | 3/2 | the sibling's-own-tree assertion |
| MB4c | `(tree unknown)` | early | 3/2 | the sibling's-own-tree assertion |
| MB4b | `(tree unknown)` | late | 3/2 | the sibling's-own-tree assertion |

**All four are 3/2, and only the shipped combination makes the guard speak — so the string fix and
the reorder are each independently necessary.** That is a 2×2 rather than an anecdote, and it is a
better argument than the one I shipped. Credit to the #438 reviewer for constructing it.

Note what every cell also shows: the pre-existing test goes red under MB4 regardless, so the
vacuous guard was never the only thing standing there. What it was not doing was **its own job** —
a reader of the failure would have been sent to the wrong line.

No unattributable red appeared in any run.

## One more thing carried over from the review (comment only)

The new part-5 test dropped its sibling's comment explaining why `mockHealth` is load-bearing. It is
back, and worded from what the reviewer verified rather than from what I assumed: with
`skipNetwork: false`, the mocked body is read by the health check **and** by the oauth check via
`classifyAuthOk`, so an unmocked run here would issue a real request to the documented default port
— the **live production proxy on the host running the suite**. `mockLatest` closes the git fetch and
the `run` mock throws on any unexpected command. Comment-only; the executable diff is unchanged.

## Suite numbers, each against the SHA it was measured on

- Base **`7f13a13`** (`origin/main`): **1273 passed / 0 failed**.
- This branch **`8c63b1a`**: **1276 passed / 0 failed**, 2 skipped.
- Delta **+3**, re-checkable from the diff rather than from a total:
  `git diff origin/main...HEAD -- test-features.mjs | grep -cE '^\+(test|ltTest)\('` → **3**, none removed.

Full suite is the gate; the `--only` runs above are the mutation campaign, not the verdict.

## Related

- `ALIGNMENT.md` Rule(s) invoked: none — not endpoint-touching.
- Related issue / prior PR: #327 (closed; these are its recorded audit findings), #425, #426, #434.

### User-visible change self-check (铁律第五律 5.3)

- [x] This PR has no user-visible changes → "no user-visible change" stated in Summary.

### Privacy self-check (for PUBLIC repos)

- [x] No real names, nicknames or handles.
- [x] No literal personal paths. The fixture trees `/home/opc/ocp` and `/opt/ocp-wifibot` are copied
      verbatim from the pre-existing part-4 fixture; `opc` is the Oracle Linux default account, not
      a person.
- [x] No personal machine hostnames.
- [x] No personal email addresses.

## Reviewer — independent review REQUIRED (Iron Rule 10)

**I am the author and cannot approve this.** A fresh-context reviewer is required. Specifically
worth checking:

1. **Confirm the class yourself** against `ALIGNMENT.md` rather than taking the diffstat's word —
   "not endpoint-touching" is the cheapest class to declare.
2. **The vacuous-guard claim.** It is falsifiable in one command:
   `grep -rn '(tree unknown)' scripts/ ocp server.mjs lib/`. If that finds an emitting site, the
   fold-in is wrong and should be reverted.
3. **The `clear`-branch premise.** The new part-5 test asserts *"no `multi_unit_boot_race` check
   pushed"* before anything else, because `warn` and `declared` also carry `units` — a fixture that
   drifted into either would satisfy every later assertion while testing a different branch.
4. **MB4 vs MB4b.** These two rows are the argument for the reorder; if you disagree that the guard
   needs to precede the positives, that is the place to say so.

## Second measurement, on the other platform (CI, ubuntu-latest)

| where | base | this branch | delta |
|---|---|---|---|
| workstation, darwin | `7f13a13` → **1273 / 0**, 2 skips | `8c63b1a` → **1276 / 0**, 2 skips | **+3** |
| CI, ubuntu-latest | `main` → **1272 / 0**, 3 skips | this PR → **1275 / 0**, 3 skips | **+3** |

Same delta on both, skip count unchanged. The absolute totals differ between platforms by design.
