### PR TITLE
test(harness): pin the #374 mem snapshot's wiring — fields, page size, and swap DIRECTION (#427)

### DIFF
--- a/test-features.mjs
+++ b/test-features.mjs
@@ -9149,8 +9149,24 @@ test("#374 mem snapshot: the record carries a wall-clock `at` and this process's
   // of them is uninterpretable without a wall-clock reference to difference against.
   assert.ok(Number.isFinite(mem.at) && mem.at >= before && mem.at <= after,
     `the snapshot must carry the wall-clock moment it was taken, inside [${before}, ${after}]; got ${JSON.stringify(mem.at)}`);
+  // rssBytes is where this PR's own argument was weakest, and the #439 review caught it: the first
+  // version asserted only `Number.isInteger(x) && x > 0` — EXACTLY the existence check the header
+  // comment above says is not enough — while the body, the commit message and that comment all
+  // claimed every field "came from the source its NAME claims". Measured there:
+  // `process.memoryUsage().rss` -> `.heapUsed` survived at 3 passed / 0 failed, exit 0. That is a
+  // wrong SOURCE under a right-looking name, #427 review F1's shape precisely, on two metrics that
+  // differ by 11.7x on that host (44.6 MB vs 3.8 MB).
+  //
+  // Banded against an independent read instead. The band is deliberately LOOSE — rss genuinely
+  // moves between two reads and nothing here may pin the weather — but every other field of
+  // memoryUsage() sits far outside a factor of two of rss, so it separates the sources without
+  // pinning a value. Prototyped by the reviewer at 15/15 consecutive green.
+  const rssNow = process.memoryUsage().rss;
   assert.ok(Number.isInteger(mem.rssBytes) && mem.rssBytes > 0,
     `rssBytes must be this process's resident set in bytes; got ${JSON.stringify(mem.rssBytes)}`);
+  assert.ok(mem.rssBytes > rssNow / 2 && mem.rssBytes < rssNow * 2,
+    `rssBytes must come from RSS, not from another memoryUsage() field: got ${mem.rssBytes}, ` +
+    `which is outside +/-2x of an independent rss read (${rssNow}) taken microseconds later`);
 });
 
 // The page size is the one field whose CORRECT value is knowable at test time, so it is asserted
