### PR TITLE
chore(release): v3.31.0 — a public DNS name may no longer vouch for itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## v3.31.0 — 2026-08-27
+
+> **Governance audit for this section**, per `CLAUDE.md`'s `release_kit.governance_audits`:
+> **no B.2 key-set change this cycle** — `git diff v3.30.0..HEAD -- docs/governance/b2-response-keys.json`
+> is empty in both profiles, verified with a positive control on a range known to have changed (31 lines)
+> because an empty diff and a command that never ran are the same output. Recorded rather than omitted:
+> a reader cannot otherwise tell a cycle that was audited and added nothing from a cycle nobody audited.
+> **No ADR 0012 additions this cycle; the cumulative count stays at 2** (`instanceName`, `auth.consecutiveInconclusive`,
+> both on `/health`, both v3.29.0). ADR 0020 changes B.2 **semantics** without adding a field, which is why it is
+> ADR 0006 route (b) and why the key-set snapshot is silent on it — the two audits answer different questions and
+> this release is the case that shows it.
+
 ### Security
 
 - **`OCP_ALLOWED_HOSTS` — an undeclared public DNS name may no longer vouch for itself (#446, [ADR 0020](docs/adr/0020-declared-hosts.md)).** ADR 0019's same-origin arm admitted any request whose `Origin` host equalled its `Host`. **DNS rebinding produces exactly that equality** — the attacker serves their page on this port, flips the A record to `127.0.0.1`, and the browser sends their domain in both headers, equal by construction. Measured against a live default-configuration instance: `Host: r.attacker.example:PORT` + the matching `Origin` returned **200**. No `Origin` check can refuse that, because the request genuinely *is* same-origin.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-claude-proxy",
-  "version": "3.30.0",
+  "version": "3.31.0",
   "description": "OCP (Open Claude Proxy) — use your Claude Pro/Max subscription as an OpenAI-compatible API for any IDE. Works with Cline, OpenCode, Aider, Continue.dev, OpenClaw, and more.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Version bump + CHANGELOG only. No code change; everything shipping here is already on `main` and was reviewed in its own PR (#447, #448).

## Breaking, for exactly one deployment shape

A dashboard at a real **public DNS name** resolving straight to the box now needs `OCP_ALLOWED_HOSTS=your.host`. **That is the same shape DNS rebinding imitates** — from inside a request the two are indistinguishable, which is the finding rather than a limitation. Nothing reached by IP, `localhost`, `*.local` or Tailscale is affected; the 403 names the setting.

## Governance audit for the dated section

Both audits ran, and **they disagree by design this release** — which is the clearest demonstration yet that they answer different questions:

- **PRIMARY (B.2 key-set diff): no B.2 key-set change this cycle**, both profiles. Verified with a **positive control** on a range known to have changed (31 lines), because an empty diff and a command that never ran are the same output. **The first run of this audit was a false green** — it ran in a checkout detached at `v3.30.0`, so `git diff v3.30.0..HEAD` compared a commit to itself. Recorded because that is the exact failure this repo keeps writing rules about.
- **SECONDARY (ADR 0012 marker): none this cycle; cumulative count stays 2.**
- ADR 0020 changes B.2 **semantics** without adding a field, so the snapshot is correctly silent while `ALIGNMENT.md` gained a new cross-cutting authorization. The snapshot answers *"did the response shape move"*, never *"was the change allowed"*.

## Release-notes body

**8057 B** against the 125 000 cap, `kind=section` (verbatim). The mechanism #441 added after v3.29.3 shipped with **no Release** at 169 670 B.

## Endpoint Class

- [x] **Not endpoint-touching** — `package.json` and `CHANGELOG.md` only.

### Privacy self-check (PUBLIC repo)

- [x] No names, personal paths, hostnames, or emails beyond `noreply@anthropic.com`.