### PR TITLE
fix(health): `stats.errors` moves by exactly one per failed request (#460)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,26 +14,44 @@
 
   All three predate #459 — the third reproduces identically against `server.mjs` at **v3.32.0**, with the same two `recentErrors` entries, which is the attribution rather than an assumption.
 
-  **The non-streaming case was worse than a miscount.** An `is_error` result is a *protocol* failure with a **zero exit code**, and `callClaude` had no `errored` flag — the one `callClaudeStreaming` already had. So its `close` handler read `code === 0` and took the **success** branch for a request that had just returned HTTP 500: measured, it logged **`claude_ok`**, recorded a per-model **success**, and told the **circuit breaker** the model was healthy. A model failing every request this way would never have tripped the breaker. Adding the flag fixes the counter and all three of those together.
+  **The non-streaming case was worse than a miscount.** An `is_error` result is a *protocol* failure with a **zero exit code**, and `callClaude` had no `errored` flag — the one `callClaudeStreaming` already had. So its `close` handler read `code === 0` and took the **success** branch for a request that had just returned HTTP 500. Measured, that request also logged **`claude_ok`**, recorded a per-model **success**, and called `noteAuthVerifiedByRequest()` — which is **wire-visible**:
+
+  | after one `is_error` request that returned **500** | `/health` `auth` |
+  |---|---|
+  | before | `ok: true`, `okSource: "request"`, *"verified by a completed request"* |
+  | after | `ok: null`, `okSource: "none"` |
+
+  That last one is governed by **[ADR 0014](docs/adr/0014-auth-verdict-measures-what-it-measured.md)**, whose rule is a single sentence with two halves: *"A request that reaches the model **and succeeds** proves the credential is valid. A request that **fails** proves something, and OCP already counts those (`stats.errors`, `recentErrors`)."* This one flag brings **both halves** into conformance — which is a stronger argument for the change than the one an earlier draft of this entry made, and is route (a) for the same reason: the rule is unchanged and the code was not implementing it.
+
+  **A retraction, recorded rather than quietly dropped.** That earlier draft also said the request *"told the **circuit breaker** the model was healthy"* and that *"a model failing every request this way would never have tripped the breaker."* **False as a consequence of this bug.** `breakerRecordSuccess` is an **empty stub** — the breaker was removed in v2.5.0, `/health` reports `circuitBreaker: "disabled"`, and there is no failure recorder anywhere (`grep -rnE 'breakerRecord(Error|Failure)|breakerTrip|breakerOpen'` exits 1, with `breakerRecordSuccess` as a positive control at exit 0). So the sentence is true of **every** failure in **every** lane and says nothing about this one. It was read off the function's *name*, and stamped `[measured]` with no observable that would differ.
 
   **The double-counts are fixed by a per-request guard**, because that is the unit the field counts. `trackError()` is global and every arm of a lane calls it independently, so a failure tripping two arms counted twice. The guard is deliberately **not** inside `trackError()` — that function is also reached from `callClaudeTui` and from paths outside a request, and giving it hidden per-call-site state would make it lie to those callers.
+
+  **`recentErrors` now carries the upstream's own message on both lanes.** The non-streaming arm counted from the `close` handler, so an `is_error` failure was recorded as `"claude exit 0"` — a string with no diagnostic value that reads as a *successful* exit, for the failure it is reporting. It now counts in the `parsed.error` arm with the upstream text, mirroring the streaming lane. **This is free of double-counting precisely because of the per-request guard** — the `close` handler's later call becomes a no-op — which is the guard paying for itself rather than merely preventing a regression.
 
   **Class B.2, [ADR 0006](docs/adr/0006-openai-shim-scope.md) route (a).** No field is added, removed or renamed, and no documented *meaning* changes — the values stop being wrong under ADR 0018's unchanged rule. The #193 `activeRequests` precedent, not ADR 0010's changed-rule case. `docs/governance/b2-response-keys.json` is unaffected and ADR 0012 is not engaged. The counter reaches the wire on three surfaces (`/health`'s `stats.errors`, `/status`'s `requests.errors`, `/usage`'s `proxy.errors`), which were all wrong together.
 
 ### Tests
 
-- **Three live-boot tests, and the third is the load-bearing one (#460).** Two drive an `is_error` result — a child that exits **0** while reporting failure, which is a different kind from #459's non-zero-exit fake and takes a different branch — and assert each lane counts exactly one. The non-streaming test additionally asserts the **log**, because `stats.errors` alone cannot distinguish "counted once" from "counted once *and still recorded a success*": it waits for `claude_exit` on **stderr** and asserts `claude_ok` is absent from **stdout**. Those are different streams because `logEvent` routes by level, and the first draft of that test asserted both against stdout and reported a missing `claude_exit` for a run where it had fired correctly.
+- **Five live-boot tests (#460).** Two drive an `is_error` result — a child that exits **0** while reporting failure, which is a different kind from #459's non-zero-exit fake and takes a different branch — and assert each lane counts exactly one. The non-streaming test additionally asserts the **log**, because `stats.errors` alone cannot distinguish "counted once" from "counted once *and still recorded a success*": it waits for `claude_exit` on **stderr** and asserts `claude_ok` is absent from **stdout**. Those are different streams because `logEvent` routes by level, and the first draft of that test asserted both against stdout and reported a missing `claude_exit` for a run where it had fired correctly.
 
   The third is the control, and it guards against a fix far worse than the bug: **a *global* "already counted" flag would pass both tests above and then silence every subsequent request's error for the life of the process.** It drives failure → success → failure and asserts 1 → 1 → 2.
 
   | row | mutation | reddens | `=== Results:` |
   |---|---|---|---|
-  | — | baseline | — | **3 passed, 0 failed** |
-  | M1 | revert `server.mjs` to pre-fix | all three | 0 passed, 3 failed |
-  | M2 | drop only `callClaude`'s `errored = true` | the non-streaming test + the control | 1 passed, 2 failed |
-  | M3 | make the guard **global** instead of per-request | **the control alone**, on *"the SECOND failure did not count"* | 2 passed, 1 failed |
+  | — | baseline | — | **5 passed, 0 failed** |
+  | M1 | revert `server.mjs` to pre-fix | **all five** | 0 passed, 5 failed |
+  | M2 | drop only `callClaude`'s `errored = true` | **the success test alone** | 4 passed, 1 failed |
+  | M3 | make the guard **global** instead of per-request | **the control alone** | 4 passed, 1 failed |
+  | M4 | neuter **only** `callClaude`'s guard | non-streaming + **spawn-failure** + control | 2 passed, 3 failed |
+  | M5 | drop `\|\| errored` from the close condition | **the success test alone** | 4 passed, 1 failed |
 
-  M3 is the row the control exists for: it is invisible to every single-request test.
+  Every row was re-measured against the final five tests rather than carried forward, and **M2's reach shrank in the process** — worth recording, because it is exactly what a carried-forward table hides. Before the `recentErrors` change below, dropping `errored` also broke the counter; after it the `parsed.error` arm counts directly, so `errored`'s only remaining job is suppressing the success branch, and M2 now reddens precisely the test for that.
+
+  **M3 is the row the control exists for** — invisible to every single-request test. **M4 and M5 exist because the first draft of this change had neither**, and both gaps were found by the independent reviewer running mutations the author's own table did not suggest:
+
+  - **M4** showed the third row of the table above — the asynchronously-failing spawn — was **claimed fixed and pinned by nothing**: neutering `callClaude`'s guard alone left the entire suite green at `1340 passed, 0 failed`. It now has its own test, using the lever recorded on #460 (force the isolated spawn HOME, warm it, then delete it and make its parent unwritable, so the spawn proceeds with a `cwd` that does not exist).
+  - **M5** showed the log assertions could **never execute**: co-located with the counter assertion, the mutation that breaks them breaks the counter too, the counter's `assert` throws first, and execution never reaches them — `AGENTS.md`'s **"Mutual"** case, whose stated remedy is separate `test()` bodies. Split out, M5 reddens that test alone.
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## Unreleased
 
+### Fixed
+
+- **`stats.errors` now moves by exactly one per failed request — it was wrong in both directions (#460).** [ADR 0018](docs/adr/0018-aggregate-counters-count-every-lane.md) defines the field as *"any upstream failure on either lane"*. Measured, one failed request moved it by **0, 1 or 2** depending on how it failed:
+
+  | failure | before | after |
+  |---|---|---|
+  | `is_error` result, **non-streaming** | **0** | 1 |
+  | `is_error` result, **streaming** | **2** | 1 |
+  | spawn fails **asynchronously** (`'error'` then `'close'`) | **2** | 1 |
+
+  All three predate #459 — the third reproduces identically against `server.mjs` at **v3.32.0**, with the same two `recentErrors` entries, which is the attribution rather than an assumption.
+
+  **The non-streaming case was worse than a miscount.** An `is_error` result is a *protocol* failure with a **zero exit code**, and `callClaude` had no `errored` flag — the one `callClaudeStreaming` already had. So its `close` handler read `code === 0` and took the **success** branch for a request that had just returned HTTP 500: measured, it logged **`claude_ok`**, recorded a per-model **success**, and told the **circuit breaker** the model was healthy. A model failing every request this way would never have tripped the breaker. Adding the flag fixes the counter and all three of those together.
+
+  **The double-counts are fixed by a per-request guard**, because that is the unit the field counts. `trackError()` is global and every arm of a lane calls it independently, so a failure tripping two arms counted twice. The guard is deliberately **not** inside `trackError()` — that function is also reached from `callClaudeTui` and from paths outside a request, and giving it hidden per-call-site state would make it lie to those callers.
+
+  **Class B.2, [ADR 0006](docs/adr/0006-openai-shim-scope.md) route (a).** No field is added, removed or renamed, and no documented *meaning* changes — the values stop being wrong under ADR 0018's unchanged rule. The #193 `activeRequests` precedent, not ADR 0010's changed-rule case. `docs/governance/b2-response-keys.json` is unaffected and ADR 0012 is not engaged. The counter reaches the wire on three surfaces (`/health`'s `stats.errors`, `/status`'s `requests.errors`, `/usage`'s `proxy.errors`), which were all wrong together.
+
+### Tests
+
+- **Three live-boot tests, and the third is the load-bearing one (#460).** Two drive an `is_error` result — a child that exits **0** while reporting failure, which is a different kind from #459's non-zero-exit fake and takes a different branch — and assert each lane counts exactly one. The non-streaming test additionally asserts the **log**, because `stats.errors` alone cannot distinguish "counted once" from "counted once *and still recorded a success*": it waits for `claude_exit` on **stderr** and asserts `claude_ok` is absent from **stdout**. Those are different streams because `logEvent` routes by level, and the first draft of that test asserted both against stdout and reported a missing `claude_exit` for a run where it had fired correctly.
+
+  The third is the control, and it guards against a fix far worse than the bug: **a *global* "already counted" flag would pass both tests above and then silence every subsequent request's error for the life of the process.** It drives failure → success → failure and asserts 1 → 1 → 2.
+
+  | row | mutation | reddens | `=== Results:` |
+  |---|---|---|---|
+  | — | baseline | — | **3 passed, 0 failed** |
+  | M1 | revert `server.mjs` to pre-fix | all three | 0 passed, 3 failed |
+  | M2 | drop only `callClaude`'s `errored = true` | the non-streaming test + the control | 1 passed, 2 failed |
+  | M3 | make the guard **global** instead of per-request | **the control alone**, on *"the SECOND failure did not count"* | 2 passed, 1 failed |
+
+  M3 is the row the control exists for: it is invisible to every single-request test.
+
+
 ### Added
 
 - **A boot-time `claude` capability gate — OCP now refuses to start against a CLI missing a flag it passes (#455).** OCP spawns `claude` on every request and had **no** gate for it. #453 sharpened that by depending on `--system-prompt-file`, which does not appear in `claude --help`'s option list at all. If a host's CLI lacked any flag OCP passes, every request 500s — loudly and self-namingly, but **per request**; nothing said so at boot, so the first person to notice was a user rather than the operator.

--- a/server.mjs
+++ b/server.mjs
@@ -2098,11 +2098,31 @@ async function callClaude(model, messages, conversationId, keyName, res) {
           // #460: `errored` is set here for the same reason callClaudeStreaming sets it, and its
           // absence on THIS lane was the whole defect. The child exits 0 (an is_error result is a
           // PROTOCOL failure, not a process one), so without it the close handler below reads
-          // `code === 0` and takes the SUCCESS branch for a request that just 500'd -- measured:
-          // one such request logged `claude_ok`, recorded a per-model SUCCESS, told the circuit
-          // breaker the model was healthy, and left stats.errors at 0. A model failing every
-          // request this way would never trip the breaker.
+          // `code === 0` and takes the SUCCESS branch for a request that just 500'd. [measured]
+          // one such request left stats.errors at 0, logged `claude_ok`, recorded a per-model
+          // SUCCESS, and called noteAuthVerifiedByRequest() -- which is wire-visible: /health
+          // reported auth.ok=true, okSource="request", "verified by a completed request", for a
+          // request that returned 500. ADR 0014 is the authority and its rule is ONE SENTENCE with
+          // two halves: "A request that reaches the model AND SUCCEEDS proves the credential is
+          // valid. A request that FAILS proves something, and OCP already counts those
+          // (stats.errors, recentErrors)." This flag brings both halves into conformance at once.
+          //
+          // NOT a claim about the circuit breaker. breakerRecordSuccess is an EMPTY STUB
+          // (server.mjs, `function breakerRecordSuccess(_cliModel) {}`; the breaker was removed in
+          // v2.5.0 and /health reports circuitBreaker "disabled"), and there is no failure
+          // recorder at all -- so "this would never trip the breaker" is true of EVERY failure and
+          // says nothing about this one. An earlier revision of this comment claimed it as a
+          // consequence of the missing flag, stamped [measured], with no observable that would
+          // differ. Read what assigns the value, not what it is called.
           errored = true;
+          // #460 F5: count it HERE, with the upstream's own message, mirroring
+          // callClaudeStreaming's parsed.error arm. Without this the close handler counts it
+          // instead and records `claude exit 0` -- an operator-facing string that carries no
+          // diagnostic and reads as a SUCCESSFUL exit, for the failure it is reporting. Free of
+          // double-counting precisely because of the per-request guard above: the close handler's
+          // countError becomes a no-op. That is the guard paying for itself rather than merely
+          // preventing a regression.
+          countError(String(parsed.error).slice(0, 200));
           reject(new Error(String(parsed.error)));
         }
       }

--- a/server.mjs
+++ b/server.mjs
@@ -1969,6 +1969,23 @@ function spawnClaudeProcess(model, messages, conversationId, keyName, releaseSlo
 // can be cancelled the moment the client disconnects, instead of spawning claude for a dead
 // socket once a slot finally frees up.
 async function callClaude(model, messages, conversationId, keyName, res) {
+  // #460: stats.errors must move by exactly ONE per failed request, and before this it moved by
+  // 0, 1 or 2 depending on HOW the request failed. trackError() is global and every arm of this
+  // lane calls it independently, so a failure that trips two arms counted twice -- MEASURED: a
+  // spawn that fails asynchronously fires both 'error' and 'close', and one request moved the
+  // counter by 2 (reproduced identically on v3.32.0, so it long predates #459). ADR 0018 defines
+  // the field as "any upstream failure on either lane" -- one failure, one count.
+  //
+  // The guard is per-REQUEST because that is the unit the field counts. A global flag would
+  // silence concurrent requests' errors; a per-arm flag would not compose across arms, which is
+  // exactly the bug. It is deliberately NOT inside trackError(): that function is also reached
+  // from callClaudeTui and from paths outside a request, and giving it hidden per-call-site state
+  // would make it lie to those callers.
+  let errorCounted = false;
+  const countError = (msg) => { if (errorCounted) return; errorCounted = true; trackError(msg); };
+  // Mirrors callClaudeStreaming's flag of the same name: an is_error result is a PROTOCOL
+  // failure with a zero exit code, so the close handler cannot see it from `code` alone.
+  let errored = false;
   // FIX ⑥: acquire a concurrency slot first (queues up to CLAUDE_MAX_QUEUE; rejects with a
   // ConcurrencyOverflowError → 429 when the queue is full, or a RequestDisconnectedError (F2)
   // if the client goes away first). The release fn is passed into the spawn so the idempotent
@@ -2004,7 +2021,7 @@ async function callClaude(model, messages, conversationId, keyName, res) {
     // takes EACCES -- the request gets PAST this catch and 500s downstream on `spawn ... ENOENT`.
     // Kept because the rethrow exists so a FUTURE fallible call inside that try still releases the
     // mutex; if one is ever added, this counts it.
-    trackError(err.message);
+    countError(err.message);
     throw err;
   }
   return new Promise((resolve, reject) => {
@@ -2038,7 +2055,7 @@ async function callClaude(model, messages, conversationId, keyName, res) {
       //
       // RequestDisconnectedError cannot reach here -- acquireClaudeSlot runs before this try -- so
       // no exclusion is needed; adding one would be dead code.
-      trackError(err.message);
+      countError(err.message);
       return reject(err);
     }
 
@@ -2076,7 +2093,16 @@ async function callClaude(model, messages, conversationId, keyName, res) {
         } else if (parsed.stop) {
           resultEventSeen = true;
         } else if (parsed.error) {
-          // is_error result — treat as process error
+          // is_error result — treat as process error.
+          //
+          // #460: `errored` is set here for the same reason callClaudeStreaming sets it, and its
+          // absence on THIS lane was the whole defect. The child exits 0 (an is_error result is a
+          // PROTOCOL failure, not a process one), so without it the close handler below reads
+          // `code === 0` and takes the SUCCESS branch for a request that just 500'd -- measured:
+          // one such request logged `claude_ok`, recorded a per-model SUCCESS, told the circuit
+          // breaker the model was healthy, and left stats.errors at 0. A model failing every
+          // request this way would never trip the breaker.
+          errored = true;
           reject(new Error(String(parsed.error)));
         }
       }
@@ -2093,10 +2119,10 @@ async function callClaude(model, messages, conversationId, keyName, res) {
       cleanup();
       // Tolerate null exit code when result event was seen (sandbox-wrap noise, same
       // as OLP commit 2864275 — bwrap shell exits null after model completes).
-      if (code !== 0 && !resultEventSeen) {
+      if ((code !== 0 && !resultEventSeen) || errored) {
         recordModelError(cliModel, false);
-        logEvent("error", "claude_exit", { model: cliModel, code, signal: signal || "none", elapsed, stderr: stderr.slice(0, 300) });
-        trackError(stderr.slice(0, 300) || assembledText.slice(0, 300) || `claude exit ${code}`);
+        logEvent("error", "claude_exit", { model: cliModel, code, signal: signal || "none", elapsed, errored, stderr: stderr.slice(0, 300) });
+        countError(stderr.slice(0, 300) || assembledText.slice(0, 300) || `claude exit ${code}`);
         handleSessionFailure();
         reject(new Error(stderr.slice(0, 300) || assembledText.slice(0, 300) || `claude exit ${code}`));
       } else {
@@ -2111,7 +2137,7 @@ async function callClaude(model, messages, conversationId, keyName, res) {
     proc.on("error", (err) => {
       console.error(`[claude] spawn error: ${err.message}`);
       cleanup();
-      trackError(err.message);
+      countError(err.message);
       handleSessionFailure();
       reject(err);
     });
@@ -2527,6 +2553,20 @@ function startHeartbeat(res, intervalMs, sessionId) {
 // The result event triggers the stop/[DONE] sequence.
 // Reference: OLP ADR 0009 Amendment 1 + commits 97e7d16, 65f945c.
 async function callClaudeStreaming(model, messages, conversationId, res, authInfo = {}) {
+  // #460: stats.errors must move by exactly ONE per failed request, and before this it moved by
+  // 0, 1 or 2 depending on HOW the request failed. trackError() is global and every arm of this
+  // lane calls it independently, so a failure that trips two arms counted twice -- MEASURED: a
+  // spawn that fails asynchronously fires both 'error' and 'close', and one request moved the
+  // counter by 2 (reproduced identically on v3.32.0, so it long predates #459). ADR 0018 defines
+  // the field as "any upstream failure on either lane" -- one failure, one count.
+  //
+  // The guard is per-REQUEST because that is the unit the field counts. A global flag would
+  // silence concurrent requests' errors; a per-arm flag would not compose across arms, which is
+  // exactly the bug. It is deliberately NOT inside trackError(): that function is also reached
+  // from callClaudeTui and from paths outside a request, and giving it hidden per-call-site state
+  // would make it lie to those callers.
+  let errorCounted = false;
+  const countError = (msg) => { if (errorCounted) return; errorCounted = true; trackError(msg); };
   const id = `chatcmpl-${randomUUID()}`;
   const created = Math.floor(Date.now() / 1000);
 
@@ -2555,7 +2595,7 @@ async function callClaudeStreaming(model, messages, conversationId, res, authInf
     spawnDecision = await resolveSpawnDecision();
   } catch (err) {
     releaseSlot();
-    trackError(err.message); // #458 — defensive and unreachable in this tree; see callClaude's twin.
+    countError(err.message); // #458 — defensive and unreachable in this tree; see callClaude's twin.
     return jsonResponse(res, 500, { error: { message: sanitizeError(err.message), type: "proxy_error" } });
   }
   let ctx;
@@ -2566,7 +2606,7 @@ async function callClaudeStreaming(model, messages, conversationId, res, authInf
     // Spawn threw before cleanup() was wired → release the fallback mutex here so it never leaks.
     try { spawnDecision.releaseFallback?.(); } catch { /* best effort */ }
     // #458 — see the twin in callClaude for why this is counted here rather than in the caller.
-    trackError(err.message);
+    countError(err.message);
     return jsonResponse(res, 500, { error: { message: sanitizeError(err.message), type: "proxy_error" } });
   }
 
@@ -2664,7 +2704,7 @@ async function callClaudeStreaming(model, messages, conversationId, res, authInf
         errored = true;
         const errStr = String(parsed.error);
         logEvent("error", "claude_result_error", { model: cliModel, error: errStr.slice(0, 200) });
-        trackError(errStr.slice(0, 200));
+        countError(errStr.slice(0, 200));
         if (!headersSent && !res.writableEnded && !res.destroyed) {
           jsonResponse(res, 500, { error: { message: sanitizeError(errStr), type: "provider_error" } });
         } else if (!res.writableEnded && !res.destroyed) {
@@ -2697,7 +2737,7 @@ async function callClaudeStreaming(model, messages, conversationId, res, authInf
       recordModelError(cliModel, false);
       try { recordUsage({ keyId: authInfo.keyId, keyName: authInfo.keyName, model, promptChars: messages.reduce((a, m) => a + contentToText(m.content).length, 0), responseChars: 0, elapsedMs: elapsed, success: false }); } catch (e) { logEvent("error", "usage_record_failed", { error: e.message }); }
       logEvent("error", "claude_exit", { model: cliModel, code, signal: signal || "none", elapsed, errored, stderr: stderr.slice(0, 300) });
-      trackError(stderr.slice(0, 300) || `claude exit ${code}`);
+      countError(stderr.slice(0, 300) || `claude exit ${code}`);
       handleSessionFailure();
 
       // If the error was already sent inline (parsed.error branch above), the
@@ -2743,7 +2783,7 @@ async function callClaudeStreaming(model, messages, conversationId, res, authInf
     console.error(`[claude] spawn error: ${err.message}`);
     hb.stop();
     cleanup();
-    trackError(err.message);
+    countError(err.message);
     handleSessionFailure();
     if (!headersSent && !res.writableEnded && !res.destroyed) {
       jsonResponse(res, 500, { error: { message: sanitizeError(err.message), type: "proxy_error" } });

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -4344,8 +4344,9 @@ console.log("\nstats.errors moves by exactly one per failed request (#460):");
 // change, one failed request moved it by 0, 1 or 2:
 //
 //   is_error result, non-streaming  -> 0   the close handler saw code===0 and took the SUCCESS
-//                                          branch, so it also logged claude_ok and recorded a
-//                                          per-model success and a circuit-breaker success
+//                                          branch, so it also logged claude_ok, recorded a
+//                                          per-model success, and marked the credential verified
+//                                          (ADR 0014) for a request that returned 500
 //   is_error result, streaming      -> 2   parsed.error counted, then close re-entered on errored
 //   spawn fails asynchronously      -> 2   'error' and 'close' both fired
 //
@@ -4382,26 +4383,40 @@ ltTest("integration (#460): an is_error result counts ONCE on the non-streaming 
         `without the 'errored' flag the close handler reads code===0 and takes the SUCCESS ` +
         `branch: ${JSON.stringify(after.stats)}`);
       assert.equal((after.recentErrors || []).length, 1, `recentErrors: ${JSON.stringify(after.recentErrors)}`);
-      // The counter is not the only thing that was wrong. A request that 500'd was also logged as
-      // claude_ok and recorded as a per-model SUCCESS and a circuit-breaker success -- so a model
-      // failing every request this way would never trip the breaker. Assert the log directly,
-      // because stats.errors alone cannot distinguish "counted once" from "counted once AND still
-      // recorded a success".
-      // Wait for the line being asserted, not for a proxy for it: the HTTP response returns
-      // before the child's close handler has necessarily reached the parent's stdout pipe, and
-      // asserting on an unflushed buffer is a race that fails intermittently for the wrong reason.
-      // Waiting for the POSITIVE line first also makes the negative assertion below meaningful --
-      // "no claude_ok" is satisfied by an empty buffer.
-      // The two events land on DIFFERENT streams, because logEvent routes by level:
-      // claude_exit is level "error" -> console.error -> stderr, claude_ok is level "info" ->
-      // console.log -> stdout. Asserting both against buf.out reports "claude_exit missing" for a
-      // run where it fired correctly, which is what the first draft of this test did.
+    } finally { child.kill("SIGKILL"); await ltDrain(() => buf.closed, "err460-nonstream", 5000); }
+  } finally { _ltRmRetry(dir); }
+});
+
+// SEPARATE BODY, and not for tidiness. The missing `errored` flag broke more than the counter:
+// the same close handler took the whole SUCCESS branch. But co-located with the counter assertion
+// above, these could never report -- the mutation that breaks them (dropping `errored`) breaks the
+// counter too, the counter's assert throws first, and execution never reaches here. AGENTS.md's
+// "Mutual" case, whose stated remedy is separate test() bodies, because ordering cannot help when
+// ONE mutation breaks both claims.
+ltTest("integration (#460): a request that 500s must not ALSO be recorded as a success", async () => {
+  if (!LT_POSIX) return;
+  const dir = ltMkdir();
+  try {
+    const fake = join(dir, "claude-iserr"); _ltWrite(fake, LT460_FAKE); _ltChmod(fake, 0o755);
+    const { child, buf, port } = await ltBootFresh({ CLAUDE_BIN: fake }, dir);
+    try {
+      assert.ok(await ltWait(() => buf.out.includes("listening on")), `— ${ltDiag(buf)}`);
+      assert.equal((await ltPostStatus(port, { model: "sonnet", messages: [{ role: "user", content: "hi" }] })).status, 500,
+        `— ${ltDiag(buf)}`);
+      // The two events land on DIFFERENT streams, because logEvent routes by level: claude_exit is
+      // level "error" -> console.error -> stderr; claude_ok is level "info" -> console.log ->
+      // stdout. Asserting both against buf.out reports "claude_exit missing" for a run where it
+      // fired correctly -- which is what this test's first draft did.
+      //
+      // Wait for the POSITIVE line first: the response returns before the close handler has
+      // necessarily reached the parent's pipe, and "no claude_ok" is satisfied by an empty buffer,
+      // so the negative assertion below means nothing without it.
       assert.ok(await ltWait(() => /"event":"claude_exit"/.test(buf.err)),
         `the close handler never logged claude_exit — ${ltDiag(buf)}`);
       assert.ok(!/"event":"claude_ok"/.test(buf.out),
-        `a request that 500'd also logged claude_ok, so it recorded a per-model success and a ` +
-        `circuit-breaker success — ${ltDiag(buf)}`);
-    } finally { child.kill("SIGKILL"); await ltDrain(() => buf.closed, "err460-nonstream", 5000); }
+        `a request that returned 500 also logged claude_ok, so the close handler took the SUCCESS ` +
+        `branch: it recorded a per-model success and marked the credential verified — ${ltDiag(buf)}`);
+    } finally { child.kill("SIGKILL"); await ltDrain(() => buf.closed, "err460-success", 5000); }
   } finally { _ltRmRetry(dir); }
 });
 
@@ -4421,6 +4436,55 @@ ltTest("integration (#460): an is_error result counts ONCE on the streaming lane
         `one streaming failure moved stats.errors by ${after.stats.errors}, not 1: ${JSON.stringify(after.stats)}`);
       assert.equal((after.recentErrors || []).length, 1, `recentErrors: ${JSON.stringify(after.recentErrors)}`);
     } finally { child.kill("SIGKILL"); await ltDrain(() => buf.closed, "err460-stream", 5000); }
+  } finally { _ltRmRetry(dir); }
+});
+
+ltTest("integration (#460): an ASYNCHRONOUSLY-failing spawn counts ONCE, not once per handler (was 2)", async () => {
+  if (!LT_POSIX) return;
+  const dir = ltMkdir();
+  try {
+    // The third kind, and until this test it was claimed fixed and pinned by nothing: neutering
+    // callClaude's guard alone left the whole suite green. It is also the most reachable kind in
+    // production -- it needs only a `claude` that is not where OCP expects it -- and it is the one
+    // that reproduces identically on v3.32.0, i.e. it long predates #459.
+    //
+    // LEVER: force the isolated spawn HOME (a resolvable token does that), let one request create
+    // it, then delete it and make its parent unwritable. ensureSpawnHome's mkdir then fails and is
+    // swallowed by prepareSpawnHome, so the spawn goes ahead with a cwd that does not exist ->
+    // node emits 'error' AND 'close', and both handlers used to call trackError.
+    const fake = join(dir, "claude-ok");
+    _ltWrite(fake, `#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"OK"}]}}'\nprintf '%s\\n' '{"type":"result"}'\nexit 0\n`);
+    _ltChmod(fake, 0o755);
+    const { child, buf, port } = await ltBootFresh(
+      { CLAUDE_BIN: fake, CLAUDE_CODE_OAUTH_TOKEN: "sk-fake-forces-isolated-spawn-home" }, dir);
+    const health = () => fetch(`http://127.0.0.1:${port}/health`).then(x => x.json());
+    try {
+      assert.ok(await ltWait(() => buf.out.includes("listening on")), `— ${ltDiag(buf)}`);
+      const pre = await health();
+      // Premise, and it is not ceremony: if isolation is OFF this fixture cannot arm the lever at
+      // all, and every assertion below would be measuring a different failure.
+      assert.equal(pre.spawn?.isolated, true, `the fixture must run isolated to arm this lever: ${JSON.stringify(pre.spawn)}`);
+      assert.equal((await ltPostStatus(port, { model: "sonnet", messages: [{ role: "user", content: "hi" }] })).status, 200,
+        `the warm-up request must succeed — ${ltDiag(buf)}`);
+      assert.equal((await health()).stats.errors, 0, "premise: the warm-up left the counter at 0");
+
+      const spawnHome = pre.spawn.home;
+      assert.ok(_ltExists(spawnHome), `the warm-up should have created ${spawnHome}`);
+      _ltRmRetry(spawnHome);
+      _ltChmod(join(spawnHome, ".."), 0o500);
+      try {
+        assert.equal((await ltPostStatus(port, { model: "sonnet", messages: [{ role: "user", content: "hi" }] })).status, 500,
+          `the spawn should fail with an unusable cwd — ${ltDiag(buf)}`);
+        const after = await health();
+        assert.equal(after.stats.errors, 1,
+          `one asynchronously-failing spawn moved stats.errors by ${after.stats.errors}. Two means ` +
+          `'error' and 'close' each counted the same failure: ${JSON.stringify((after.recentErrors || []).map(e => e.message.slice(0, 40)))}`);
+        assert.equal((after.recentErrors || []).length, 1, `recentErrors: ${JSON.stringify(after.recentErrors)}`);
+      } finally {
+        // Restore the mode before the fixture teardown tries to remove the tree.
+        try { _ltChmod(join(spawnHome, ".."), 0o700); } catch { /* best effort */ }
+      }
+    } finally { child.kill("SIGKILL"); await ltDrain(() => buf.closed, "err460-spawnfail", 5000); }
   } finally { _ltRmRetry(dir); }
 });
 

--- a/test-features.mjs
+++ b/test-features.mjs
@@ -4336,6 +4336,143 @@ ltTest("integration: boot gate REFUSES each unsafe config (multi / non-loopback 
   } finally { _ltRmRetry(dir); }
 });
 
+console.log("\nstats.errors moves by exactly one per failed request (#460):");
+
+// ── #460: the counter was wrong in BOTH directions, depending on HOW the request failed ───────
+//
+// ADR 0018 defines stats.errors as "any upstream failure on either lane". Measured before this
+// change, one failed request moved it by 0, 1 or 2:
+//
+//   is_error result, non-streaming  -> 0   the close handler saw code===0 and took the SUCCESS
+//                                          branch, so it also logged claude_ok and recorded a
+//                                          per-model success and a circuit-breaker success
+//   is_error result, streaming      -> 2   parsed.error counted, then close re-entered on errored
+//   spawn fails asynchronously      -> 2   'error' and 'close' both fired
+//
+// All three predate #459 (kind 3 reproduces identically on v3.32.0). The fix is one `errored`
+// flag on the non-streaming lane -- which the streaming lane already had -- plus a PER-REQUEST
+// counting guard so no failure is counted twice.
+
+// A fake that emits an is_error RESULT and exits 0: a PROTOCOL failure, not a process one. That
+// distinction is the whole of kinds 1 and 2, and it is why #459's tests (which drive a non-zero
+// EXIT code) could not see them.
+const LT460_FAKE = `#!/bin/sh
+cat >/dev/null
+printf '%s\\n' '{"type":"result","is_error":true,"result":"deliberate is_error"}'
+exit 0
+`;
+
+ltTest("integration (#460): an is_error result counts ONCE on the non-streaming lane (was 0)", async () => {
+  if (!LT_POSIX) return;
+  const dir = ltMkdir();
+  try {
+    const fake = join(dir, "claude-iserr"); _ltWrite(fake, LT460_FAKE); _ltChmod(fake, 0o755);
+    const { child, buf, port } = await ltBootFresh({ CLAUDE_BIN: fake }, dir);
+    try {
+      assert.ok(await ltWait(() => buf.out.includes("listening on")), `— ${ltDiag(buf)}`);
+      const before = await fetch(`http://127.0.0.1:${port}/health`).then(x => x.json());
+      assert.equal(before.stats.errors, 0, `premise: the counter must start at 0`);
+
+      const r = await ltPostStatus(port, { model: "sonnet", messages: [{ role: "user", content: "hi" }] });
+      assert.equal(r.status, 500, `the is_error result must 500 — got ${r.status}: ${r.text.slice(0, 160)}`);
+
+      const after = await fetch(`http://127.0.0.1:${port}/health`).then(x => x.json());
+      assert.equal(after.stats.errors, 1,
+        `an is_error result left stats.errors at ${after.stats.errors}. The child exits 0, so ` +
+        `without the 'errored' flag the close handler reads code===0 and takes the SUCCESS ` +
+        `branch: ${JSON.stringify(after.stats)}`);
+      assert.equal((after.recentErrors || []).length, 1, `recentErrors: ${JSON.stringify(after.recentErrors)}`);
+      // The counter is not the only thing that was wrong. A request that 500'd was also logged as
+      // claude_ok and recorded as a per-model SUCCESS and a circuit-breaker success -- so a model
+      // failing every request this way would never trip the breaker. Assert the log directly,
+      // because stats.errors alone cannot distinguish "counted once" from "counted once AND still
+      // recorded a success".
+      // Wait for the line being asserted, not for a proxy for it: the HTTP response returns
+      // before the child's close handler has necessarily reached the parent's stdout pipe, and
+      // asserting on an unflushed buffer is a race that fails intermittently for the wrong reason.
+      // Waiting for the POSITIVE line first also makes the negative assertion below meaningful --
+      // "no claude_ok" is satisfied by an empty buffer.
+      // The two events land on DIFFERENT streams, because logEvent routes by level:
+      // claude_exit is level "error" -> console.error -> stderr, claude_ok is level "info" ->
+      // console.log -> stdout. Asserting both against buf.out reports "claude_exit missing" for a
+      // run where it fired correctly, which is what the first draft of this test did.
+      assert.ok(await ltWait(() => /"event":"claude_exit"/.test(buf.err)),
+        `the close handler never logged claude_exit — ${ltDiag(buf)}`);
+      assert.ok(!/"event":"claude_ok"/.test(buf.out),
+        `a request that 500'd also logged claude_ok, so it recorded a per-model success and a ` +
+        `circuit-breaker success — ${ltDiag(buf)}`);
+    } finally { child.kill("SIGKILL"); await ltDrain(() => buf.closed, "err460-nonstream", 5000); }
+  } finally { _ltRmRetry(dir); }
+});
+
+ltTest("integration (#460): an is_error result counts ONCE on the streaming lane (was 2)", async () => {
+  if (!LT_POSIX) return;
+  const dir = ltMkdir();
+  try {
+    const fake = join(dir, "claude-iserr"); _ltWrite(fake, LT460_FAKE); _ltChmod(fake, 0o755);
+    const { child, buf, port } = await ltBootFresh({ CLAUDE_BIN: fake }, dir);
+    try {
+      assert.ok(await ltWait(() => buf.out.includes("listening on")), `— ${ltDiag(buf)}`);
+      await ltPostStatus(port, { model: "sonnet", stream: true, messages: [{ role: "user", content: "hi" }] });
+      const after = await fetch(`http://127.0.0.1:${port}/health`).then(x => x.json());
+      // 2 was the pre-fix value: parsed.error counted, then the close handler re-entered on
+      // `errored` and counted the same failure again.
+      assert.equal(after.stats.errors, 1,
+        `one streaming failure moved stats.errors by ${after.stats.errors}, not 1: ${JSON.stringify(after.stats)}`);
+      assert.equal((after.recentErrors || []).length, 1, `recentErrors: ${JSON.stringify(after.recentErrors)}`);
+    } finally { child.kill("SIGKILL"); await ltDrain(() => buf.closed, "err460-stream", 5000); }
+  } finally { _ltRmRetry(dir); }
+});
+
+// THE CONTROL, and it is the one that matters most. A GLOBAL "already counted" flag would pass
+// all three tests above and then silence every subsequent request's error for the life of the
+// process -- a far worse bug than the one being fixed, and invisible to any single-request test.
+// Two failures must count two; a success in between must count nothing.
+ltTest("integration (#460 control): the guard is per-REQUEST — two failures count TWO, and a success counts none", async () => {
+  if (!LT_POSIX) return;
+  const dir = ltMkdir();
+  try {
+    // One fake, two behaviours by system-prompt content: FAIL-ME yields an is_error result,
+    // anything else succeeds. Selected on the prompt FILE's content, not the model name, because
+    // an invalid model is rejected before any spawn (the #458 control's own first-draft defect).
+    const fake = join(dir, "claude-dual");
+    _ltWrite(fake, `#!/bin/sh
+cat >/dev/null
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--system-prompt-file" ] && grep -q FAIL-ME "$a"; then
+    printf '%s\\n' '{"type":"result","is_error":true,"result":"deliberate"}'
+    exit 0
+  fi
+  prev="$a"
+done
+printf '%s\\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"OK"}]}}'
+printf '%s\\n' '{"type":"result"}'
+exit 0
+`);
+    _ltChmod(fake, 0o755);
+    const bad = { model: "sonnet", messages: [{ role: "system", content: "FAIL-ME" }, { role: "user", content: "hi" }] };
+    const good = { model: "sonnet", messages: [{ role: "user", content: "hi" }] };
+    const { child, buf, port } = await ltBootFresh({ CLAUDE_BIN: fake }, dir);
+    const errs = async () => (await fetch(`http://127.0.0.1:${port}/health`).then(x => x.json())).stats.errors;
+    try {
+      assert.ok(await ltWait(() => buf.out.includes("listening on")), `— ${ltDiag(buf)}`);
+      assert.equal(await errs(), 0, "premise: starts at 0");
+
+      assert.equal((await ltPostStatus(port, bad)).status, 500, `first failure — ${ltDiag(buf)}`);
+      assert.equal(await errs(), 1, "the first failure must count 1");
+
+      assert.equal((await ltPostStatus(port, good)).status, 200, `the success must succeed — ${ltDiag(buf)}`);
+      assert.equal(await errs(), 1, "a SUCCESSFUL request must not move the counter");
+
+      assert.equal((await ltPostStatus(port, bad)).status, 500, `second failure — ${ltDiag(buf)}`);
+      assert.equal(await errs(), 2,
+        "the SECOND failure did not count. A global (rather than per-request) guard passes every " +
+        "single-request test and then silences errors for the life of the process.");
+    } finally { child.kill("SIGKILL"); await ltDrain(() => buf.closed, "err460-control", 5000); }
+  } finally { _ltRmRetry(dir); }
+});
+
 console.log("\nboot-time `claude` capability gate (#455):");
 
 // ── #455: OCP spawns `claude` on every request and had no gate for the flags it passes ────────


### PR DESCRIPTION
# Pull Request

## Summary

[ADR 0018](docs/adr/0018-aggregate-counters-count-every-lane.md) defines `stats.errors` as *"any upstream failure on either lane"*. Measured, **one failed request moved it by 0, 1 or 2** depending on how it failed:

| failure | before | after |
|---|---|---|
| `is_error` result, **non-streaming** | **0** | 1 |
| `is_error` result, **streaming** | **2** | 1 |
| spawn fails **asynchronously** (`'error'` then `'close'`) | **2** | 1 |

Fixes #460. All three predate #459 — the third reproduces identically against `server.mjs` at **v3.32.0** (`1253196`) with the same two `recentErrors` entries, which is the attribution rather than an assumption.

## The non-streaming case was worse than a miscount — and this part is not in the issue

An `is_error` result is a **protocol** failure carrying a **zero exit code**, and `callClaude` had no `errored` flag — the one `callClaudeStreaming` already had. So its `close` handler read `code === 0` and took the **success** branch for a request that had just returned HTTP 500.

Measured, that request also logged **`claude_ok`**, recorded a per-model **success**, and called `noteAuthVerifiedByRequest()` — which is **wire-visible**:

| `/health` `auth`, after one `is_error` request that returned **500** | |
|---|---|
| before | `ok: true`, `okSource: "request"`, *"verified by a completed request"* |
| after | `ok: null`, `okSource: "none"` |

That last one is governed by **[ADR 0014](docs/adr/0014-auth-verdict-measures-what-it-measured.md)**, whose rule is a single sentence with two halves: *"A request that reaches the model **and succeeds** proves the credential is valid. A request that **fails** proves something, and OCP already counts those (`stats.errors`, `recentErrors`)."* This one flag brings **both halves** into conformance — which is why the fix is one flag rather than one extra `trackError` call.

### A retraction, recorded rather than quietly dropped

An earlier revision of this PR also claimed the request *"told the **circuit breaker** the model was healthy"* and that *"a model failing every request this way would never have tripped the breaker."* **False as a consequence of this bug.** `breakerRecordSuccess` is an **empty stub** — the breaker was removed in v2.5.0, `/health` reports `circuitBreaker: "disabled"`, and there is no failure recorder anywhere (`grep -rnE 'breakerRecord(Error|Failure)|breakerTrip|breakerOpen'` exits 1, with `breakerRecordSuccess` as a positive control at exit 0). The sentence is true of **every** failure in **every** lane and says nothing about this one. It was read off the function's *name* and stamped `[measured]` with no observable that would differ.

## The double-counts: a per-request guard

`trackError()` is global and every arm of a lane calls it independently, so a failure tripping two arms counted twice. The guard is per-**request** because that is the unit the field counts.

It is deliberately **not** inside `trackError()`: that function is also reached from `callClaudeTui` and from paths outside a request, and giving it hidden per-call-site state would make it lie to those callers.

## Endpoint Class (REQUIRED)

- [x] **Class B** → **B.2** (`/health`, `/status`; `/usage` is Hybrid and only its B.2 synthesis layer reads this counter — the ADR 0018 precedent)

### If Class B

- [x] **Authorizing ADR.** `ADR 0006 (grandfathered as of v3.16.4)`, **route (a)**, with `docs/adr/0018-aggregate-counters-count-every-lane.md` as the document that defines the field.
- [x] **Specification citation.** ADR 0018 § "Folded" table: `stats.errors` | *any upstream failure on either lane*. **Route (a)**: the documented *meaning* is unchanged; only the values stop being wrong. The #193 `activeRequests` precedent, **not** ADR 0010's changed-rule case — the rule that determines the value is ADR 0018's and it is untouched.
- [x] **No invention beyond the specification.** Nothing outside ADR 0018's stated rule. No field added, removed or renamed, so `docs/governance/b2-response-keys.json` is unaffected and ADR 0012 is not engaged.

The counter reaches the wire on three surfaces (`/health`'s `stats.errors`, `/status`'s `requests.errors`, `/usage`'s `proxy.errors`), which were all wrong together.

## Type of change

- [x] Bug fix

## Tests

Five live boots. Two drive an `is_error` result — **a child that exits `0` while reporting failure**, a *different kind* from #459's non-zero-exit fake, taking a different branch, which is exactly why #459's tests could not see any of this — and assert each lane counts exactly one.

The non-streaming test additionally asserts the **log**, because `stats.errors` alone cannot distinguish *"counted once"* from *"counted once **and still recorded a success**"*. It waits for `claude_exit` on **stderr** and asserts `claude_ok` is absent from **stdout** — different streams, because `logEvent` routes by level. The first draft asserted both against stdout and reported a missing `claude_exit` for a run where it had fired correctly; recorded because the failure message was indistinguishable from a real regression.

The third is the control, and it guards against **a fix far worse than the bug**: a *global* "already counted" flag would pass both tests above and then silence every subsequent request's error for the life of the process. It drives failure → success → failure and asserts **1 → 1 → 2**.

| row | mutation | reddens | `=== Results:` |
|---|---|---|---|
| — | baseline | — | **5 passed, 0 failed** |
| M1 | revert `server.mjs` to pre-fix | **all five** | 0 passed, 5 failed |
| M2 | drop only `callClaude`'s `errored = true` | **the success test alone** | 4 passed, 1 failed |
| M3 | make the guard **global** instead of per-request | **the control alone** | 4 passed, 1 failed |
| M4 | neuter **only** `callClaude`'s guard | non-streaming + **spawn-failure** + control | 2 passed, 3 failed |
| M5 | drop `\|\| errored` from the close condition | **the success test alone** | 4 passed, 1 failed |

**M3 is the row the control exists for** — invisible to every single-request test. **M4 and M5 exist because the first draft had neither**, and both were found by the reviewer running mutations my own table did not suggest:

- **M4** showed the third row of the before/after table was **claimed fixed and pinned by nothing** — neutering `callClaude`'s guard alone left the entire suite green at `1340 passed, 0 failed`. It now has its own test.
- **M5** showed the log assertions could **never execute**: co-located with the counter assertion, one mutation broke both and the counter's `assert` threw first. `AGENTS.md`'s **"Mutual"** case; split into its own `test()`.

Every row was **re-measured against the final five tests**, and **M2's reach shrank** in the process — before the `recentErrors` change, dropping `errored` also broke the counter; after it, `errored`'s only job is suppressing the success branch. Every row's landing was asserted (`mutated !== original`, superstring replacement refused); every restore was from a `cmp`-verified file backup, never `git checkout --`.

Full suite: **`=== Results: 1342 passed, 0 failed ===`** (1337 + 5).

## What is deliberately NOT changed

`callClaudeTui`'s single `trackError` call. One catch per turn means no double-count is reachable there, so wrapping it would add a guard with nothing to guard.

## Related

- Fixes #460 (found by #459's independent reviewer; the third kind added from a measurement during #459's review-fix round)
- Field defined by **ADR 0018**; precedent **#193** (a value made truthful under an unchanged rule); contrast **ADR 0010** (the rule itself changed)

### User-visible change self-check (铁律第五律 5.3)

- [x] No user-visible **contract** change. `/health`, `/status` and `/usage` keep the same fields with the same documented meanings; only the values stop being wrong. No README change is owed.

### Privacy self-check (for PUBLIC repos)

- [x] No real names, nicknames, or handles.
- [x] No literal personal paths — measurement transcripts use `$HOME`.
- [x] No personal machine hostnames.
- [x] No personal email addresses beyond `noreply@` placeholders.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgSMzkmmQQMkeWsSdHgqBL