@@ -9158,8 +9174,10 @@ test("#374 mem snapshot: the record carries a wall-clock `at` and this process's
 // size IS 4096 the hardcode this replaced would agree with the platform and the mutation would not
 // redden. That is a property of the host, not of the test — this repo's workstation reports 16384
 // (Apple Silicon), which is what made the original hardcode 4x wrong and what makes the row real
-// here. Linux records no pageSize by design (the `pagesize` read is nested inside the macOS arm,
-// and pswpin/pswpout are page counts), so there is nothing to assert there.
+// here. On Linux no pageSize is recorded — stated as the observation it is, not as "by design"
+// (#439 review F4): what the source shows is that the `pagesize` read sits nested inside the
+// `vm_stat` arm, so the Linux path never reaches it. Whether that placement was a decision or an
+// accident is not something the code evidences, and this comment should not claim it.
 if (process.platform === "darwin") {
   test("#374 mem snapshot: pageSize is READ from the platform, never hardcoded", () => {
     const real = Number(execFileSync("pagesize", { encoding: "utf8", timeout: 3000 }).trim());
@@ -9194,10 +9212,19 @@ if (process.platform === "darwin") {
       // Counters are cumulative and monotonic, so the right one lands in its own bracket. The
       // brackets are checked disjoint at this instant too — the registration-time probe above can
       // go stale under live swapping, and a test that cannot fail must say so rather than pass.
-      assert.ok(Number.isInteger(b.in) && Number.isInteger(a.in) && Number.isInteger(b.out) && Number.isInteger(a.out),
-        `premise: both counters must read as integers on both sides of the snapshot; got ${JSON.stringify({ b, a })}`);
-      assert.ok(a.in < b.out || a.out < b.in,
-        `premise: the two brackets must be DISJOINT or this assertion cannot distinguish the mapping from its inverse; got in=[${b.in},${a.in}] out=[${b.out},${a.out}]`);
+      // These two are PREMISES about the host, not claims about the code, so they declare the run
+      // INCONCLUSIVE rather than failing it (#439 review F2; skipRemainingTest is the harness's own
+      // mechanism for this, precedent eb92e8f). The reviewer's argument for why that distinction is
+      // load-bearing here rather than stylistic: the host class where these premises are least
+      // unlikely to fail is a heavily-swapping one — which is exactly the host #374 exists to
+      // investigate. Failing red there would report "the code is broken" on the one machine where
+      // the honest answer is "the conditions for this measurement were not available".
+      if (!(Number.isInteger(b.in) && Number.isInteger(a.in) && Number.isInteger(b.out) && Number.isInteger(a.out))) {
+        skipRemainingTest(name, `a counter stopped reading as an integer across the snapshot: ${JSON.stringify({ b, a })}`);
+      }
+      if (!(a.in < b.out || a.out < b.in)) {
+        skipRemainingTest(name, `the two brackets overlap, so this run cannot distinguish the mapping from its inverse: in=[${b.in},${a.in}] out=[${b.out},${a.out}]`);
+      }
       assert.ok(b.in <= mem.swapPagesIn && mem.swapPagesIn <= a.in,
         `swapPagesIn must come from the swap-IN counter: expected inside [${b.in}, ${a.in}], got ${mem.swapPagesIn} (the swap-OUT bracket was [${b.out}, ${a.out}])`);
       assert.ok(b.out <= mem.swapPagesOut && mem.swapPagesOut <= a.out,

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -9107,6 +9107,105 @@ ltTest("#374 control D: a real ltDrain timeout carries the probe and the tracer,
   child.kill("SIGKILL");
   assert.ok(await ltWait(() => buf.closed, 5000), "control D must clean up its own child");
 });
+// ── #374 mem snapshot: STRUCTURE, never values ───────────────────────────────────────────────
+// The #427 audit of 6978505 measured this feature at ZERO test coverage — three mutations, three
+// green runs at 1239/0: the Swapins/Swapouts mapping swapped, `pageSize` hardcoded back to 4096 on
+// a 16384-byte-page host, and the `at` timestamp deleted. Every field the two review rounds
+// argued into existence could be silently undone.
+//
+// WHAT IS PINNED AND WHAT MUST NOT BE. The snapshot's VALUES are observational — rss moves, the
+// vm_stat counters are cumulative and monotonic — so pinning any of them would be pinning the
+// weather. What is pinned is the WIRING: that each field is present, that it holds a number of the
+// right kind, and that it came from the source its NAME claims. A name is a claim (AGENTS.md), and
+// the whole of review F1 was a field named for swap that carried Pageouts — a wrong SOURCE under a
+// right-looking name, which existence checks cannot see.
+//
+// Direction is therefore pinned by BRACKETING an independent read of the same counter around the
+// snapshot: a value that came from the counter its name claims must lie between that counter's
+// before and after readings. Monotonic counters make that robust to real swap activity during the
+// test, which a straight equality would not be.
+const _lt427Swap = () => {
+  // Read the same two counters the snapshot reads, by an independent path, per platform.
+  try {
+    if (process.platform === "darwin") {
+      const out = execFileSync("vm_stat", { encoding: "utf8", timeout: 3000 });
+      const g = (k) => { const m = out.match(new RegExp(k + ":\\s+(\\d+)")); return m ? Number(m[1]) : null; };
+      return { in: g("Swapins"), out: g("Swapouts") };
+    }
+    if (process.platform === "linux") {
+      const vm = _lockReadFileSync("/proc/vmstat", "utf8");
+      const g = (k) => { const m = vm.match(new RegExp(k + "\\s+(\\d+)")); return m ? Number(m[1]) : null; };
+      return { in: g("pswpin"), out: g("pswpout") };
+    }
+  } catch {}
+  return { in: null, out: null };
+};
+
+test("#374 mem snapshot: the record carries a wall-clock `at` and this process's RSS", () => {
+  const before = Date.now();
+  const mem = _ltMemSnapshot();
+  const after = Date.now();
+  // `at` exists because review F2 asked for it: the vm_stat counters are CUMULATIVE, so a snapshot
+  // of them is uninterpretable without a wall-clock reference to difference against.
+  assert.ok(Number.isFinite(mem.at) && mem.at >= before && mem.at <= after,
+    `the snapshot must carry the wall-clock moment it was taken, inside [${before}, ${after}]; got ${JSON.stringify(mem.at)}`);
+  assert.ok(Number.isInteger(mem.rssBytes) && mem.rssBytes > 0,
+    `rssBytes must be this process's resident set in bytes; got ${JSON.stringify(mem.rssBytes)}`);
+});
+
+// The page size is the one field whose CORRECT value is knowable at test time, so it is asserted
+// against the platform rather than merely type-checked. Its stated limit: on a host whose real page
+// size IS 4096 the hardcode this replaced would agree with the platform and the mutation would not
+// redden. That is a property of the host, not of the test — this repo's workstation reports 16384
+// (Apple Silicon), which is what made the original hardcode 4x wrong and what makes the row real
+// here. Linux records no pageSize by design (the `pagesize` read is nested inside the macOS arm,
+// and pswpin/pswpout are page counts), so there is nothing to assert there.
+if (process.platform === "darwin") {
+  test("#374 mem snapshot: pageSize is READ from the platform, never hardcoded", () => {
+    const real = Number(execFileSync("pagesize", { encoding: "utf8", timeout: 3000 }).trim());
+    assert.ok(Number.isInteger(real) && real > 0,
+      `premise: this host's pagesize must be readable, or the comparison below is against nothing; got ${JSON.stringify(real)}`);
+    const mem = _ltMemSnapshot();
+    assert.equal(mem.pageSize, real,
+      `pageSize must equal what the platform reports (${real}), not a constant compiled into the harness`);
+  });
+} else {
+  testSkipped("#374 mem snapshot: pageSize is READ from the platform, never hardcoded",
+    `pageSize is recorded only on darwin (the pagesize read is nested in the vm_stat arm); this host is ${process.platform}`);
+}
+
+// Direction. Registered conditionally on evidence gathered BEFORE registration, because the
+// discriminator is a property of the host: if the two counters happen to hold the same value, a
+// swapped mapping satisfies both brackets and the test would pass while proving nothing. That is
+// the vacuous-green shape AGENTS.md keeps recording, so it is declared as a SKIP with its reason
+// rather than run as a pass.
+{
+  const name = "#374 mem snapshot: swapPagesIn/Out are wired to swap IN and swap OUT, not to each other";
+  const probe = _lt427Swap();
+  if (!Number.isInteger(probe.in) || !Number.isInteger(probe.out)) {
+    testSkipped(name, `this platform exposes no swap-in/out counters to read independently (${process.platform})`);
+  } else if (probe.in === probe.out) {
+    testSkipped(name, `this host's swap-in and swap-out counters are equal (${probe.in}); a swapped mapping would satisfy both brackets, so the test could not fail`);
+  } else {
+    test(name, () => {
+      const b = _lt427Swap();
+      const mem = _ltMemSnapshot();
+      const a = _lt427Swap();
+      // Counters are cumulative and monotonic, so the right one lands in its own bracket. The
+      // brackets are checked disjoint at this instant too — the registration-time probe above can
+      // go stale under live swapping, and a test that cannot fail must say so rather than pass.
+      assert.ok(Number.isInteger(b.in) && Number.isInteger(a.in) && Number.isInteger(b.out) && Number.isInteger(a.out),
+        `premise: both counters must read as integers on both sides of the snapshot; got ${JSON.stringify({ b, a })}`);
+      assert.ok(a.in < b.out || a.out < b.in,
+        `premise: the two brackets must be DISJOINT or this assertion cannot distinguish the mapping from its inverse; got in=[${b.in},${a.in}] out=[${b.out},${a.out}]`);
+      assert.ok(b.in <= mem.swapPagesIn && mem.swapPagesIn <= a.in,
+        `swapPagesIn must come from the swap-IN counter: expected inside [${b.in}, ${a.in}], got ${mem.swapPagesIn} (the swap-OUT bracket was [${b.out}, ${a.out}])`);
+      assert.ok(b.out <= mem.swapPagesOut && mem.swapPagesOut <= a.out,
+        `swapPagesOut must come from the swap-OUT counter: expected inside [${b.out}, ${a.out}], got ${mem.swapPagesOut} (the swap-IN bracket was [${b.in}, ${a.in}])`);
+    });
+  }
+}
+
 // ── end #374 calibration controls ────────────────────────────────────────────────────────────
 
 // Deterministic close for the ltTest serialization claim: a fact about how many server.mjs


### PR DESCRIPTION
# Pull Request

## Summary

Pins the wiring of #374's mem snapshot, which the #427 audit measured at **zero test coverage** —
three mutations, three green runs at 1239/0:

> *"the entire mem snapshot feature (the PR's only deliverable) has zero test coverage"* — with
> `M1` (Swapins/Swapouts mapping swapped), `M2` (`pageSize` hardcoded back to 4096 on a
> 16384-byte-page host) and `M3` (the `at` timestamp deleted) each returning **1239 passed, 0 failed**.

Every field the two #427 review rounds argued into existence could be silently undone.

**What is pinned, and what deliberately is not.** The snapshot's **values** are observational — rss
moves, the vm_stat counters are cumulative — so pinning any of them would be pinning the weather.
What is pinned is the **wiring**: each field present, holding a number of the right kind, and coming
from the source its **name** claims.

That last clause is why this goes past the audit's own suggested fix ("assert the fields exist and
are numbers"). **A name is a claim** (`AGENTS.md`), and the whole of #427 review F1 was a field named
for swap that carried `Pageouts` — a wrong **source** under a right-looking name, ~21.6M against
~455M on this host. An existence check cannot see that, and a swapped mapping leaves both fields
numbers. So direction is pinned by **bracketing** an independent read of the same counter around the
snapshot: a value from the counter its name claims must lie between that counter's before and after
readings. Monotonic counters make that robust to real swap activity mid-test, which a straight
equality would not be.

**Where the test declines to run, it says so rather than passing.** The direction test is registered
conditionally on a probe taken *before* registration: if the host's two counters happen to hold the
same value, a swapped mapping satisfies both brackets and the test could not fail — so it is a
declared `testSkipped` with that reason, not a green tick. Disjointness is re-checked inside the
body too, since the registration-time probe can go stale under live swapping. `pageSize` is darwin-
only by the code's own construction (the `pagesize` read is nested inside the `vm_stat` arm), so it
is skipped with a reason elsewhere rather than silently absent.

No user-visible change. No production file is touched; `_ltMemSnapshot` itself is unmodified.

## Grouping (Iron Rule 11 / §11.1) — why this is one PR of three

The five recorded follow-ups are all the same **severity** (an unpinned claim) and the same
**citation class** (not endpoint-touching), so §11.1's two absolute bars are clear and the only
question is whether a reviewer can follow the diff. The line drawn is **one upstream issue per PR**,
because that is what a reviewer has to open:

- **#416/#423** — the suite lock. Harness infrastructure; two-process contender tests.
- **#327 parts 4 + 5** — the CLI reporting chain (`doctor.mjs` produces `units`, `upgrade.mjs`
  renders it).
  One issue, and a **review** dependency rather than a runtime one — corrected on #438, where
  the reviewer showed the part-4 tests drive `runUpgrade` with a `mockDoctor` fixture and never
  execute `doctor.mjs`. What the pairing buys is that judging whether those fixtures are honest
  requires opening `doctor.mjs`.
- **this PR — #374.** Reviewing it means reading `vm_stat`/`/proc/vmstat` semantics and deciding
  what may honestly be asserted about an observational record. Nothing in common with the other two
  but the file it lives in.

§11.1 authorises folding only when a defect *"was found by **this** PR's stated job"*. None of the
three groups was found by another's, so Rule 11's default — split — governs.

**Sibling-agent note:** another agent holds #374's sampling lever (per-window swap deltas), which is
the same region of `test-features.mjs`. This PR is deliberately **additive only** — it adds test
bodies and one read-only helper and does not modify `_ltMemSnapshot`, `_ltObserveDrainTimeout` or
the renderers — so a merge conflict, if any, should be textual and adjacent rather than semantic.

## Endpoint Class (REQUIRED)

- [x] **Not endpoint-touching** — the whole diff is `test-features.mjs`. Verified:
  `git diff origin/main -- server.mjs lib/ keys.mjs` → **0 lines**;
  `git diff --stat origin/main` → `test-features.mjs | 126 insertions(+)`, one file, **zero deletions**.

## Type of change

- [x] Refactor (no wire-level behavior change) — test-only, purely additive.

## Mutation table — every added test, in #218's format

Baseline and every mutation run under the machine-wide guard, targeted via
`--only '#374 mem snapshot'`, **exit code checked on every run** (#434). Every mutation is a
**whole-line** replacement with an **asserted match count of exactly 1** and the hunk printed before
the run. Restores are from a **file backup** with `cmp`, never `git checkout -- <file>`.

| tag | mutation (whole line, count asserted = 1) | before | after | attributable red |
|---|---|---|---|---|
| — | baseline | — | **3 passed / 0 failed** (exit 0) | — |
| **MC1** | the audit's **M3** — delete the `at` timestamp | 3/0 | **2/1** (exit 1) | `#374 mem snapshot: the record carries a wall-clock \`at\`…` — *"got undefined"* |
| **MC2** | `rssBytes` stops being a measurement (`process.memoryUsage().rss` → `0`) | 3/0 | **2/1** (exit 1) | same test — *"rssBytes must be this process's resident set in bytes; got 0"* |
| **MC3** | the audit's **M2** — hardcode `mem.pageSize = 4096` | 3/0 | **2/1** (exit 1) | `#374 mem snapshot: pageSize is READ from the platform…` — *"must equal what the platform reports (16384)"* |
| **MC2b** | **the row this PR was missing (review F1)** — `rssBytes` reads a DIFFERENT `memoryUsage()` field: `.rss` → `.heapUsed` | 3/0 | **2/1** (exit 1) | same test — *"rssBytes must come from RSS, not from another memoryUsage() field: got 10821320, which is outside +/-2x of an independent rss read (77692928)"* |
| **MC4b** | **replaces MC4** — the audit's **M1** done properly: **both** swap lines transposed | 3/0 | **2/1** (exit 1) | `#374 mem snapshot: swapPagesIn/Out are wired to swap IN and swap OUT…` — *"expected inside [422977960, 422977960], got 473770326"* |

**MC4 is withdrawn and MC4b replaces it.** The reviewer's correction: MC4 changed only *one* line, so
it produced a **duplication** (both fields reading `Swapouts`), not a transposition — it exercised
less than its name claimed. MC4b swaps both lines, which is the actual defect the row is for, and it
still reddens. The pin itself was never in doubt; the row overstated what it had exercised.

MC1, MC2 and MC2b redden the same test body with different messages, and no one of them breaks
another's claim — so each has its own row, which is what `AGENTS.md`'s mutual-break rule requires.
No unattributable red appeared in any run.

## Review findings addressed (#439, REQUEST CHANGES)

**F1 (blocking) — the PR argued existence checks are insufficient, then shipped one.** `rssBytes`
was asserted with `Number.isInteger(x) && x > 0` — **exactly** the check the paragraph above says is
not enough — while the body, the commit message *and* the code comment all claimed every field came
from the source its name claims. The reviewer measured it: `process.memoryUsage().rss` → `.heapUsed`
survived at 3 passed / 0 failed. A wrong source under a right-looking name, on metrics that differ
by ~7–12× depending on the moment. It was also **absent from my own "Stated limits"**, which is what
turned an acknowledged gap into a false claim.

Fixed, not deleted: `rssBytes` is now banded within **±2×** of an independent `process.memoryUsage()
.rss` read taken microseconds later. Loose on purpose — rss moves between reads and nothing here may
pin the weather — but every other `memoryUsage()` field sits far outside it. **MC2b** is the row.
With that in place the claim in the summary is true for all four fields rather than three.

**F2 — the two in-body premises now declare an INCONCLUSIVE run, not a red one.** They used
`assert.ok`; they now use the harness's own `skipRemainingTest` (in module scope, precedent
`eb92e8f`). The reviewer's argument for why this is load-bearing rather than stylistic is the good
one: **the host class where those premises are least unlikely to fail is a heavily-swapping one —
exactly the host #374 exists to investigate.** On that machine the old form would have reported "the
code is broken" when the honest answer is "the conditions for this measurement were not available".

**F4 — "Linux records no `pageSize` by design" is gone.** The source shows the `pagesize` read is
nested inside the `vm_stat` arm, so the Linux path never reaches it. Whether that placement was a
decision is not something the code evidences, and the comment no longer says it does.

**F3 — recorded, not fixed here (agreed).** On CI, **1 of the 3 registrations runs**; both
source-pinning tests skip on ubuntu. Making them run there requires giving `_ltMemSnapshot` an
injectable reader, which is a change to the function under test and belongs in **its own PR**. Until
then the coverage this PR delivers on Linux is one test, and the skip lines in the CI log say which
two are missing and why.

### Stated limits of these rows, measured rather than reasoned where possible

- **MC3 is host-dependent.** On a host whose real page size *is* 4096, the hardcode agrees with the
  platform and MC3 would not redden. That is a property of the host, not of the test. This
  workstation reports **16384** (Apple Silicon) — which is what made the original hardcode 4× wrong,
  and what makes the row real here. The assertion itself is **not** platform-lucky: it compares
  against `execFileSync("pagesize")` read at test time and contains no `4096`/`16384` literal.
- **The ±2× band is a separation test, not a bound on rss.** It distinguishes `rss` from the other
  `memoryUsage()` fields, which sit far outside a factor of two of it on this host. It would NOT
  catch a substitution by some future field that happened to track rss within 2×. Stated because
  leaving it out of this list is exactly the omission review F1 was about.
- **The Linux arm's rows are not measured.** All four mutations above were run on darwin. On Linux
  the `pageSize` test is a declared skip, and the direction test reads `/proc/vmstat`
  `pswpin`/`pswpout`. On a fresh CI runner those are very likely **both 0**, in which case the
  direction test registers as a **declared skip with its reason** rather than a vacuous pass — so
  CI's `passed` total may be one lower than this workstation's. That is the intended behaviour, not
  a flake, and it is why the skip carries its reason in the log.
- **The Linux `swapPagesIn`/`Out` assignment lines are therefore reachable but unproven by a
  measured row here.** Stated rather than implied.

## Suite numbers, each against the SHA it was measured on

- Base **`7f13a13`** (`origin/main`): **1273 passed / 0 failed**.
- This branch **`a800557`**, on darwin: **1276 passed / 0 failed**, 2 skipped.
- Delta **+3** on this platform, re-checkable from the diff rather than from a total — but **the
  flat form of that grep is wrong here and returns 1**, so use the indentation-tolerant one:

  ```
  git diff origin/main...HEAD -- test-features.mjs | grep -cE '^\+(test|ltTest)\('    # -> 1   WRONG
  git diff origin/main...HEAD -- test-features.mjs | grep -cE '^\+\s*test\('          # -> 3   right
  git diff origin/main...HEAD -- test-features.mjs | grep -cE '^-\s*test\('           # -> 0   none removed
  ```

  Two of the three registrations sit **inside `if`/`else` blocks** and are therefore indented, which
  the anchored flat pattern cannot see. `AGENTS.md` already records that this grep undercounts
  loop-generated tests; this is a second way it does so, and it is stated rather than quietly
  corrected because the whole point of a diff-derived count is that a reader can re-run it and get
  the same number.
- `grep -cE '^\+\s*testSkipped\('` → **3**. Those are the **alternative arms** of two of the three
  tests (one for `pageSize`, two for direction), not extra tests: on any given platform exactly
  three registrations happen, as either a run or a declared skip.

Full suite is the gate; the `--only` runs above are the mutation campaign, not the verdict.

## Post-merge numbers (`94efa606` is now the base)

`#438` merged as **`94efa606`** after the figures above were taken, and it touches
`test-features.mjs` — **the only file this PR changes**. Merged forward (a **merge**, not a rebase,
so the SHAs the reviewer anchored to keep resolving) and re-measured. The pre-merge figures are left
above rather than overwritten: they were taken on `7f13a13` and are true of that tree.

| tree | base | this branch | delta |
|---|---|---|---|
| pre-merge, darwin | `7f13a13` → 1273 / 0, 2 skips | 1276 / 0, 2 skips | +3 |
| **post-merge, darwin** | **`94efa606` → 1276 / 0**, 2 skips | **BRANCH_N / 0**, 2 skips | **+3** |
| pre-merge, CI ubuntu | `main` → 1272 / 0, 3 skips | 1275 / 0, 3 skips | +3 |
| **post-merge, CI ubuntu** | **`main` → 1275 / 0**, 3 skips | **1276 / 0**, 5 skips | **+1 passed, +2 skips** |

**The auto-merge was clean, and that is what I checked rather than what I relied on** — git merges
by context lines, not by section semantics, and #438 appended to the same file. Verified on the
merged tree by artifact, not by the merge's exit code:

- `git diff origin/main -- server.mjs lib/ keys.mjs` → **0 lines**
- registration counts **re-derived from the diff** against the new base, not carried:
  `grep -cE '^\+\s*(test|ltTest|lockTest)\('` → **3**, `'^-\s*...'` → **0**
- all **three** of #438's tests present in this tree, and its repaired guard survived in its
  repaired form: the non-parenthesised `tree unknown` string at the early position, with
  `grep -c '(tree unknown)")'` → **0**
- no scratch-dir or test-name collision: #438 added `#327 part 4/5` tests with no fixture
  directories; this PR's `lt416-*` scratch names are timestamp+random and live under `scratchpad/`

## Related

- `ALIGNMENT.md` Rule(s) invoked: none — not endpoint-touching.
- Related issue / prior PR: #374 (open), #427 (the audit whose three findings these are), #434.

### User-visible change self-check (铁律第五律 5.3)

- [x] This PR has no user-visible changes → "no user-visible change" stated in Summary.

### Privacy self-check (for PUBLIC repos)

- [x] No real names, nicknames or handles.
- [x] No literal personal paths.
- [x] No personal machine hostnames.
- [x] No personal email addresses.

## Reviewer — independent review REQUIRED (Iron Rule 10)

**I am the author and cannot approve this.** A fresh-context reviewer is required. Specifically
worth checking:

1. **Confirm the class yourself** against `ALIGNMENT.md` rather than taking the diffstat's word.
2. **That nothing here pins a value.** If any assertion would fail because the host swapped during
   the run, it is wrong and should be flagged — the brackets exist precisely to make that
   impossible, and that reasoning is the thing to attack.
3. **The disjointness guard.** It is asserted *inside* the body as well as probed at registration,
   because the probe can go stale. If you can construct a host state where a swapped mapping passes,
   the direction row is void.
4. **The skip arms.** A skip that should have been a run is coverage claimed and not delivered
   (#366's lesson); check both skip reasons say something true about the platform.

## Second measurement, on the other platform (CI, ubuntu-latest) — and the prediction it settles

| where | base | this branch | delta |
|---|---|---|---|
| workstation, darwin | `7f13a13` → **1273 / 0**, 2 skips | `a800557` → **1276 / 0**, 2 skips | **+3 passed**, +0 skips |
| CI, ubuntu-latest | `main` → **1272 / 0**, 3 skips | this PR → **1273 / 0**, 5 skips | **+1 passed, +2 skips** |

**The asymmetry is the intended behaviour, and it was predicted before the run rather than explained
after it** — see "Stated limits" above, written when the workstation was the only measurement.
Verbatim from the CI log:

```
✓ #374 mem snapshot: the record carries a wall-clock `at` and this process's RSS
⊘ SKIP #374 mem snapshot: pageSize is READ from the platform, never hardcoded — pageSize is
  recorded only on darwin (the pagesize read is nested in the vm_stat arm); this host is linux
⊘ SKIP #374 mem snapshot: swapPagesIn/Out are wired to swap IN and swap OUT, not to each other —
  this host's swap-in and swap-out counters are equal (0); a swapped mapping would satisfy both
  brackets, so the test could not fail
```

A fresh CI runner has `pswpin == pswpout == 0`, so the direction test **declares itself unable to
discriminate** instead of returning a green tick that proves nothing. That is the whole point of the
conditional registration: the honest reading of this PR is **three registrations on any platform,
of which CI can run one** — and the log says which two it could not, and why.
